### PR TITLE
Added smoke tests for logging

### DIFF
--- a/core/core/test/serverspec/spec/elasticsearch-curator/elasticsearch-curator_spec.rb
+++ b/core/core/test/serverspec/spec/elasticsearch-curator/elasticsearch-curator_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'Checking if Elasticsearch Curator package is installed' do
+  describe package('elasticsearch-curator') do
+    it { should be_installed }
+  end
+end
+
+describe 'Checking if cron job to delete old elasticsearch indices exists' do
+  let(:disable_sudo) { false }
+  describe command("crontab -l | grep -q 'Delete old elasticsearch indices.' && echo 'EXISTS' || echo 'NOTEXISTS'") do
+    its(:stdout) { should match /\bEXISTS\b/ }
+    its(:stdout) { should_not match /\bNOTEXISTS\b/ }
+  end
+end

--- a/core/core/test/serverspec/spec/elasticsearch/elasticsearch_spec.rb
+++ b/core/core/test/serverspec/spec/elasticsearch/elasticsearch_spec.rb
@@ -1,17 +1,60 @@
 require 'spec_helper'
 
-describe service('elsaticsearch') do
-  it { should be_enabled }
-  it { should be_running }
+elasticsearch_rest_api_port = 9200
+elasticsearch_communication_port = 9300
+
+describe 'Checking if Elasticsearch service is running' do
+  describe service('elasticsearch') do
+    it { should be_enabled }
+    it { should be_running }
+  end
 end
 
-describe service('kibana') do
-    it { should be_enabled }
-    it { should be_running }
+describe 'Checking if Elasticsearch user exists' do
+  describe group('elasticsearch') do
+    it { should exist }
   end
-
-describe service('filebeat') do
-    it { should be_enabled }
-    it { should be_running }
+  describe user('elasticsearch') do
+    it { should exist }
+    it { should belong_to_group 'elasticsearch' }
   end
+end
 
+describe 'Checking Elasticsearch directories and config files' do
+  let(:disable_sudo) { false }
+  describe file('/etc/elasticsearch') do
+    it { should exist }
+    it { should be_a_directory }
+  end
+  describe file("/etc/elasticsearch/elasticsearch.yml") do
+    it { should exist }
+    it { should be_a_file }
+  end
+end
+
+describe 'Checking if the ports are open' do
+  let(:disable_sudo) { false }
+  describe port(elasticsearch_rest_api_port) do
+    it { should be_listening }
+  end
+  describe port(elasticsearch_communication_port) do
+    it { should be_listening }
+  end
+end 
+
+describe 'Checking Elasticsearch HTTP status code' do
+  let(:disable_sudo) { false }
+  describe command("curl -o /dev/null -s -w '%{http_code}' $(grep 'network.host' /etc/elasticsearch/elasticsearch.yml | awk '{print $2}'):#{elasticsearch_rest_api_port}") do
+    it "is expected to be equal" do
+      expect(subject.stdout.to_i).to eq 200
+    end
+  end
+end
+
+describe 'Checking Elasticsearch health' do
+  let(:disable_sudo) { false }
+  describe command("curl $(grep 'network.host' /etc/elasticsearch/elasticsearch.yml | awk '{print $2}'):#{elasticsearch_rest_api_port}/_cluster/health?pretty=true") do
+    its(:stdout) { should match /"status" : "yellow"|"status" : "green"/ }
+    its(:exit_status) { should eq 0 }
+  end
+end

--- a/core/core/test/serverspec/spec/elasticsearch/elasticsearch_spec.rb
+++ b/core/core/test/serverspec/spec/elasticsearch/elasticsearch_spec.rb
@@ -54,7 +54,7 @@ end
 describe 'Checking Elasticsearch health' do
   let(:disable_sudo) { false }
   describe command("curl $(grep 'network.host' /etc/elasticsearch/elasticsearch.yml | awk '{print $2}'):#{elasticsearch_rest_api_port}/_cluster/health?pretty=true") do
-    its(:stdout) { should match /"status" : "yellow"|"status" : "green"/ }
+    its(:stdout_as_json) { should include('status' => /green|yellow/) }
     its(:exit_status) { should eq 0 }
   end
 end

--- a/core/core/test/serverspec/spec/filebeat/filebeat_spec.rb
+++ b/core/core/test/serverspec/spec/filebeat/filebeat_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe 'Checking if Filebeat package is installed' do
+  describe package('filebeat') do
+    it { should be_installed }
+  end
+end
+
+describe 'Checking if Filebeat service is running' do
+  describe service('filebeat') do
+    it { should be_enabled }
+    it { should be_running }
+  end
+end
+
+describe 'Checking Filebeat directories and config files' do
+  let(:disable_sudo) { false }
+  describe file('/etc/filebeat') do
+    it { should exist }
+    it { should be_a_directory }
+  end
+  describe file("/etc/filebeat/filebeat.yml") do
+    it { should exist }
+    it { should be_a_file }
+  end
+end
+
+if hostInGroups?("master") || hostInGroups?("worker")
+  describe 'Checking extra configuration for master/worker roles - setting Filebeat to be started after Docker' do
+    describe file("/etc/systemd/system/filebeat.service.d/extra-dependencies.conf") do
+      it { should exist }
+      it { should be_a_file }
+      its(:content) { should match /After=docker\.service/ }
+    end
+  end
+end
+
+if count_inventory_roles("elasticsearch") > 0
+  describe 'Checking the connection to the Elasticsearch host' do
+    let(:disable_sudo) { false }
+    describe command("curl -o /dev/null -s -w '%{http_code}' $(awk '/- Elasticsearch output -/,/- Logstash output -/' /etc/filebeat/filebeat.yml \
+    |  grep -oP '(?<=hosts: \\\[\\\").*(?=\\\"\\\])')") do
+      it "is expected to be equal" do
+        expect(subject.stdout.to_i).to eq 200
+      end
+    end
+  end
+end
+
+if count_inventory_roles("kibana") > 0
+  describe 'Checking the connection to the Kibana endpoint' do
+    let(:disable_sudo) { false }
+    describe command("curl -o /dev/null -s -w '%{http_code}' $(awk '/= Kibana =/,/= Elastic Cloud =/' /etc/filebeat/filebeat.yml \
+    |  grep -oP '(?<=host: \\\").*(?=\\\")')") do
+      it "is expected to be equal" do
+        expect(subject.stdout.to_i).to eq 200
+      end
+    end
+  end
+end

