### PR TITLE
Flexible configuration of ES Curator cron jobs

### DIFF
--- a/CHANGELOG-0.5.md
+++ b/CHANGELOG-0.5.md
@@ -1,0 +1,8 @@
+# Changelog 0.5
+
+## [0.5.0] 2019-12-NN
+
+### Changed
+
+- [#763](https://github.com/epiphany-platform/epiphany/pull/763) - Flexible configuration of Elasticsearch Curator cron jobs
+- [#763](https://github.com/epiphany-platform/epiphany/pull/763) - Elasticsearch Curator updated to v5.8.1

--- a/core/src/epicli/data/common/ansible/playbooks/elasticsearch_curator.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/elasticsearch_curator.yml
@@ -1,8 +1,5 @@
 ---
-# Ansible playbook that installs and configures Elasticsearch Curator
-- hosts: elasticsearch
-  gather_facts: yes
-  tasks: [ ]
+# Ansible playbook that installs Elasticsearch Curator and configures cron jobs that delete indices
 
 - hosts: elasticsearch_curator
   become: true

--- a/core/src/epicli/data/common/ansible/playbooks/elasticsearch_curator.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/elasticsearch_curator.yml
@@ -1,6 +1,6 @@
 ---
-# Ansible playbook that makes sure elasticsearch-curator will be installed
-- hosts: all
+# Ansible playbook that installs and configures Elasticsearch Curator
+- hosts: elasticsearch
   gather_facts: yes
   tasks: [ ]
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/defaults/main.yml
@@ -1,10 +1,2 @@
 ---
-elasticsearch_ip: "{{ hostvars[groups['elasticsearch'][0]]['ansible_default_ipv4']['address'] }}"
-
-elasticsearch_curator_cron_jobs:
-- hour: 1
-  job: curator_cli --host '{{ elasticsearch_ip }}' delete_indices --filter_list
-    '[{"filtertype":"age","source":"creation_date","direction":"older","unit":"days","unit_count":{{
-    specification.indices_retention_days }}}]'
-  minute: 0
-  name: Delete old elasticsearch indices.
+elasticsearch_ip: "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/Debian.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/Debian.yml
@@ -1,6 +1,6 @@
-- name: Install Elasticsearch-Curator package
-  apt: 
+- name: Install elasticsearch-curator package
+  apt:
     name:
-      - elasticsearch-curator
-    update_cache: yes 
+      - elasticsearch-curator={{ versions.elasticsearch_curator }}
+    update_cache: yes
     state: present

--- a/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/RedHat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/RedHat.yml
@@ -1,6 +1,6 @@
-- name: Install Elasticsearch-Curator package
+- name: Install elasticsearch-curator package
   yum:
     name:
-      - elasticsearch-curator
+      - elasticsearch-curator-{{ versions.elasticsearch_curator }}
     update_cache: yes
     state: present

--- a/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/configure-cron-jobs.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/configure-cron-jobs.yml
@@ -1,4 +1,19 @@
 ---
+
+- name: Prepare list of cron jobs based on configuration
+  set_fact:
+    curator_cron_jobs: >-
+      {{ curator_cron_jobs | default([])
+         + [ { 'cmd': curator_cmd, 'cron': item.cron, 'config_hash': job_config_hash } ] }}
+  vars:
+    curator_cmd: curator_cli --host '{{ elasticsearch_ip }}' delete_indices
+      --filter_list '{{ item.filter_list | to_json(separators=(',',':')) }}'
+      --ignore_empty_list                        # separators used to remove spaces
+    job_config_hash: "{{ item | string | hash('sha1') }}"
+  loop: "{{ specification.delete_indices_cron_jobs }}"
+  when:
+    - specification.delete_indices_cron_jobs is defined
+
 - name: Remove old Ansible managed Elasticsearch Curator cron jobs
   block:
     - name: Get crontab
@@ -9,7 +24,10 @@
     - name: Get Ansible managed Elasticsearch Curator cron jobs
       set_fact:
         managed_curator_cron_jobs: >-
