### PR TITLE
Changes in QA image Dockerfile required for running tests as non-root user

### DIFF
--- a/core/src/epicli/tests/docker/test-ci-epicli/Dockerfile
+++ b/core/src/epicli/tests/docker/test-ci-epicli/Dockerfile
@@ -6,10 +6,4 @@ RUN sudo apt-get update \
 && sudo apt-get -y install ruby-full \
 && sudo gem install serverspec rake rspec_junit_formatter
 
-RUN ssh-keygen -q -t rsa -m PEM -N '' -f ~/.ssh/id_rsa
-
-COPY tests/serverspec-cli/ /serverspec
-
-WORKDIR /serverspec
-
-ENTRYPOINT ["/bin/bash"]
+COPY --chown=epiuser:epiuser tests/serverspec-cli/ /serverspec


### PR DESCRIPTION
Inheriting WORKDIR and ENTRYPOINT from base image