### PR TITLE
Fix for 'port already in use by another kube-scheduler process'

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/docker.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/docker.yml
@@ -10,17 +10,13 @@
 
 # Check if docker-ce is updatable to conditionally stop kubelet service before update
 - name: Check if docker-ce is updatable
-  command: yum check-update docker-ce
+  command: >-
+    {{ 'yum check-update docker-ce' if ansible_os_family == 'RedHat' else
+       'apt list --upgradable docker-ce' if ansible_os_family == 'Debian' else None }}
+  args:
+    warn: no
   register: check_docker_update
   failed_when: check_docker_update.rc not in [0, 100] # check-update returns code 100 if there are packages available for an update
-  when:
-    - ansible_os_family == "RedHat"
-
-- name: Check if docker-ce is updatable
-  command: apt list --upgradable docker-ce
-  register: check_docker_update
-  when:
-    - ansible_os_family == "Debian"
 
 - name: Set is_docker_updatable fact
   set_fact:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/docker.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/docker.yml
@@ -8,6 +8,31 @@
   debug:
     var: result.stdout
 
+# Check if docker-ce is updatable to conditionally stop kubelet service before update
+- name: Check if docker-ce is updatable
+  command: yum check-update docker-ce
+  register: check_docker_update
+  failed_when: check_docker_update.rc not in [0, 100] # check-update returns code 100 if there are packages available for an update
+  when:
+    - ansible_os_family == "RedHat"
+
+- name: Check if docker-ce is updatable
+  command: apt list --upgradable docker-ce
+  register: check_docker_update
+  when:
+    - ansible_os_family == "Debian"
+
+- name: Set is_docker_updatable fact
+  set_fact:
+    is_docker_updatable: "{{ check_docker_update.stdout is search('docker-ce') }}"
+
+- name: Stop kubelet before Docker update
+  systemd:
+    state: stopped
+    name: kubelet
+  when:
+    - is_docker_updatable
+
 # Remove Docker in version < 18.09 on RedHat before installing v18.09 to avoid package conflict error like below
 # 'file /usr/bin/docker from install of docker-ce-cli-1:18.09.9-3.el7.x86_64 conflicts with file from package docker-ce-17.03.2.ce-1.el7.centos.x86_64'
 - name: Remove Docker in version < 18.09 (RedHat)
@@ -47,3 +72,11 @@
 - name: Print version of Docker server
   debug:
     var: result.stdout
+
+- name: Start kubelet after Docker update
+  systemd:
+    state: started
+    name: kubelet
+    daemon_reload: yes
+  when:
+    - is_docker_updatable

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master.yml
@@ -109,6 +109,8 @@
     state: restarted
     daemon_reload: yes
     name: kubelet
+  when:
+    - not is_docker_updatable
 
 - name: upgrade-master | Wait for cluster's readiness
   include_tasks: wait.yml

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master.yml
@@ -110,7 +110,7 @@
     daemon_reload: yes
     name: kubelet
   when:
-    - not is_docker_updatable
+    - is_docker_updatable is undefined or not is_docker_updatable
 
 - name: upgrade-master | Wait for cluster's readiness
   include_tasks: wait.yml


### PR DESCRIPTION
 Stop kubelet service before updating Docker (#731)