### PR TITLE
Improvements for offline upgrade

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/common/upgrade-common.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/common/upgrade-common.yml
@@ -1,22 +1,12 @@
 ---
+- name: Get list of installed packages as facts
+  package_facts:
+    manager: auto
+  changed_when: false
 
-- name: Remove jq installed directly from github
+- name: Remove jq installed as binary from GitHub
   file:
     path: /usr/local/bin/jq
     state: absent
-
-- name: Install jq Debian family packages
-  apt:
-    name:
-      - jq
-    update_cache: yes
-    state: present
-  when: ansible_os_family == "Debian"
-
-- name: Install jq RedHat family packages
-  yum:
-    name:
-      - jq
-    update_cache: yes
-    state: present
-  when: ansible_os_family == "RedHat"
+  when:
+    - "'jq' in ansible_facts.packages"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/common/upgrade-common.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/common/upgrade-common.yml
@@ -4,7 +4,7 @@
     manager: auto
   changed_when: false
 
-- name: Remove jq installed as binary from GitHub
+- name: Clean up jq installed as binary from GitHub
   file:
     path: /usr/local/bin/jq
     state: absent

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/image-registry.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/image-registry.yml
@@ -1,25 +1,36 @@
 ---
 
-- name: Include get-registries.yml from docker role # this sets result
+- name: image-registry | Include get-registries.yml from docker role # this sets result
   include_role:
     name: docker
     tasks_from: get-registries
 
 - name: Reconfigure Docker for pulling images from local registry
   block:
-    - name: image-registry | Drain node in preparation for docker reconfiguration
+    - name: image-registry | Drain node in preparation for Docker reconfiguration
       include_tasks: kubernetes/node/drain.yml
+      when:
+        - inventory_hostname in groups['kubernetes_node']
 
     - name: image-registry | Wait for cluster's readiness
       include_tasks: kubernetes/wait.yml
+      when:
+        - inventory_hostname in groups['kubernetes_node']
 
     - name: image-registry | Reconfigure Docker if necessary # this restarts Docker daemon
       include_role:
         name: docker
         tasks_from: configure-docker
 
+    - name: Include wait-for-kube-apiserver.yml
+      include_tasks: kubernetes/wait-for-kube-apiserver.yml
+      when:
+        - inventory_hostname in groups['kubernetes_master']
+
     - name: image-registry | Uncordon node - mark node as schedulable
       include_tasks: kubernetes/node/uncordon.yml
+      when:
+        - inventory_hostname in groups['kubernetes_node']
 
   when:
     - not image_registry_address in result.stdout

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
@@ -8,20 +8,6 @@
 - name: Include get-kubelet-version.yml
   include_tasks: kubernetes/get-kubelet-version.yml # sets kubelet_version
 
-- name: Reconfigure Docker for pulling images from local registry
-  block:
-    - name: Include get-registries.yml from docker role # this sets result
-      include_role:
-        name: docker
-        tasks_from: get-registries
-
-    - name: Reconfigure Docker if necessary # this restarts Docker daemon
-      include_role:
-        name: docker
-        tasks_from: configure-docker
-      when:
-        - not image_registry_address in result.stdout
-
 - name: Upgrade master to v{{ version }}
   include_tasks: kubernetes/upgrade-master.yml
   vars:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
@@ -1,4 +1,7 @@
 ---
+- name: Include wait-for-kube-apiserver.yml
+  include_tasks: kubernetes/wait-for-kube-apiserver.yml
+
 - name: Include get-cluster-version.yml
   include_tasks: kubernetes/get-cluster-version.yml # sets cluster_version
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/wait-for-kube-apiserver.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/wait-for-kube-apiserver.yml
@@ -1,0 +1,12 @@
+---
+# Wait for kube-apiserver, e.g. after Docker service was restarted on master
+
+- name: Wait for kubectl to access K8s cluster
+  environment:
+    KUBECONFIG: /home/{{ admin_user.name }}/.kube/config
+  shell: kubectl cluster-info
+  register: output
+  until: output is succeeded and "running" in output.stdout
+  retries: 60 # 1min
+  delay: 1
+  changed_when: false

--- a/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
@@ -9,7 +9,7 @@
         name: upgrade
         tasks_from: common
 
-- hosts: kubernetes_node
+- hosts: kubernetes_master:kubernetes_node
   serial: 1
   become: true
   become_method: sudo

--- a/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
@@ -1,7 +1,7 @@
 ---
-# Ansible playbook for upgrading Kubernetes cluster
+# Ansible playbook for upgrading common and K8s components
 
-- hosts: kubernetes_master:kubernetes_node
+- hosts: all
   become: true
   become_method: sudo
   tasks:


### PR DESCRIPTION
- Run tasks from upgrade-common on all hosts
- jq is installed from one place (common role)
- Wait for kube-apiserver after Docker service was restarted
- Reconfigure Docker only in image-registry.yml