### PR TITLE
ssh key deployment fix

### DIFF
--- a/core/core/src/ansible/roles/common/tasks/main.yml
+++ b/core/core/src/ansible/roles/common/tasks/main.yml
@@ -73,14 +73,6 @@
     - disableswap
   notify: restart waagent
 
-- name: Manage {{ admin_user.name }} key
-  copy:
-    src: "{{ admin_user.key_path }}"
-    dest: /home/{{ admin_user.name }}/.ssh/id_rsa
-    mode: 0600
-    owner: "{{ admin_user.name }}"
-    group: "{{ admin_user.name }}"
-
 - name: Disable SELinux at next reboot
   selinux:
     state: disabled


### PR DESCRIPTION
I'm pretty sure priv part of the keys shouldn't be copied over. If there's a need for ssh based communication between deployed hosts/nodes we'd need to generate dedicated key-pairs for it.

User's public part is defined here in data.yaml:

>       security:
>         ssh: &ssh
>           key:
>             # Public portion of the key
>             file: ~/.ssh/epiphany-operations/id_rsa.pub

and deployment is done via terraform: core/core/src/templates/azure/main.tf.j2

> ssh_keys {
>       path     = "/home/${var.admin_username}/.ssh/authorized_keys"
> key_data = "${file("{{ core.azure.standard.security.ssh.key.file }}")}"