### PR TITLE
fix/always apt update before apt install

### DIFF
--- a/core/src/epicli/cli/engine/ansible/AnsibleRunner.py
+++ b/core/src/epicli/cli/engine/ansible/AnsibleRunner.py
@@ -42,7 +42,7 @@ class AnsibleRunner(Step):
         # todo: install packages to run ansible on Red Hat hosts
         self.ansible_command.run_task_with_retries(hosts="all", inventory=inventory_path, module="raw",
                                                    args="cat /etc/lsb-release | grep -i DISTRIB_ID | grep -i ubuntu && "
-                                                        "sudo apt-get install -y python-simplejson "
+                                                        "sudo apt-get update && sudo apt-get install -y python-simplejson "
                                                         "|| echo 'Cannot find information about Ubuntu distribution'", retries=5)
 
         self.ansible_vars_generator.run()


### PR DESCRIPTION
Always refresh local package list before installation or it'll go out-of-sync.

This fixes:

> Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/p/python2.7/python2.7_2.7.15~rc1-1ubuntu0.1_amd64.deb  404  Not Found