### PR TITLE
Fix ZooKeeper distribution URL

### DIFF
--- a/core/core/src/ansible/roles/zookeeper/defaults/main.yml
+++ b/core/core/src/ansible/roles/zookeeper/defaults/main.yml
@@ -4,8 +4,7 @@ zookeeper_hosts: "{{ groups['zookeeper'] }}"
 
 zookeeper_version: 3.4.12
 zookeeper: zookeeper-{{zookeeper_version}}
-# zookeeper_url: http://apache.uib.no/zookeeper/stable
-zookeeper_url: http://www.us.apache.org/dist/zookeeper
+zookeeper_url: http://archive.apache.org/dist/zookeeper
 
 zookeeper_data_dir: /var/lib/zookeeper
 zookeeper_log_dir: /var/log/zookeeper


### PR DESCRIPTION
ZooKeeper v3.4.12 is no longer available at http://www.us.apache.org/dist/zookeeper