### PR TITLE
K8s offline upgrade progress

### DIFF
--- a/core/src/epicli/cli/engine/ansible/AnsibleVarsGenerator.py
+++ b/core/src/epicli/cli/engine/ansible/AnsibleVarsGenerator.py
@@ -50,12 +50,12 @@ class AnsibleVarsGenerator(Step):
             dump(clean_cluster_model, stream)
 
         if self.inventory_creator == None:
-            # For upgrade at this point we dont need any of other roles then 
-            # common, upgrade, repository and image_registry.
-            # - commmon us already provisioned from the cluster model constructed from the inventory.
+            # For upgrade at this point we don't need any of other roles then
+            # common, upgrade, repository, image_registry, kubernetes_master and kubernetes_node.
+            # - commmon is already provisioned from the cluster model constructed from the inventory.
             # - upgrade should not require any addition config
-            # - repository and image_registry are provisioned below from default for upgrade
-            enabled_roles = ['repository', 'image_registry']        
+            # - other roles are provisioned below from default for upgrade
+            enabled_roles = ['repository', 'image_registry', 'kubernetes_master', 'kubernetes_node']
         else:
             enabled_roles = self.inventory_creator.get_enabled_roles()
 

--- a/core/src/epicli/cli/epicli.py
+++ b/core/src/epicli/cli/epicli.py
@@ -169,9 +169,9 @@ def upgrade_parser(subparsers):
     sub_parser.add_argument('-b', '--build', dest='build_directory', type=str, required=True,
                             help='Absolute path to directory with build artifacts.')
     sub_parser.add_argument('--wait-for-pods', dest='wait_for_pods', action="store_true",
-                            help='Waits for the pods to be in a ready state before starting the K8s upgrade.')                            
+                            help="Waits for all pods to be in the 'Ready' state before proceeding to the next step of the K8s upgrade.")
     sub_parser.add_argument('--offline-requirements', dest='offline_requirements', type=str, required=False,
-                            help='Path to the folder with pre-prepared offline requirements.')                            
+                            help='Path to the folder with pre-prepared offline requirements.')
 
     def run_upgrade(args):
         adjust_paths_from_build(args)

--- a/core/src/epicli/data/common/ansible/playbooks/roles/docker/tasks/get-server-version.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/docker/tasks/get-server-version.yml
@@ -1,0 +1,7 @@
+---
+# This file is meant to be used by other roles
+
+- name: Get version of Docker server
+  command: "{% raw %}docker version --format '{{.Server.Version}}'{% endraw %}"
+  register: result
+  changed_when: false

--- a/core/src/epicli/data/common/ansible/playbooks/roles/image_registry/tasks/load-image.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/image_registry/tasks/load-image.yml
@@ -27,7 +27,8 @@
       become: yes
       shell: "docker load --input {{ download_directory }}/{{ docker_image.file_name }}"
 
-    - name: Tag image {{ docker_image.name }} with {{ new_image_tag }}
+    - name: Tag image {{ docker_image.name +
+            (' with ' + new_image_tag if docker_image.name != specification.registry_image.name else '') }}
       become: yes
       shell: "docker tag {{ docker_image.name }} {{ new_image_tag }}"
       when:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
@@ -144,6 +144,8 @@ registry:2
 jboss/keycloak:4.8.3.Final
 rabbitmq:3.7.10
 # K8s upgrade
+## v1.11.5
+coredns/coredns:1.1.3 # needed to drain master before upgrade
 ## v1.12.10
 k8s.gcr.io/coredns:1.2.2
 k8s.gcr.io/etcd:3.2.24

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
@@ -141,6 +141,8 @@ registry:2
 jboss/keycloak:4.8.3.Final
 rabbitmq:3.7.10
 # K8s upgrade
+## v1.11.5
+coredns/coredns:1.1.3 # needed to drain master before upgrade
 ## v1.12.10
 k8s.gcr.io/coredns:1.2.2
 k8s.gcr.io/etcd:3.2.24

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
@@ -151,7 +151,10 @@ registry:2
 # applications
 jboss/keycloak:4.8.3.Final
 rabbitmq:3.7.10
-# K8s upgrades
+# K8s upgrade
+## v1.11.5
+# coredns/coredns:1.1.3 is needed to drain master before upgrade
+coredns/coredns:1.1.3
 ## v1.12.10
 k8s.gcr.io/coredns:1.2.2
 k8s.gcr.io/etcd:3.2.24

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/common.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/common.yml
@@ -1,3 +1,5 @@
 ---
