### PR TITLE
Do not run kubernetes_master and kubernetes_node roles after upgrade

### DIFF
--- a/core/src/epicli/cli/engine/ansible/AnsibleVarsGenerator.py
+++ b/core/src/epicli/cli/engine/ansible/AnsibleVarsGenerator.py
@@ -33,7 +33,7 @@ class AnsibleVarsGenerator(Step):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        super().__exit__(exc_type, exc_value, traceback)           
+        super().__exit__(exc_type, exc_value, traceback)
 
     def generate(self):
         self.logger.info('Generate Ansible vars')
@@ -51,11 +51,11 @@ class AnsibleVarsGenerator(Step):
 
         if self.inventory_creator == None:
             # For upgrade at this point we don't need any of other roles then
-            # common, upgrade, repository, image_registry, kubernetes_master and kubernetes_node.
+            # common, upgrade, repository and image_registry.
             # - commmon is already provisioned from the cluster model constructed from the inventory.
-            # - upgrade should not require any addition config
-            # - other roles are provisioned below from default for upgrade
-            enabled_roles = ['repository', 'image_registry', 'kubernetes_master', 'kubernetes_node']
+            # - upgrade should not require any additional config
+            # roles in the list below are provisioned for upgrade from defaults
+            enabled_roles = ['repository', 'image_registry']
         else:
             enabled_roles = self.inventory_creator.get_enabled_roles()
 

--- a/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
@@ -48,18 +48,6 @@
         tasks_from: kubernetes
       vars: { ver: "1.14.6", cni_ver: "0.7.5" }
 
-- hosts: kubernetes_master
-  become: true
-  become_method: sudo
-  roles:
-    - kubernetes_master
-
-- hosts: kubernetes_node
-  become: true
-  become_method: sudo
-  roles:
-    - kubernetes_node
-
 # latest patch versions:
 # 1.11.10
 # 1.12.10


### PR DESCRIPTION
Since for `epicli upgrade` we can use only configuration provisioned from `defaults` (Ansible's vars), run these roles may overwrite previously customized configuration with the default, for example K8s network plugin.