### PR TITLE
ip-change scripts and manuals

### DIFF
--- a/tools/ip_change/elasticsearch/1_update_hosts.sh
+++ b/tools/ip_change/elasticsearch/1_update_hosts.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright 2019 ABB. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script updates /etc/hosts with newly provided ip address
+# Run script:
+# sudo ./1_update_hosts.sh "OLD_IP" "NEW_IP"
+
+set -e
+
+OLD_IP=$1
+NEW_IP=$2
+
+echo "==== Modifying /etc/hosts for new IP ===="
+
+sed -i "s/$OLD_IP/$NEW_IP/g" "/etc/hosts"
+
+echo "==== /etc/hosts modification completed ===="

--- a/tools/ip_change/elasticsearch/2_config_files.sh
+++ b/tools/ip_change/elasticsearch/2_config_files.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright 2019 ABB. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script updates Elastisearch and Kibana configuration files:
+# /etc/elasticsearch/elasticsearch.yml
+# /etc/kibana/kibana.yml
+#
+# Run script:
+# sudo ./2_config_files.sh "OLD_IP" "NEW_IP"
+
+
+# OLD_IP - Address which will be modified
+# NEW_IP - Updated value
+set -e
+
+OLD_IP=$1
+NEW_IP=$2
+
+echo "==== Modifying /etc/elasticsearch/elasticsearch.yml for new IP ===="
+sed -i "s/$OLD_IP/$NEW_IP/g" "/etc/elasticsearch/elasticsearch.yml"
+echo "==== /etc/elasticsearch/elasticsearch.yml modification completed ===="
+
+echo "==== Modifying /etc/kibana/kibana.yml for new IP ===="
+sed -i "s/$OLD_IP/$NEW_IP/g" "/etc/kibana/kibana.yml"
+echo "==== /etc/kibana/kibana.yml modification completed ===="
+
+echo "==== Restarting Kibana ===="
+systemctl restart kibana
+echo "==== Kibana restarted ===="
+
+echo "==== Restarting Elasticsearch ===="
+systemctl restart elasticsearch
+echo "==== Elasticsearch restarted ===="

--- a/tools/ip_change/elasticsearch/3_update_filebeat.sh
+++ b/tools/ip_change/elasticsearch/3_update_filebeat.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Copyright 2019 ABB. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script updates Elastisearch and Kibana configuration files:
+# /etc/elasticsearch/elasticsearch.yml
+# /etc/kibana/kibana.yml
+#
+# Run script:
+# sudo ./3_update_filebeat.sh "OLD_IP" "NEW_IP"
+
+
+# OLD_IP - Address which will be modified
+# NEW_IP - Updated value
+set -e
+
+OLD_IP=$1
+NEW_IP=$2
+
+echo "==== Modifying /etc/filebeat/filebeat.yml for new IP ===="
+sed -i "s/$OLD_IP/$NEW_IP/g" "/etc/filebeat/filebeat.yml"
+echo "==== /etc/filebeat/filebeat.yml modification completed ===="
+
+echo "==== Restarting Filebeat ===="
+systemctl restart filebeat
+echo "==== Filebeat restarted ===="

--- a/tools/ip_change/elasticsearch/README.md
+++ b/tools/ip_change/elasticsearch/README.md
@@ -1,0 +1,42 @@
+# Changing IP for Elasticsearch infrastructure
+
+## Requirements:
+
+- Note all actual and desired ip configurations for Elasticsearch node
+- User with sudo privileges
+
+## Update configuration
+
+1. Update /etc/hosts file
+
+Execute `1_update_hosts.sh` script:
+
+  ```bash
+  sudo ./1_update_hosts.sh "CURRENT_IP" "NEW_IP"
+  ```
+
+  This script will update /etc/hosts file
+
+2. Update Elasticsearch and Kibana configuration.
+
+Execute `2_config_files.sh` script:
+
+```bash
+sudo ./2_config_files.sh "CURRENT_IP" "NEW_IP"
+```
+
+This script will update files:
+
+- /etc/elasticsearch/elasticsearch.yml
+- /etc/kibana/kibana.yml
+
+Both services will be restarted.
+
+3. Update Filebeat configuration on every host in cluster to setup new Elasticseach's ip.
+
+ Execute `3_update_filebeat.sh` script on all cluster nodes.
+ This will also restart filebeat service.
+
+```bash
+sudo ./3_update_filebeat.sh "CURRENT_IP" "NEW_IP"
+```

