### PR TITLE
Fix typo rabbitmq

### DIFF
--- a/core/src/epicli/data/common/defaults/configuration/feature-mapping.yml
+++ b/core/src/epicli/data/common/defaults/configuration/feature-mapping.yml
@@ -85,7 +85,7 @@ specification:
       - elasticsearch-curator
     single_machine:
       - kubernetes-master
-      - rabbitmql
+      - rabbitmq
       - postgresql
     kubernetes_master:
       - kubernetes-master


### PR DESCRIPTION
Got error:
```
14:20:06 ERROR cli.engine.EpiphanyEngine - [Errno 2] No such file or directory: '/usr/local/epicli/data/common/defaults/configuration/rabbitmql.yml'
```

Found that single-machine references `rabbitmql` role, should be `rabbitmq` I assume.