### PR TITLE
Make sure connection to epirepo is not blocked by firewall

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/firewall.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/firewall.yml
@@ -1,7 +1,16 @@
 ---
 # Ansible playbook that installs and configures OS level firewall
 
-- hosts: all
+# To make sure connection to epirepo is not blocked between firewalld was installed and not configured yet
+# On Ubuntu firewalld service starts automatically while installing firewalld package
+
+- hosts: repository
+  become: true
+  become_method: sudo
+  roles:
+    - firewall
+
+- hosts: all:!repository
   become: true
   become_method: sudo
   roles:


### PR DESCRIPTION
Make sure connection to epirepo is not blocked between firewalld was installed and not configured yet.
On Ubuntu firewalld service starts automatically while installing firewalld package.