--- a/tools/ip_change/kafka/1_update_hosts.sh
+++ b/tools/ip_change/kafka/1_update_hosts.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright 2019 ABB. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script updates /etc/hosts with newly provided ip address
+# Run script:
+# sudo ./1_update_hosts.sh "OLD_IP" "NEW_IP"
+
+set -e
+
+echo "==== Modifying /etc/hosts for new IP ===="
+
+OLD_IP=$1
+NEW_IP=$2
+
+sed -i "s/$OLD_IP/$NEW_IP/g" "/etc/hosts"
+
+echo "==== /etc/hosts modification completed ===="

--- a/tools/ip_change/kafka/README.md
+++ b/tools/ip_change/kafka/README.md
@@ -1,0 +1,30 @@
+# Changing IP for Kafka infrastructure
+
+## Requirements:
+
+- Note all actual and desired ip configurations for Elasticsearch node
+- User with sudo privileges
+
+## Update configuration
+
+Kafka and Zookeeper configuration delivered by Epiphany uses hostnames in configuration files.
+To apply ip change administrator needs to modify hosts inserts in /etc/hosts configuration file.
+
+1. Update /etc/hosts file
+
+Execute `1_update_hosts.sh` script:
+
+  ```bash
+  sudo ./1_update_hosts.sh "CURRENT_IP" "NEW_IP"
+  ```
+
+  This script will update /etc/hosts file. Script needs to be run on and for every Kafka node.
+
+Example:
+
+  ```bash
+  sudo ./1_update_hosts.sh "MASTER_CURRENT_IP" "MASTER_NEW_IP"
+  sudo ./1_update_hosts.sh "SLAVE1_CURRENT_IP" "SLAVE1_NEW_IP"
+  ...
+  sudo ./1_update_hosts.sh "SLAVEx_CURRENT_IP" "SLAVEx_NEW_IP"
+  ```

--- a/tools/ip_change/postgresql/1_update_hosts.sh
+++ b/tools/ip_change/postgresql/1_update_hosts.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Copyright 2019 ABB. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+
+OLD_IP=$1
+NEW_IP=$2
+
+echo "==== Modifying /etc/hosts for new IP ===="
+echo "Run this script also if you want to modify slave inserts"
+
+sed -i "s/$OLD_IP/$NEW_IP/g" "/etc/hosts"
+
+echo "==== /etc/hosts modification completed ===="

--- a/tools/ip_change/postgresql/2_update_pg_hba.sh
+++ b/tools/ip_change/postgresql/2_update_pg_hba.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright 2019 ABB. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#Run this script on Master as many times as many Slaves you've got
+set -e
+
+#OLD_IP_SLAVE - Address which will be modified
+#NEW_IP_SLAVE - Updated value
+
+OLD_IP_SLAVE=$1
+NEW_IP_SLAVE=$2
+
+echo "==== Modifying /etc/postgresql/10/main/pg_hba.conf for new IP ===="
+
+sed -i "s/$OLD_IP_SLAVE/$NEW_IP_SLAVE/g" "/etc/postgresql/10/main/pg_hba.conf"
+
+echo "==== /etc/postgresql/10/main/pg_hba.conf modification completed ===="

--- a/tools/ip_change/postgresql/3_update_pgpass.sh
+++ b/tools/ip_change/postgresql/3_update_pgpass.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright 2019 ABB. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#Run this script on every Slave which you've got
+
+echo "==== Modifying /var/lib/postgresql/.pgpass for new IP ===="
+
+#OLD_IP_MASTER - Address which will be modified
+#NEW_IP_MASTER - Updated value 
+
+OLD_IP_MASTER=$1
+NEW_IP_MASTER=$2
+
+sed -i "s/$OLD_IP_MASTER/$NEW_IP_MASTER/g" "/var/lib/postgresql/.pgpass"
+
+echo "==== /var/lib/postgresql/.pgpass modification completed ===="

