### PR TITLE
Fix for 'Create epirepo repository' task waits for user input in offline mode

### DIFF
--- a/CHANGELOG-0.6.md
+++ b/CHANGELOG-0.6.md
@@ -12,3 +12,4 @@
 ### Fixed
 
 - [#624](https://github.com/epiphany-platform/epiphany/issues/624) - Don't run epicli as root in container
+- [#966](https://github.com/epiphany-platform/epiphany/issues/966) - Ubuntu builds get stuck on 'Create epirepo repository' task waiting for user input in offline mode

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/server/Debian/create-repository.sh
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/server/Debian/create-repository.sh
@@ -18,16 +18,25 @@ if $IS_OFFLINE_MODE = true; then
     cd "${EPI_REPO_SERVER_PATH}"/packages && /tmp/epi-repository-setup-scripts/dpkg-scanpackages -m . | gzip -9c > Packages.gz && cd "${script_path}"
     echo "deb [trusted=yes] file:${EPI_REPO_SERVER_PATH}/packages ./" > /etc/apt/sources.list.d/epilocal.list
     #apt update --assume-no # workaround for botched docker repository https://github.com/docker/for-linux/issues/812
-    echo "updating apt and installing apache..."
+    echo "updating list of available packages..."
     apt -y update
-    apt -y install apache2 dpkg-dev
+    echo "installing apache..."
+    # force non-interactive mode, ref: https://bugs.launchpad.net/ubuntu/+source/ansible/+bug/1833013
+    DEBIAN_FRONTEND=noninteractive \
+    UCF_FORCE_CONFOLD=1 \
+      apt-get \
+      -o Dpkg::Options::=--force-confold \
+      -o Dpkg::Options::=--force-confdef \
+      -y -q install apache2 dpkg-dev
     echo "removing temporary repo definition: /etc/apt/sources.list.d/epilocal.list..."
     rm -f /etc/apt/sources.list.d/epilocal.list
     #rm -f ${EPI_REPO_SERVER_PATH}/packages/Packages.gz
-    echo "updating apt..."
+    echo "updating list of available packages..."
     apt -y update
 else
-    # for online mode just install apache (force non-interactive mode, ref: https://bugs.launchpad.net/ubuntu/+source/ansible/+bug/1833013)
+    # for online mode just install apache
+    echo "installing apache..."
+    # force non-interactive mode, ref: https://bugs.launchpad.net/ubuntu/+source/ansible/+bug/1833013
     DEBIAN_FRONTEND=noninteractive \
     UCF_FORCE_CONFOLD=1 \
       apt-get \


### PR DESCRIPTION
Initially issue #966 was found and fixed only for online mode, **this PR is for offline mode**.