-          {{ managed_curator_cron_jobs | default([]) + [ item | regex_replace('^[^:]+:\s*', '', ignorecase=True) ] }}
+          {{ managed_curator_cron_jobs | default([])
+             + [ { 'name':        item | regex_replace('^[^:]+:\s*', '', ignorecase=True),
+                   'config_hash': item | regex_replace('.*config_hash: ([a-f0-9]+).*', '\1')
+                 } ] }}
       loop_control:
         extended: yes
       loop: "{{ crontab.stdout_lines }}"
@@ -20,54 +38,52 @@
 
     - name: Remove old Ansible managed Elasticsearch Curator cron jobs
       cron:
-        name: "{{ item }}"
+        name: "{{ item.name }}"
         state: absent
       loop: "{{ managed_curator_cron_jobs }}"
-      when: managed_curator_cron_jobs is defined
+      when:
+        - managed_curator_cron_jobs is defined
+        - curator_cron_jobs is undefined
+          or (curator_cron_jobs | selectattr('config_hash','equalto', item.config_hash) | list | count == 0)
 
-- name: Configure cron jobs that delete Elasticsearch indices
+- name: Test curator_cli commands for new cron jobs
   block:
-    - name: Set curator_cli commands for cron jobs
-      set_fact:
-        curator_cli_cmds: "{{ curator_cli_cmds | default([]) + [ curator_cmd ] }}"
-      vars:
-        curator_cmd: curator_cli --host '{{ elasticsearch_ip }}' delete_indices
-          --filter_list '{{ item.filter_list | to_json(separators=(',',':')) }}'
-          --ignore_empty_list                        # separators used to remove spaces
-      loop: "{{ specification.delete_indices_cron_jobs }}"
-
-    - name: Test curator_cli commands with --dry-run
+    - name: Test curator_cli commands for new cron jobs with --dry-run
       command: "{{ curator_test_cmd }}"
       changed_when: false
       failed_when: false
       register: result
       vars:
-        curator_test_cmd: "{{ item | replace('curator_cli', 'curator_cli --dry-run') }}"
+        curator_test_cmd: "{{ item.cmd | replace('curator_cli', 'curator_cli --dry-run') }}"
       loop_control:
         label: "{{ curator_test_cmd }}"
-      loop: "{{ curator_cli_cmds }}"
+      loop: "{{ curator_cron_jobs }}"
+      when:
+       - managed_curator_cron_jobs is undefined
+         or (managed_curator_cron_jobs | selectattr('config_hash','equalto', item.config_hash) | list | count == 0)
 
     - name: Check test results
       assert:
         that: item.rc == 0
         quiet: true
       loop_control:
-        label: "{{ item.cmd }}"
+        label: "{{ item.cmd | default('skipped') }}"
       loop: "{{ result.results }}"
-
-    - name: Configure cron jobs that delete Elasticsearch indices
-      cron:
-        # NOTE: name should be unique since changing it will result in a new cron task being created
-        name: "Elasticsearch Curator job that deletes indices #{{ ansible_loop.index }}"
-        job: "{{ curator_cli_cmds[ansible_loop.index0] }}"
-        minute:   "{{ item.cron.minute       | default('*') }}"
-        hour:     "{{ item.cron.hour         | default('*') }}"
-        day:      "{{ item.cron.day          | default('*') }}"
-        weekday:  "{{ item.cron.weekday      | default('*') }}"
-        month:    "{{ item.cron.month        | default('*') }}"
-        disabled: "{{ not (item.cron.enabled | default(True)) }}"
-      loop_control:
-        extended: yes
-      loop: "{{ specification.delete_indices_cron_jobs }}"
+      when: item.rc is defined
   when:
-    - specification.delete_indices_cron_jobs is defined
+    - curator_cron_jobs is defined
+
+- name: Configure cron jobs that delete Elasticsearch indices
+  cron:
+    # NOTE: name should be unique since changing it will result in a new cron task being created
+    name: "Elasticsearch Curator job that deletes indices, config_hash: {{ item.config_hash }}"
+    job: "{{ item.cmd }}"
+    minute:   "{{ item.cron.minute       | default('*') }}"
+    hour:     "{{ item.cron.hour         | default('*') }}"
+    day:      "{{ item.cron.day          | default('*') }}"
+    weekday:  "{{ item.cron.weekday      | default('*') }}"
+    month:    "{{ item.cron.month        | default('*') }}"
+    disabled: "{{ not (item.cron.enabled | default(True)) }}"
+  loop: "{{ curator_cron_jobs }}"
+  when:
+    - curator_cron_jobs is defined

--- a/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/configure-cron-jobs.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/configure-cron-jobs.yml
@@ -1,0 +1,73 @@
+---
+- name: Remove old Ansible managed Elasticsearch Curator cron jobs
+  block:
+    - name: Get crontab
+      command: crontab -l
+      register: crontab
+      changed_when: false
+
+    - name: Get Ansible managed Elasticsearch Curator cron jobs
+      set_fact:
+        managed_curator_cron_jobs: >-
+          {{ managed_curator_cron_jobs | default([]) + [ item | regex_replace('^[^:]+:\s*', '', ignorecase=True) ] }}
+      loop_control:
+        extended: yes
+      loop: "{{ crontab.stdout_lines }}"
+      when:
+        - item is regex('^#ansible', ignorecase=True)
+        - ansible_loop.nextitem is defined
+        - ansible_loop.nextitem is regex('\\bcurator_cli\\b')
+
+    - name: Remove old Ansible managed Elasticsearch Curator cron jobs
+      cron:
+        name: "{{ item }}"
+        state: absent
+      loop: "{{ managed_curator_cron_jobs }}"
+      when: managed_curator_cron_jobs is defined
+
+- name: Configure cron jobs that delete Elasticsearch indices
+  block:
+    - name: Set curator_cli commands for cron jobs
+      set_fact:
+        curator_cli_cmds: "{{ curator_cli_cmds | default([]) + [ curator_cmd ] }}"
+      vars:
+        curator_cmd: curator_cli --host '{{ elasticsearch_ip }}' delete_indices
+          --filter_list '{{ item.filter_list | to_json(separators=(',',':')) }}'
+          --ignore_empty_list                        # separators used to remove spaces
+      loop: "{{ specification.delete_indices_cron_jobs }}"
+
+    - name: Test curator_cli commands with --dry-run
+      command: "{{ curator_test_cmd }}"
+      changed_when: false
+      failed_when: false
+      register: result
+      vars:
+        curator_test_cmd: "{{ item | replace('curator_cli', 'curator_cli --dry-run') }}"
+      loop_control:
+        label: "{{ curator_test_cmd }}"
+      loop: "{{ curator_cli_cmds }}"
+
+    - name: Check test results
+      assert:
+        that: item.rc == 0
+        quiet: true
+      loop_control:
+        label: "{{ item.cmd }}"
+      loop: "{{ result.results }}"
+
+    - name: Configure cron jobs that delete Elasticsearch indices
+      cron:
+        # NOTE: name should be unique since changing it will result in a new cron task being created
+        name: "Elasticsearch Curator job that deletes indices #{{ ansible_loop.index }}"
+        job: "{{ curator_cli_cmds[ansible_loop.index0] }}"
+        minute:   "{{ item.cron.minute       | default('*') }}"
+        hour:     "{{ item.cron.hour         | default('*') }}"
+        day:      "{{ item.cron.day          | default('*') }}"
+        weekday:  "{{ item.cron.weekday      | default('*') }}"
+        month:    "{{ item.cron.month        | default('*') }}"
+        disabled: "{{ not (item.cron.enabled | default(True)) }}"
+      loop_control:
+        extended: yes
+      loop: "{{ specification.delete_indices_cron_jobs }}"
+  when:
+    - specification.delete_indices_cron_jobs is defined

--- a/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/install-es-curator.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/install-es-curator.yml
@@ -1,5 +1,5 @@
 ---
-# This file is meant to be used also by upgrade role
+# This file is meant to be also used by upgrade role
 
 - name: Install Elasticsearch Curator ({{ ansible_os_family }})
   include_tasks: "{{ ansible_os_family }}.yml"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/install-es-curator.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/install-es-curator.yml