--- a/tools/ip_change/postgresql/README.md
+++ b/tools/ip_change/postgresql/README.md
@@ -1,0 +1,64 @@
+# Changing IP for Database infrastructure
+
+## Requirements:
+
+- Note all actual and desired ip configurations for master and all slaves (if exist)
+- User with sudo privileges
+
+## Note that host ip change may impact database when data contains network address types
+
+See more: <https://www.postgresql.org/docs/10/datatype-net-types.html>
+
+## Master Node
+
+This part describes actions to execute on Master Database Node
+
+1. Execute `1_update_hosts.sh` script to update `/etc/hosts file`.
+
+  ```bash
+  sudo ./1_update_hosts.sh "CURRENT_IP" "NEW_IP"
+  ```
+   This part needs to be run once per every database (Master and Slave) record in `/etc/hosts` file:
+  ```bash
+  sudo ./1_update_hosts.sh "MASTER_CURRENT_IP" "MASTER_NEW_IP"
+  sudo ./1_update_hosts.sh "SLAVE1_CURRENT_IP" "SLAVE1_NEW_IP"
+  ...
+  sudo ./1_update_hosts.sh "SLAVEx_CURRENT_IP" "SLAVEx_NEW_IP"
+  ```
+
+2. This steps need to be executed only for Master-Slave(s) configuration:
+
+  Update host-based authentication file:
+  ```bash
+  sudo ./2_update_pg_hba.sh "SLAVE1_CURRENT_IP" "SLAVE1_NEW_IP"
+  sudo ./2_update_pg_hba.sh "SLAVE2_CURRENT_IP" "SLAVE2_NEW_IP"
+  ...
+  sudo ./2_update_pg_hba.sh "SLAVEx_CURRENT_IP" "SLAVEx_NEW_IP"
+  ```
+
+  This command needs to run for every Slave's record in pg_hba.conf file
+
+## Slave Node(s)
+
+This part describes actions to execute on Slave Database Nodes
+
+1. Execute `1_update_hosts.sh` script to update `/etc/hosts file`.
+
+  ```bash
+  sudo ./1_update_hosts.sh "CURRENT_IP" "NEW_IP"
+  ```
+   This part needs to be run once per every database (Master and Slave) record in `/etc/hosts` file:
+  ```bash
+  sudo ./1_update_hosts.sh "MASTER_CURRENT_IP" "MASTER_NEW_IP"
+  sudo ./1_update_hosts.sh "SLAVE1_CURRENT_IP" "SLAVE1_NEW_IP"
+  ...
+  sudo ./1_update_hosts.sh "SLAVEx_CURRENT_IP" "SLAVEx_NEW_IP"
+  ```
+
+2. Execute `3_update_pgpass.sh` on every Slave Node
+```bash
+sudo ./3_update_pgpass.sh "MASTER_CURRENT_IP" "MASTER_NEW_IP"
+```
+This script will update connection string to Master Database
+
+3. Update any other application connection strings to establish connection to new address.

--- a/tools/ip_change/prometheus/1_update_hosts.sh
+++ b/tools/ip_change/prometheus/1_update_hosts.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Copyright 2019 ABB. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+
+OLD_IP=$1
+NEW_IP=$2
+
+echo "==== Modifying /etc/hosts for new IP ===="
+echo "Run this script also if you want to modify slave inserts"
+
+sed -i "s/$OLD_IP/$NEW_IP/g" "/etc/hosts"
+
+echo "==== /etc/hosts modification completed ===="

--- a/tools/ip_change/prometheus/README.md
+++ b/tools/ip_change/prometheus/README.md
@@ -1,0 +1,31 @@
+# Changing IP for Prometheus infrastructure
+
+## Requirements:
+
+- Note all actual and desired ip configurations for Prometheus node
+- User with sudo privileges
+
+## Update configuration
+
+Prometheus configuration delivered by Epiphany uses hostnames in configuration files.
+To apply ip change administrator needs to modify hosts inserts in /etc/hosts if IPs have changed.
+You need to apply this change even if you changed only ip for Prometheus targets.
+
+1. Update /etc/hosts file
+
+Execute `1_update_hosts.sh` script:
+
+  ```bash
+  sudo ./1_update_hosts.sh "CURRENT_IP" "NEW_IP"
+  ```
+
+  This script will update /etc/hosts file. Script needs to be run on and for every node defined in /etc/hosts file
+
+Example:
+
+  ```bash
+  sudo ./1_update_hosts.sh "CURRENT_IP" "NEW_IP"
+  sudo ./1_update_hosts.sh "TARGET1_CURRENT_IP" "TARGET1_NEW_IP"
+  ...
+  sudo ./1_update_hosts.sh "TARGETx_CURRENT_IP" "TARGETx_NEW_IP"
+  ```


### PR DESCRIPTION
1. Elasticsearch:
- Scripts for /etc/hosts, elasticsearch.yml, kibana.yml and filebeat.yml modifications
- Readme
2. Kafka:
- Script to modify /etc/hosts
- Readme
3. PostgreSQL
- Scripts to modify /etc/hosts, pg_hba.conf and .pgpass
- Readme
4. Prometheus
- Script to update /etc/hosts
- Readme