### PR TITLE
'/usr/sbin/nologin' fixes for Ubuntu and other distros

### DIFF
--- a/core/core/src/ansible/roles/haproxy_exporter/tasks/haproxy_exporter.yml
+++ b/core/core/src/ansible/roles/haproxy_exporter/tasks/haproxy_exporter.yml
@@ -10,7 +10,7 @@
   user:
     name: haproxy_exporter
     system: true
-    shell: "/sbin/nologin"
+    shell: "/usr/sbin/nologin"
     group: haproxy_exporter
     createhome: false
 

--- a/core/core/src/ansible/roles/jmx-exporter/tasks/main.yml
+++ b/core/core/src/ansible/roles/jmx-exporter/tasks/main.yml
@@ -9,7 +9,7 @@
   user:
     name: "{{ jmx_exporter_user }}"
     group: "{{ jmx_exporter_group }}"
-    shell: "/sbin/nologin"
+    shell: "/usr/sbin/nologin"
     createhome: false
     system: yes
 

--- a/core/core/src/ansible/roles/kafka-exporter/tasks/kafka-exporter.yml
+++ b/core/core/src/ansible/roles/kafka-exporter/tasks/kafka-exporter.yml
@@ -9,7 +9,7 @@
   user:
     name: kafka_exporter
     system: true
-    shell: "/sbin/nologin"
+    shell: "/usr/sbin/nologin"
     group: kafka_exporter
     createhome: false
 

--- a/core/core/src/ansible/roles/kafka/tasks/metrics.yml
+++ b/core/core/src/ansible/roles/kafka/tasks/metrics.yml
@@ -28,7 +28,7 @@
   user:
     name: prometheus
     system: true
-    shell: "/sbin/nologin"
+    shell: "/usr/sbin/nologin"
     group: prometheus
     createhome: false
   delegate_to: "{{ item }}"

--- a/core/core/src/ansible/roles/kafka/tasks/setup-kafka.yml
+++ b/core/core/src/ansible/roles/kafka/tasks/setup-kafka.yml
@@ -26,7 +26,7 @@
     name: "{{ kafka_var.user }}"
     system: yes
     group: "{{ kafka_var.group }}"
-    shell: "/sbin/nologin"
+    shell: "/usr/sbin/nologin"
 
 - name: Check for Kafka package
   stat:

--- a/core/core/src/ansible/roles/node_exporter/tasks/prometheus-node-exporter.yml
+++ b/core/core/src/ansible/roles/node_exporter/tasks/prometheus-node-exporter.yml
@@ -9,7 +9,7 @@
   user:
     name: node_exporter
     system: true
-    shell: "/sbin/nologin"
+    shell: "/usr/sbin/nologin"
     group: node_exporter
     createhome: false
 

--- a/core/core/src/ansible/roles/prometheus/tasks/install.yml
+++ b/core/core/src/ansible/roles/prometheus/tasks/install.yml
@@ -9,7 +9,7 @@
   user:
     name: prometheus
     system: true
-    shell: "/sbin/nologin"
+    shell: "/usr/sbin/nologin"
     group: prometheus
     createhome: false
 

--- a/core/core/src/ansible/roles/zookeeper/tasks/main.yml
+++ b/core/core/src/ansible/roles/zookeeper/tasks/main.yml
@@ -16,7 +16,7 @@
     name: "{{ zookeeper_user }}"
     group: "{{ zookeeper_group }}"
     system: yes
-    shell: "/sbin/nologin"
+    shell: "/usr/sbin/nologin"
 
 - name: Check for Zookeeper package
   stat:

--- a/core/core/src/ansible/roles/zookeeper/tasks/metrics.yml
+++ b/core/core/src/ansible/roles/zookeeper/tasks/metrics.yml
@@ -26,7 +26,7 @@
   user:
     name: prometheus
     system: true
-    shell: "/sbin/nologin"
+    shell: "/usr/sbin/nologin"
     group: prometheus
     createhome: false
   delegate_to: "{{ item }}"

--- a/core/core/test/serverspec/spec/jmx-exporter/jmx_exporter_spec.rb
+++ b/core/core/test/serverspec/spec/jmx-exporter/jmx_exporter_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe user('jmx-exporter') do
   it { should exist }
-  it { should have_login_shell '/sbin/nologin' }
+  it { should have_login_shell '/usr/sbin/nologin' }
 end
 
 describe group('jmx-exporter') do

--- a/core/core/test/serverspec/spec/kafka/kafka_spec.rb
+++ b/core/core/test/serverspec/spec/kafka/kafka_spec.rb
@@ -16,7 +16,7 @@ end
 
 describe user('kafka') do
   it { should exist }
-  it { should have_login_shell '/sbin/nologin' }
+  it { should have_login_shell '/usr/sbin/nologin' }
   it { should belong_to_group 'kafka' }
   it { should belong_to_group 'jmx-exporter' }
 end

--- a/core/core/test/serverspec/spec/prometheus/prometheus_spec.rb
+++ b/core/core/test/serverspec/spec/prometheus/prometheus_spec.rb
@@ -10,6 +10,6 @@ end
 
 describe user('prometheus') do
   it { should exist }
-  it { should have_login_shell '/sbin/nologin' }
+  it { should have_login_shell '/usr/sbin/nologin' }
   it { should belong_to_group 'prometheus' }
 end

--- a/core/core/test/serverspec/spec/zookeeper/zookeeper_spec.rb
+++ b/core/core/test/serverspec/spec/zookeeper/zookeeper_spec.rb
@@ -15,7 +15,7 @@ end
 
 describe user('zookeeper') do
   it { should exist }
-  it { should have_login_shell '/sbin/nologin' }
+  it { should have_login_shell '/usr/sbin/nologin' }
   it { should belong_to_group 'zookeeper' }
   it { should belong_to_group 'jmx-exporter' }
 end


### PR DESCRIPTION
There was a big /sbin -> /usr/sbin merge couple years ago. Nowadays distributions hold `nologin` in `/usr/sbin`. For backward compatibility some are linking `/sbin -> /usr/sbin` but it's not obligatory e.g Ubuntu 18.04 on Azure is lacking those symlinks which results in invalid path to `nologin`. 

This change will break serverspec tests for currently built epiphany clusters until someone fixes those paths or rebuilds the cluster.

tl;dr
`/sbin/nologin` - valid for RHEL7, **invalid for Ubuntu** 18.04
`/usr/sbin/nologin` - valid for RHEL7 **and** Ubuntu 18.04 and any other major distro made in the last couple years