### PR TITLE
Increase memory resources for pgpool container

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/applications/templates/pgpool/deployment.yml.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/applications/templates/pgpool/deployment.yml.j2
@@ -42,6 +42,7 @@ spec:
                 - -ec
                 - PGDATABASE=postgres
                   /opt/bitnami/scripts/pgpool/healthcheck.sh
+{#          it's better to avoid overlapping with readinessProbe #}
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5

--- a/core/src/epicli/data/common/defaults/configuration/applications.yml
+++ b/core/src/epicli/data/common/defaults/configuration/applications.yml
@@ -102,10 +102,10 @@ specification:
     resources: # Adjust to your configuration, see https://www.pgpool.net/docs/41/en/html/resource-requiremente.html
       limits:
         # cpu: 900m # Set according to your env
-        memory: 164Mi
+        memory: 176Mi
       requests:
         cpu: 250m # Adjust to your env, increase if possible
-        memory: 164Mi
+        memory: 176Mi
     pgpool:
       # https://github.com/bitnami/bitnami-docker-pgpool#configuration + https://github.com/bitnami/bitnami-docker-pgpool#environment-variables
       env:


### PR DESCRIPTION
The amount of memory calculated based on Pgpool documentation turned out to be too low under stress tests causing pgpool pod to keep CrashLoopBackOff status.

```
kubectl logs pgpool-6d9ff478c-l9xrz | grep -A3 FATAL
2020-04-02 13:32:33: pid 1: FATAL:  failed to fork a child
2020-04-02 13:32:33: pid 1: DETAIL:  system call fork() failed with reason: Cannot allocate memory
2020-04-02 13:32:33: pid 1: LOCATION:  pgpool_main.c:719
```