-- name: Include upgrade-common
-  include_tasks: common/upgrade-common.yml # upgrades common components
+- name: Clean up jq installed as binary from GitHub
+  file:
+    path: /usr/local/bin/jq
+    state: absent

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/common/upgrade-common.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/common/upgrade-common.yml
@@ -1,5 +1,0 @@
----
-- name: Clean up jq installed as binary from GitHub
-  file:
-    path: /usr/local/bin/jq
-    state: absent

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/docker.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/docker.yml
@@ -1,6 +1,15 @@
 ---
+- name: Include get-server-version from docker role # this sets result
+  include_role:
+    name: docker
+    tasks_from: get-server-version
+
+- name: Print version of Docker server
+  debug:
+    var: result.stdout
+
 # Remove Docker v17.03 before installing v18.09 to avoid package conflict error like below
-# file /usr/bin/docker from install of docker-ce-cli-1:18.09.9-3.el7.x86_64 conflicts with file from package docker-ce-17.03.2.ce-1.el7.centos.x86_64
+# 'file /usr/bin/docker from install of docker-ce-cli-1:18.09.9-3.el7.x86_64 conflicts with file from package docker-ce-17.03.2.ce-1.el7.centos.x86_64'
 
 - name: Remove Docker in version 17.03 (RedHat)
   package:
@@ -23,3 +32,12 @@
 - name: Install Docker # this may restart Docker daemon
   import_role:
     name: docker
+
+- name: Include get-server-version from docker role # this sets result
+  include_role:
+    name: docker
+    tasks_from: get-server-version
+
+- name: Print version of Docker server
+  debug:
+    var: result.stdout

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/docker.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/docker.yml
@@ -1,0 +1,25 @@
+---
+# Remove Docker v17.03 before installing v18.09 to avoid package conflict error like below
+# file /usr/bin/docker from install of docker-ce-cli-1:18.09.9-3.el7.x86_64 conflicts with file from package docker-ce-17.03.2.ce-1.el7.centos.x86_64
+
+- name: Remove Docker in version 17.03 (RedHat)
+  package:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - docker-ce-17.03.*
+    - docker-ce-selinux-17.03.*
+  when: ansible_os_family == "RedHat"
+
+- name: Remove Docker in version 18.06 (Debian)
+  package:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - docker-ce=18.06.*
+  when: ansible_os_family == "Debian"
+
+# Install Docker in current version
+- name: Install Docker # this may restart Docker daemon
+  import_role:
+    name: docker

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/delete-kubernetes-dashboard.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/delete-kubernetes-dashboard.yml
@@ -1,5 +1,6 @@
 ---
 # Delete old kubernetes-dashboard from kube-system, new dashboard has its own namespace
+
 - name: Check if any resource with label 'k8s-app=kubernetes-dashboard' exists in kube-system
   environment:
     KUBECONFIG: /home/{{ admin_user.name }}/.kube/config

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/delete-kubernetes-dashboard.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/delete-kubernetes-dashboard.yml
@@ -5,6 +5,7 @@
     KUBECONFIG: /home/{{ admin_user.name }}/.kube/config
   shell: kubectl get all -l k8s-app=kubernetes-dashboard -n kube-system
   register: result
+  changed_when: false
 
 - name: Delete all resources with label 'k8s-app=kubernetes-dashboard' from kube-system
   environment:
@@ -18,6 +19,7 @@
     KUBECONFIG: /home/{{ admin_user.name }}/.kube/config
   shell: kubectl get Role,RoleBinding kubernetes-dashboard-minimal -n kube-system
   register: result
+  changed_when: false
 
 - name: Delete 'kubernetes-dashboard-minimal' Role and RoleBinding from kube-system
   environment:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/delete-kubernetes-dashboard.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/delete-kubernetes-dashboard.yml
@@ -12,7 +12,7 @@
     KUBECONFIG: /home/{{ admin_user.name }}/.kube/config
   shell: kubectl delete all -l k8s-app=kubernetes-dashboard -n kube-system
   when:
-    - "'No resources found' not in result.stdout"
+    - not 'No resources found' in result.stderr
 
 - name: Check if 'kubernetes-dashboard-minimal' Role or RoleBinding exists in kube-system
   environment:
@@ -20,10 +20,13 @@
   shell: kubectl get Role,RoleBinding kubernetes-dashboard-minimal -n kube-system
   register: result
   changed_when: false
+  failed_when:
+    - result.rc != 0
+    - not 'not found' in result.stderr
 
 - name: Delete 'kubernetes-dashboard-minimal' Role and RoleBinding from kube-system
   environment:
     KUBECONFIG: /home/{{ admin_user.name }}/.kube/config
   shell: kubectl delete Role,RoleBinding kubernetes-dashboard-minimal -n kube-system
   when:
