### PR TITLE
Fix/kibana and filebeat role

### DIFF
--- a/core/core/src/ansible/roles/filebeat/tasks/configure-filebeat.yml
+++ b/core/core/src/ansible/roles/filebeat/tasks/configure-filebeat.yml
@@ -25,7 +25,7 @@
         src: extra-dependencies.conf.j2
       register: filebeat_unit_dependencies
       notify: Restart Filebeat service
-  when: inventory_hostname in groups['master'] or inventory_hostname in groups['worker']
+  when: (groups['master'] is defined and inventory_hostname in groups['master']) or (groups['worker'] is defined and inventory_hostname in groups['worker'])
 
 - name: Enable Filebeat service
   systemd:

--- a/core/core/src/ansible/roles/kibana/tasks/Debian.yml
+++ b/core/core/src/ansible/roles/kibana/tasks/Debian.yml
@@ -26,6 +26,8 @@
     - groups['kibana'][0] == inventory_hostname
 
 - include_tasks: setup-logging.yml
+  when:
+    - groups['kibana'][0] == inventory_hostname
 
 - name: Start kibana service
   service:

--- a/core/core/src/ansible/roles/kibana/tasks/RedHat.yml
+++ b/core/core/src/ansible/roles/kibana/tasks/RedHat.yml
@@ -32,6 +32,8 @@
     - groups['kibana'][0] == inventory_hostname
 
 - include_tasks: setup-logging.yml
+  when:
+    - groups['kibana'][0] == inventory_hostname
 
 - name: Start kibana service
   service:


### PR DESCRIPTION
Fixes before finishing and testing fix/filebeat-zookeeper-memory-usage role:
 Issues: 
 - #94 - Kibana fail to install when specified on multiple nodes
 - #95 - Filebeat is failing on master dependency during installation