@@ -1,5 +1,5 @@
 ---
-# This file is meant to be also used by upgrade role
+# This file is meant to be also used by upgrade playbook
 
 - name: Install Elasticsearch Curator ({{ ansible_os_family }})
   include_tasks: "{{ ansible_os_family }}.yml"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/install-package.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/install-package.yml
@@ -1,0 +1,5 @@
+---
+# This file is meant to be used also by upgrade role
+
+- name: Install Elasticsearch Curator ({{ ansible_os_family }})
+  include_tasks: "{{ ansible_os_family }}.yml"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-
-- include_tasks: "{{ ansible_os_family }}.yml"  
+- name: Include installation tasks
+  include_tasks: install-package.yml
 
 - name: Configure cron jobs for Elasticsearch Curator
   cron:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/main.yml
@@ -1,27 +1,6 @@
 ---
 - name: Include installation tasks
-  include_tasks: install-package.yml
+  include_tasks: install-es-curator.yml
 
-- name: Configure cron jobs for Elasticsearch Curator
-  cron:
-    name: "{{ item.name }}"
-    job: "{{ item.job }}"
-    minute: "{{ item.minute | default('*') }}"
-    hour: "{{ item.hour | default('*') }}"
-    day: "{{ item.day | default('*') }}"
-    weekday: "{{ item.weekday | default('*') }}"
-    month: "{{ item.month | default('*') }}"
-  with_items: "{{ specification.elasticsearch_curator_cron_jobs }}"
-  when: specification.elasticsearch_curator_cron_jobs is defined
-
-- name: Configure cron jobs for Elasticsearch Curator
-  cron:
-    name: "{{ item.name }}"
-    job: "{{ item.job }}"
-    minute: "{{ item.minute | default('*') }}"
-    hour: "{{ item.hour | default('*') }}"
-    day: "{{ item.day | default('*') }}"
-    weekday: "{{ item.weekday | default('*') }}"
-    month: "{{ item.month | default('*') }}"
-  with_items: "{{ elasticsearch_curator_cron_jobs }}"
-  when: not specification.elasticsearch_curator_cron_jobs is defined
+- name: Include configuration tasks
+  include_tasks: configure-cron-jobs.yml

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
@@ -29,7 +29,7 @@ dejavu-sans-fonts # for grafana
 docker-ce-18.09.9
 docker-ce-cli-18.09.9
 ebtables
-elasticsearch-curator-5.5.4
+elasticsearch-curator-5.8.1
 elasticsearch-oss-6.4.0
 erlang-21.3.8.7
 ethtool

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
@@ -28,7 +28,7 @@ dejavu-sans-fonts # for grafana
 docker-ce-18.09.9
 docker-ce-cli-18.09.9
 ebtables
-elasticsearch-curator-5.5.4
+elasticsearch-curator-5.8.1
 elasticsearch-oss-6.4.0
 erlang-21.3.8.7
 ethtool

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
@@ -11,7 +11,7 @@ curl
 docker-ce 5:18.09
 docker-ce-cli 5:18.09
 ebtables
-elasticsearch-curator
+elasticsearch-curator 5.8.1
 elasticsearch-oss 6.4.0
 erlang-nox
 ethtool

--- a/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
@@ -53,3 +53,11 @@
 # 1.12.10
 # 1.13.12
 # 1.14.8
+
+- hosts: elasticsearch_curator
+  become: true
+  become_method: sudo
+  tasks:
+    - import_role:
+        name: elasticsearch_curator
+        tasks_from: install-package # upgrade only package and do not change configured jobs

--- a/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
@@ -60,4 +60,4 @@
   tasks:
     - import_role:
         name: elasticsearch_curator
-        tasks_from: install-package # upgrade only package and do not change configured jobs
+        tasks_from: install-es-curator # upgrade only package and do not change configured cron jobs

--- a/core/src/epicli/data/common/defaults/configuration/elasticsearch-curator.yml
+++ b/core/src/epicli/data/common/defaults/configuration/elasticsearch-curator.yml
@@ -1,7 +1,5 @@
 kind: configuration/elasticsearch-curator
