### PR TITLE
Fix misspell of rabbitmq in single_machine feature mapping

### DIFF
--- a/core/src/epicli/data/common/defaults/configuration/feature-mapping.yml
+++ b/core/src/epicli/data/common/defaults/configuration/feature-mapping.yml
@@ -106,7 +106,7 @@ specification:
       - image-registry
       - kubernetes-master
       - applications
-      - rabbitmql
+      - rabbitmq
       - postgresql
       - firewall
     kubernetes_master:


### PR DESCRIPTION
I believe this was merged earlier but somehow got overwritten.