--- a/core/core/test/serverspec/spec/kibana/kibana_spec.rb
+++ b/core/core/test/serverspec/spec/kibana/kibana_spec.rb
@@ -36,11 +36,11 @@ describe 'Checking Kibana directories and config files' do
   end
 end
 
-describe 'Checking if Kibana log file exists' do
+describe 'Checking if Kibana log file exists and is not empty' do
   describe file('/var/log/kibana/kibana.log') do
     it { should exist }
     it { should be_a_file }
-    its(:content) { should_not match /^$/ }
+    its(:size) { should > 0 }
   end
   describe file('/etc/logrotate.d/kibana') do
     it { should exist }

--- a/core/core/test/serverspec/spec/kibana/kibana_spec.rb
+++ b/core/core/test/serverspec/spec/kibana/kibana_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+kibana_default_port = 5601
+
+describe 'Checking if Kibana package is installed' do
+  describe package('kibana-oss') do
+    it { should be_installed }
+  end
+end
+
+describe 'Checking if Kibana service is running' do
+  describe service('kibana') do
+    it { should be_enabled }
+    it { should be_running }
+  end
+end
+
+describe 'Checking if Kibana user exists' do
+  describe group('kibana') do
+    it { should exist }
+  end
+  describe user('kibana') do
+    it { should exist }
+    it { should belong_to_group 'kibana' }
+  end
+end
+
+describe 'Checking Kibana directories and config files' do
+  describe file('/etc/kibana') do
+    it { should exist }
+    it { should be_a_directory }
+  end
+  describe file("/etc/kibana/kibana.yml") do
+    it { should exist }
+    it { should be_a_file }
+  end
+end
+
+describe 'Checking if Kibana log file exists' do
+  describe file('/var/log/kibana/kibana.log') do
+    it { should exist }
+    it { should be_a_file }
+    its(:content) { should_not match /^$/ }
+  end
+  describe file('/etc/logrotate.d/kibana') do
+    it { should exist }
+    it { should be_a_file }
+  end
+end
+
+if count_inventory_roles("elasticsearch") > 0
+  describe 'Checking the connection to the Elasticsearch host' do
+    let(:disable_sudo) { false }
+    describe command("curl -o /dev/null -s -w '%{http_code}' $(grep -oP '(?<=elasticsearch.url: \\\").*(?=\\\")' /etc/kibana/kibana.yml)") do
+      it "is expected to be equal" do
+        expect(subject.stdout.to_i).to eq 200
+      end
+    end
+  end
+end
+
+describe 'Checking Kibana app HTTP status code' do
+  let(:disable_sudo) { false }
+  describe command("curl -o /dev/null -s -w '%{http_code}' $(grep -oP '(?<=server.host: \\\").*(?=\\\")' /etc/kibana/kibana.yml):#{kibana_default_port}/app/kibana") do
+    it "is expected to be equal" do
+      expect(subject.stdout.to_i).to eq 200
+    end
+  end
+end
+
+describe 'Checking Kibana health' do
+  let(:disable_sudo) { false }
+  describe command("curl $(grep -oP '(?<=server.host: \\\").*(?=\\\")' /etc/kibana/kibana.yml):#{kibana_default_port}/api/status") do
+    its(:stdout_as_json) { should include('status' => include('overall' => include('state' => 'green'))) }
+    its(:exit_status) { should eq 0 }
+  end
+end

--- a/core/core/test/serverspec/spec/spec_helper.rb
+++ b/core/core/test/serverspec/spec/spec_helper.rb
@@ -29,6 +29,8 @@ set :ssh_options, options
 # Disable sudo
 set :disable_sudo, true
 
+# Set shell
+set :shell, '/bin/bash'
 
 # Set environment variables
 # set :env, :LANG => 'C', :LC_MESSAGES => 'C'
@@ -47,3 +49,15 @@ set :disable_sudo, true
       end
     return counter
   end
+
+  def hostInGroups?(role)
+    file = File.open(ENV['inventory'], "rb")
+    input = file.read
+    file.close
+      if input.include? "[#{role}]"
+        rows = input.split("[#{role}]")[1].split("[")[0]
+        return rows.include? ENV['TARGET_HOST']
+      else return false
+      end
+  end
+


### PR DESCRIPTION
Smoke tests for logging #44 
Checking if Elasticsearch, Filebeat and Kibana services are running
Checking if the services are listening on the correct ports
Checking Elasticsearch, Filebeat and Kibana config files
Checking Elasticsearch and Kibana HTTP status codes/health
Checking Filebeat connection to the Elasticsearch host and to the Kibana endpoint
Checking Kibana connection to the Elasticsearch host
Checking if Elasticsearch Curator package is installed