-    - "'No resources found' not in result.stdout"
+    - not 'not found' in result.stderr

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/delete-kubernetes-dashboard.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/delete-kubernetes-dashboard.yml
@@ -1,0 +1,27 @@
+---
+# Delete old kubernetes-dashboard from kube-system, new dashboard has its own namespace
+- name: Check if any resource with label 'k8s-app=kubernetes-dashboard' exists in kube-system
+  environment:
+    KUBECONFIG: /home/{{ admin_user.name }}/.kube/config
+  shell: kubectl get all -l k8s-app=kubernetes-dashboard -n kube-system
+  register: result
+
+- name: Delete all resources with label 'k8s-app=kubernetes-dashboard' from kube-system
+  environment:
+    KUBECONFIG: /home/{{ admin_user.name }}/.kube/config
+  shell: kubectl delete all -l k8s-app=kubernetes-dashboard -n kube-system
+  when:
+    - "'No resources found' not in result.stdout"
+
+- name: Check if 'kubernetes-dashboard-minimal' Role or RoleBinding exists in kube-system
+  environment:
+    KUBECONFIG: /home/{{ admin_user.name }}/.kube/config
+  shell: kubectl get Role,RoleBinding kubernetes-dashboard-minimal -n kube-system
+  register: result
+
+- name: Delete 'kubernetes-dashboard-minimal' Role and RoleBinding from kube-system
+  environment:
+    KUBECONFIG: /home/{{ admin_user.name }}/.kube/config
+  shell: kubectl delete Role,RoleBinding kubernetes-dashboard-minimal -n kube-system
+  when:
+    - "'No resources found' not in result.stdout"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master.yml
@@ -1,4 +1,7 @@
 ---
+- name: upgrade-master | Wait for cluster's readiness
+  include_tasks: wait.yml
+
 - name: upgrade-master | Check if /etc/kubeadm/kubeadm-config.yml exists
   stat:
     path: /etc/kubeadm/kubeadm-config.yml
@@ -40,8 +43,8 @@
   when:
     - not kubeadm_config_file.stat.exists
 
-- name: upgrade-master | Wait for cluster's readiness
-  include_tasks: wait.yml
+- name: upgrade-master | Delete old kubernetes-dashboard from kube-system
+  include_tasks: delete-kubernetes-dashboard.yml
 
 - name: upgrade-master | Drain master in preparation for maintenance
   environment:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master.yml
@@ -54,6 +54,11 @@
 - name: upgrade-master | Wait for cluster's readiness
   include_tasks: wait.yml
 
+- name: upgrade-master | Upgrade Docker # this may restart Docker daemon
+  include_tasks: docker.yml
+  when:
+    - version is version('1.14.0', '>=') # Docker 18.09 validated since K8s 1.14
+
 - name: upgrade-master | Install packages
   include_tasks: "{{ ansible_os_family }}/install-packages.yml"
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master.yml
@@ -54,11 +54,6 @@
 - name: upgrade-master | Wait for cluster's readiness
   include_tasks: wait.yml
 
-- name: upgrade-master | Upgrade Docker # this may restart Docker daemon
-  include_tasks: docker.yml
-  when:
-    - version is version('1.14.0', '>=') # Docker 18.09 validated since K8s 1.14
-
 - name: upgrade-master | Install packages
   include_tasks: "{{ ansible_os_family }}/install-packages.yml"
 
@@ -90,6 +85,13 @@
 
 - name: upgrade-master | Wait for cluster's readiness
   include_tasks: wait.yml
+
+- name: Upgrade Docker
+  block:
+    - name: upgrade-master | Upgrade Docker # this may restart Docker daemon
+      include_tasks: docker.yml
+  when:
+    - version is version('1.14.0', '>=') # Docker 18.09 validated since K8s 1.14
 
 - name: upgrade-master | Restart kubelet
   systemd:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-node.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-node.yml
@@ -8,6 +8,11 @@
 - name: upgrade-node | Wait for cluster's readiness
   include_tasks: wait.yml
 
+- name: upgrade-node | Upgrade Docker # this may restart Docker daemon
+  include_tasks: docker.yml
+  when:
+    - version is version('1.14.0', '>=') # Docker 18.09 validated since K8s 1.14
+
 - name: upgrade-node | Install packages
   include_tasks: "{{ ansible_os_family }}/install-packages.yml"
 

--- a/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
@@ -48,6 +48,17 @@
         tasks_from: kubernetes
       vars: { ver: "1.14.6", cni_ver: "0.7.5" }
 
+- hosts: kubernetes_master
+  become: true
+  become_method: sudo
+  roles:
+    - kubernetes_master
+
+- hosts: kubernetes_node
+  become: true
+  become_method: sudo
+  roles:
+    - kubernetes_node
 
 # latest patch versions:
 # 1.11.10