-title: "ElasticSearch curator"
+title: "Elasticsearch Curator"
 name: default
 specification:
   indices_retention_days: 30
-  debian_curator_version: "5.5.4_amd64"
-  redhat_curator_version: "5.5.4-1.x86_64"

--- a/core/src/epicli/data/common/defaults/configuration/elasticsearch-curator.yml
+++ b/core/src/epicli/data/common/defaults/configuration/elasticsearch-curator.yml
@@ -1,5 +1,25 @@
 kind: configuration/elasticsearch-curator
-title: "Elasticsearch Curator"
+title: Elasticsearch Curator
 name: default
 specification:
-  indices_retention_days: 30
+  delete_indices_cron_jobs:
+    - description: Delete indices older than N days
+      cron:
+        hour: 1
+        minute: 0
+        enabled: true
+      filter_list:
+        - filtertype: age
+          unit_count: 30
+          unit: days
+          source: creation_date
+          direction: older
+    - description: Delete the oldest indices to not consume more than N gigabytes of disk space
+      cron:
+        minute: 30
+        enabled: true
+      filter_list:
+        - filtertype: space
+          disk_space: 20
+          use_age: True
+          source: creation_date

--- a/core/src/epicli/data/common/defaults/configuration/shared-config.yml
+++ b/core/src/epicli/data/common/defaults/configuration/shared-config.yml
@@ -39,3 +39,5 @@ specification:
     - name: Ubuntu
       comparison_operator: "=="
       version: 18.04
+  versions: # versions to install or upgrade to (please keep alphabetical order)
+    elasticsearch_curator: "5.8.1"

--- a/docs/architecture/logical-view.md
+++ b/docs/architecture/logical-view.md
@@ -65,7 +65,7 @@ Docker containers | Kubernetes components that run in a container
 
 `Elasticsearch Curator` is component that manages and cleans indices and snapshots. Epiphany uses `Elasticsearch Curator` to ensure that centralized logging will not completely fill disk space.
 
-[Read more](https://www.elastic.co/guide/en/elasticsearch/client/curator/5.5/index.html)
+[Read more](https://www.elastic.co/guide/en/elasticsearch/client/curator/5.8/index.html)
 
 ### Kibana
 

--- a/docs/home/COMPONENTS.md
+++ b/docs/home/COMPONENTS.md
@@ -14,7 +14,7 @@ Note that versions are default versions and can be changed in certain cases thro
 | Docker-ce             | 18.09.6 | https://github.com/docker/docker-ce/                  | [Apache License](https://www.apache.org/licenses/LICENSE-1.0)     |
 | KeyCloak              | 4.8.3   | https://github.com/keycloak/keycloak                  | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Elasticsearch         | 6.4.0   | https://github.com/elastic/elasticsearch              | https://github.com/elastic/elasticsearch/blob/master/LICENSE.txt  |
-| Elasticsearch Curator | 5.5.4   | https://github.com/elastic/curator                    | https://github.com/elastic/curator/blob/master/LICENSE.txt        |
+| Elasticsearch Curator | 5.8.1   | https://github.com/elastic/curator                    | https://github.com/elastic/curator/blob/master/LICENSE.txt        |
 | Kibana                | 6.5.4   | https://github.com/elastic/kibana                     | https://github.com/elastic/kibana/blob/master/LICENSE.txt         |
 | Filebeat              | 2.10.0  | https://github.com/elastic/beats/tree/master/filebeat | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Prometheus            | 6.2.5   | https://github.com/prometheus/prometheus              | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |


### PR DESCRIPTION
- Flexible configuration of Elasticsearch Curator cron jobs (#762, #734)
- Update Elasticsearch Curator to v5.8.1
- Install elasticsearch-curator in version from shared configuration
- Added ES Curator to the `upgrade` playbook
- Added `--dry-run` test for `curator_cli` commands
- Added `--ignore_empty_list` option for `curator_cli` commands
- Added possibility to disable ES Curator cron jobs without removing them from configuration