### PR TITLE
Fix/aws ports and naming

### DIFF
--- a/core/src/epicli/data/any/defaults/configuration/minimal-cluster-config.yml
+++ b/core/src/epicli/data/any/defaults/configuration/minimal-cluster-config.yml
@@ -4,7 +4,7 @@ title: "Epiphany cluster Config"
 provider: any
 name: "default"
 specification:
-  name: YOUR_CLUSTER_NAME
+  name: name
   admin_user:
     name: operations # YOUR-ADMIN-USERNAME
     key_path: /user/.ssh/epiphany-operations/id_rsa # YOUR-SSH-KEY-PATH

--- a/core/src/epicli/data/aws/defaults/configuration/minimal-cluster-config.yml
+++ b/core/src/epicli/data/aws/defaults/configuration/minimal-cluster-config.yml
@@ -4,8 +4,8 @@ title: "Epiphany cluster Config"
 provider: aws
 name: "default"
 specification:
-  name: YOUR_CLUSTER_NAME
-  prefix: YOUR_CLUSTER_RESOURCES_PREFIX
+  name: name
+  prefix: prefix
   admin_user:
     name: operations # YOUR-ADMIN-USERNAME
     key_path: /user/.ssh/epiphany-operations/id_rsa # YOUR-SSH-KEY-PATH

--- a/core/src/epicli/data/aws/defaults/infrastructure/virtual-machine.yml
+++ b/core/src/epicli/data/aws/defaults/infrastructure/virtual-machine.yml
@@ -138,6 +138,26 @@ specification:
        destination_port_range: "5672"
        source_address_prefix: "10.1.0.0/20"
        destination_address_prefix: "0.0.0.0/0"
+     - name: rabbitmq_clustering_1
+       description: Allow rabbitmq clustering traffic 1
+       priority: 304
+       direction: Inbound
+       access: Allow
+       protocol: Tcp
+       source_port_range: "*"
+       destination_port_range: "4369"
+       source_address_prefix: "10.1.8.0/24"
+       destination_address_prefix: "0.0.0.0/0"
+     - name: rabbitmq_clustering_1
+       description: Allow rabbitmq clustering traffic 2
+       priority: 305
+       direction: Inbound
+       access: Allow
+       protocol: Tcp
+       source_port_range: "*"
+       destination_port_range: "25672"
+       source_address_prefix: "10.1.8.0/24"
+       destination_address_prefix: "0.0.0.0/0"       
      - name: out
        description: Allow out
        priority: 101
@@ -619,6 +639,16 @@ specification:
        destination_port_range: "0"
        source_address_prefix: "10.1.2.0/24"
        destination_address_prefix: "0.0.0.0/0"
+     - name: postgres_clustering
+       description: Allow Postgres clustering traffic
+       priority: 305
+       direction: Inbound
+       access: Allow
+       protocol: Tcp
+       source_port_range: "*"
+       destination_port_range: "5432"
+       source_address_prefix: "10.1.6.0/24"
+       destination_address_prefix: "0.0.0.0/0"  
 ---
 kind: infrastructure/virtual-machine
 version: 0.4.0

--- a/core/src/epicli/data/azure/defaults/configuration/minimal-cluster-config.yml
+++ b/core/src/epicli/data/azure/defaults/configuration/minimal-cluster-config.yml
@@ -4,8 +4,8 @@ title: "Epiphany cluster Config"
 provider: azure
 name: "default"
 specification:
-  name: YOUR_CLUSTER_NAME
-  prefix: YOUR_CLUSTER_RESOURCES_PREFIX
+  name: name
+  prefix: prefix
   admin_user:
     name: operations # YOUR-ADMIN-USERNAME
     key_path: /user/.ssh/epiphany-operations/id_rsa # YOUR-SSH-KEY-PATH

--- a/docs/home/HOWTO.md
+++ b/docs/home/HOWTO.md
@@ -15,7 +15,7 @@
 - [Epiphany cluster](./howto/CLUSTER.md)
   - Epicli
     - [How to create an Epiphany cluster on existing infrastructure](./howto/CLUSTER.md#how-to-create-an-epiphany-cluster-on-existing-infrastructure)
-    - [How to create an Epiphany cluster on a cloud provider](./howto/CLUSTER.md#how-to-create-an-epiphany-on-a-cloud-provider)
+    - [How to create an Epiphany cluster on a cloud provider](./howto/CLUSTER.md#how-to-create-an-epiphany-cluster-on-a-cloud-provider)
     - [How to delete an Epiphany cluster on a cloud provider](./howto/CLUSTER.md#how-to-delete-an-epiphany-cluster-on-a-cloud-provider)
     - [How to create an offline installation of for Epiphany cluster](./howto/CLUSTER.md#how-to-create-an-offline-installation-for-an-Epiphany-cluster)
     - [Single machine cluster](./howto/CLUSTER.md#single-machine-cluster)


### PR DESCRIPTION
- Fixed epicli init issues for different providers and new naming convention.
- Fixed link in docs
- Added ports for clustering Postgres and RabbitMQ