--- a/core/src/epicli/data/common/defaults/configuration/image-registry.yml
+++ b/core/src/epicli/data/common/defaults/configuration/image-registry.yml
@@ -46,7 +46,10 @@ specification:
       file_name: keycloak-4.8.3.Final.tar
     - name: "rabbitmq:3.7.10"
       file_name: rabbitmq-3.7.10.tar
-    # K8s upgrades
+    # K8s upgrade
+    ## v1.11.5
+    - name: "coredns/coredns:1.1.3"
+      file_name: coredns-1.1.3.tar
     ## v1.12.10
     - name: "k8s.gcr.io/coredns:1.2.2"
       file_name: coredns-1.2.2.tar

--- a/docs/home/howto/CLUSTER.md
+++ b/docs/home/howto/CLUSTER.md
@@ -6,8 +6,8 @@ Epicli has the ability to setup a cluster on infrastructure provided by you. The
 
 1. The cluster machines/vm`s are connected by a network or virtual network of some sorts and can communicate which each other and have access to the internet.
 2. The cluster machines/vm`s are running one of the following Linux distributions:
-    - Redhat 7.4+
-    - CentOS 7.4+
+    - RedHat 7.6+ and < 8
+    - CentOS 7.6+ and < 8
     - Ubuntu 18.04
    Other distributions/version might work but are un-tested.
 3. The cluster machines/vm`s are should be accessible through SSH with a set of SSH keys you provide and configure on each machine yourself.
@@ -78,13 +78,13 @@ Epicli has the ability to setup a cluster on airgapped infrastructure provided b
 
 1. The airgapped cluster machines/vm`s are connected by a network or virtual network of some sorts and can communicate which each other:
 2. The airgapped cluster machines/vm`s are running one of the following Linux distributions:
-    - Redhat 7.4+
-    - CentOS 7.4+
+    - RedHat 7.6+ and < 8
+    - CentOS 7.6+ and < 8
     - Ubuntu 18.04
    Other distributions/version might work but are un-tested.
 3. The airgapped cluster machines/vm`s should be accessible through SSH with a set of SSH keys you provide and configure on each machine yourself.
 2. A requirements machine that:
-    - Runs the same distribution as the airgapped cluster machines/vm`s (Redhat 7.4+, CentOS 7.4+, Ubuntu 18.04)
+    - Runs the same distribution as the airgapped cluster machines/vm`s (RedHat 7, CentOS 7, Ubuntu 18.04)
     - Has access to the internet.
 3. A provisioning machine that:
     - Has access to the SSH keys

--- a/docs/home/howto/UPGRADE.md
+++ b/docs/home/howto/UPGRADE.md
@@ -19,8 +19,8 @@ Your airgapped existing cluster should meet the following requirements:
 
 1. The cluster machines/vm`s are connected by a network or virtual network of some sorts and can communicate which each other and have access to the internet:
 2. The cluster machines/vm`s are **upgraded** to the following versions:
-    - Redhat 7.4
-    - CentOS 7.4
+    - RedHat 7.6
+    - CentOS 7.6
     - Ubuntu 18.04
 3. The cluster machines/vm`s should be accessible through SSH with a set of SSH keys you provided and configured on each machine yourself.
 4. A provisioning machine that:
@@ -48,12 +48,12 @@ Your airgapped existing cluster should meet the following requirements:
 
 1. The airgapped cluster machines/vm`s are connected by a network or virtual network of some sorts and can communicate which each other:
 2. The airgapped cluster machines/vm`s are **upgraded** to the following versions:
-    - Redhat 7.4
-    - CentOS 7.4
+    - RedHat 7.6
+    - CentOS 7.6
     - Ubuntu 18.04
 3. The airgapped cluster machines/vm`s should be accessible through SSH with a set of SSH keys you provided and configured on each machine yourself.
 4. A requirements machine that:
-    - Runs the same distribution as the airgapped cluster machines/vm`s (Redhat 7.4, CentOS 7.4, Ubuntu 18.04)
+    - Runs the same distribution as the airgapped cluster machines/vm`s (RedHat 7, CentOS 7, Ubuntu 18.04)
     - Has access to the internet.
 5. A provisioning machine that:
     - Has access to the SSH keys


### PR DESCRIPTION
- Upgrade Docker to current version
- Run kubernetes_master and kubernetes_node roles after K8s upgrade
- Delete old kubernetes-dashboard from kube-system
- Added coredns:1.1.3 image, needed to drain master before upgrade
- Fixed task name for 'Tag image' task
- Deleted common subdirectory, since there is only one task