### PR TITLE
Fixes before releasing 0.4.2

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/docker.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/docker.yml
@@ -16,7 +16,8 @@
   args:
     warn: no
   register: check_docker_update
-  failed_when: check_docker_update.rc not in [0, 100] # check-update returns code 100 if there are packages available for an update
+  failed_when: check_docker_update.rc not in [0, 100] # yum check-update returns code 100 if there are packages available for update
+  changed_when: false
 
 - name: Set is_docker_updatable fact
   set_fact:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/verify-upgrade.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/verify-upgrade.yml
@@ -1,6 +1,9 @@
 ---
 - name: Verify cluster version
   block:
+    - name: verify-upgrade | Include wait-for-kube-apiserver.yml
+      include_tasks: wait-for-kube-apiserver.yml
+
     - name: verify-upgrade | Include get-cluster-version.yml
       include_tasks: get-cluster-version.yml # sets cluster_version
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/wait.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/wait.yml
@@ -4,7 +4,9 @@
     KUBECONFIG: /home/{{ admin_user.name }}/.kube/config
   shell: kubectl cluster-info
   register: output
-  until: output is succeeded and "running" in output.stdout
+  until:
+    - output is succeeded
+    - "'running' in output.stdout"
   retries: 30 # 1min
   delay: 2
   changed_when: false
@@ -14,7 +16,9 @@
     KUBECONFIG: /home/{{ admin_user.name }}/.kube/config
   shell: kubectl get nodes -o json
   register: output
-  until: output.stdout|from_json|json_query("items[*].status.conditions[?(@.type=='Ready')].status[]")|unique == ["True"]
+  until:
+    - output is succeeded
+    - output.stdout|from_json|json_query("items[*].status.conditions[?(@.type=='Ready')].status[]")|unique == ["True"]
   retries: 600 # 20min
   delay: 2
   changed_when: false
@@ -24,7 +28,9 @@
     KUBECONFIG: /home/{{ admin_user.name }}/.kube/config
   shell: kubectl get pods --all-namespaces -o json
   register: output
-  until: output.stdout|from_json|json_query('items[*].status.phase')|unique == ["Running"]
+  until:
+    - output is succeeded
+    - output.stdout|from_json|json_query('items[*].status.phase')|unique == ["Running"]
   retries: 600 # 20min
   delay: 2
   changed_when: false
@@ -35,7 +41,9 @@
     KUBECONFIG: /home/{{ admin_user.name }}/.kube/config
   shell: kubectl get pods --all-namespaces -o json
   register: output
-  until: output.stdout|from_json|json_query('items[*].status.conditions[].status')|unique == ["True"]
+  until:
+    - output is succeeded
+    - output.stdout|from_json|json_query('items[*].status.conditions[].status')|unique == ["True"]
   retries: 600 # 20min
   delay: 2
   changed_when: false


### PR DESCRIPTION
-  Wait for apiserver before verifying cluster version (#742)
-  Parse output only when kubectl command succeeded (#741)