### PR TITLE
[ES Curator] Fix for 'no crontab for root' when crontab is empty

### DIFF
--- a/CHANGELOG-0.5.md
+++ b/CHANGELOG-0.5.md
@@ -4,5 +4,5 @@
 
 ### Changed
 
-- [#763](https://github.com/epiphany-platform/epiphany/pull/763) - Flexible configuration of Elasticsearch Curator cron jobs
-- [#763](https://github.com/epiphany-platform/epiphany/pull/763) - Elasticsearch Curator updated to v5.8.1
+- [#763](https://github.com/epiphany-platform/epiphany/pull/763) - Elasticsearch Curator: Flexible configuration of cron jobs
+- [#763](https://github.com/epiphany-platform/epiphany/pull/763) - Elasticsearch Curator: Upgrade to v5.8.1

--- a/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/configure-cron-jobs.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/tasks/configure-cron-jobs.yml
@@ -20,6 +20,9 @@
       command: crontab -l
       register: crontab
       changed_when: false
+      failed_when:
+        - crontab.rc != 0
+        - crontab.stderr is not match('no crontab for')
 
     - name: Get Ansible managed Elasticsearch Curator cron jobs
       set_fact:
@@ -73,7 +76,7 @@
   when:
     - curator_cron_jobs is defined
 
-- name: Configure cron jobs that delete Elasticsearch indices
+- name: Create cron jobs that delete Elasticsearch indices
   cron:
     # NOTE: name should be unique since changing it will result in a new cron task being created
     name: "Elasticsearch Curator job that deletes indices, config_hash: {{ item.config_hash }}"


### PR DESCRIPTION
When crontab is empty, `crontab -l` returns exit code 1.