### PR TITLE
epicli: objdict to/from conversion refactor

### DIFF
--- a/core/src/epicli/cli/helpers/objdict_helpers.py
+++ b/core/src/epicli/cli/helpers/objdict_helpers.py
@@ -2,30 +2,29 @@ from cli.helpers.ObjDict import ObjDict
 from copy import deepcopy
 
 
-def nested_dict_to_objdict(d):
-    for k, v in d.items():
-        if isinstance(v, dict):
-            nested_dict_to_objdict(v)
-            d[k] = ObjDict(v)
+def _nested_dict_to_dict(d, *, src_class, dst_class):
+    if isinstance(d, src_class):
+        return dst_class(
+            (k, _nested_dict_to_dict(v, src_class=src_class, dst_class=dst_class))
+            for k, v in d.items()
+        )
+    if isinstance(d, list):
+        return list(
+            _nested_dict_to_dict(v, src_class=src_class, dst_class=dst_class)
+            for v in d
+        )
+    # Clone everything unexpected
+    return deepcopy(d)
 
 
 def dict_to_objdict(d):
-    dc = deepcopy(d)
-    nested_dict_to_objdict(dc)
-    return ObjDict(dc)
-
-
-def nested_objdict_to_dict(d):
-    for k, v in d.items():
-        if isinstance(v, ObjDict):
-            nested_objdict_to_dict(v)
-            d[k] = dict(v)
+    """Recursively convert any dictionary (subclass of dict) to ObjDict."""
+    return _nested_dict_to_dict(d, src_class=dict, dst_class=ObjDict)
 
 
 def objdict_to_dict(d):
-    dc = deepcopy(d)
-    nested_objdict_to_dict(dc)
-    return dict(dc)
+    """Recursively convert any ObjDict to python dictionary."""
+    return _nested_dict_to_dict(d, src_class=dict, dst_class=dict)  # ObjDict is a subclass of dict
 
 
 def merge_objdict(to_merge, extend_by):
@@ -43,7 +42,7 @@ def remove_value(d, value):
     if isinstance(d, str):
         return
     elif isinstance(d, list):
-        for dd in d:     
+        for dd in d:
             remove_value(dd, value)
     else:
         for k in list(d):
@@ -53,4 +52,3 @@ def remove_value(d, value):
             else:
                 if value == v:
                     del d[k]
-        

--- a/core/src/epicli/cli/helpers/objdict_helpers.py
+++ b/core/src/epicli/cli/helpers/objdict_helpers.py
@@ -2,29 +2,29 @@ from cli.helpers.ObjDict import ObjDict
 from copy import deepcopy
 
 
-def _nested_dict_to_dict(d, *, src_class, dst_class):
-    if isinstance(d, src_class):
+def _nested_dict_to_dict(something, *, src_class, dst_class):
+    if isinstance(something, src_class):
         return dst_class(
-            (k, _nested_dict_to_dict(v, src_class=src_class, dst_class=dst_class))
-            for k, v in d.items()
+            (key, _nested_dict_to_dict(value, src_class=src_class, dst_class=dst_class))
+            for key, value in something.items()
         )
-    if isinstance(d, list):
+    if isinstance(something, list):
         return list(
-            _nested_dict_to_dict(v, src_class=src_class, dst_class=dst_class)
-            for v in d
+            _nested_dict_to_dict(value, src_class=src_class, dst_class=dst_class)
+            for value in something
         )
     # Clone everything unexpected
-    return deepcopy(d)
+    return deepcopy(something)
 
 
-def dict_to_objdict(d):
+def dict_to_objdict(something):
     """Recursively convert any dictionary (subclass of dict) to ObjDict."""
-    return _nested_dict_to_dict(d, src_class=dict, dst_class=ObjDict)
+    return _nested_dict_to_dict(something, src_class=dict, dst_class=ObjDict)
 
 
-def objdict_to_dict(d):
+def objdict_to_dict(something):
     """Recursively convert any ObjDict to python dictionary."""
-    return _nested_dict_to_dict(d, src_class=dict, dst_class=dict)  # ObjDict is a subclass of dict
+    return _nested_dict_to_dict(something, src_class=dict, dst_class=dict)  # ObjDict is a subclass of dict
 
 
 def merge_objdict(to_merge, extend_by):

--- a/core/src/epicli/tests/helpers/test_objdict_helpers.py
+++ b/core/src/epicli/tests/helpers/test_objdict_helpers.py
@@ -4,7 +4,7 @@ from cli.helpers.ObjDict import ObjDict
 from collections import OrderedDict
 
 
-def test_dict_to_objdict_simple():
+def test_dict_to_objdict():
     base = {
         'field1': {
             'field2': {
@@ -24,7 +24,7 @@ def test_dict_to_objdict_simple():
     assert converted.field1.field2.field3.field4 == 'val'
 
 
-def test_dict_to_objdict_mixed():
+def test_dict_to_objdict_different_dict_types():
     base = {
         'field1': ObjDict({
             'field2': {
@@ -44,7 +44,7 @@ def test_dict_to_objdict_mixed():
     assert converted.field1.field2.field3.field4 == 'val'
 
 
-def test_dict_to_objdict_simple_nested_with_lists():
+def test_dict_to_objdict_nested_with_lists():
     base = {
         'field1': [
             {

--- a/core/src/epicli/tests/helpers/test_objdict_helpers.py
+++ b/core/src/epicli/tests/helpers/test_objdict_helpers.py
@@ -1,8 +1,10 @@
 from cli.helpers.objdict_helpers import merge_objdict, dict_to_objdict, objdict_to_dict
 from cli.helpers.ObjDict import ObjDict
 
+from collections import OrderedDict
 
-def test_dict_to_objdict():
+
+def test_dict_to_objdict_simple():
     base = {
         'field1': {
             'field2': {
@@ -20,6 +22,52 @@ def test_dict_to_objdict():
     assert type(converted.field1.field2.field3) is ObjDict
     assert type(converted.field1.field2.field3.field4) is str
     assert converted.field1.field2.field3.field4 == 'val'
+
+
+def test_dict_to_objdict_mixed():
+    base = {
+        'field1': ObjDict({
+            'field2': {
+                'field3': OrderedDict({
+                    'field4': 'val'
+                })
+            }
+        })
+    }
+    converted = dict_to_objdict(base)
+
+    assert type(converted) is ObjDict
+    assert type(converted.field1) is ObjDict
+    assert type(converted.field1.field2) is ObjDict
+    assert type(converted.field1.field2.field3) is ObjDict
+    assert type(converted.field1.field2.field3.field4) is str
+    assert converted.field1.field2.field3.field4 == 'val'
+
+
+def test_dict_to_objdict_simple_nested_with_lists():
+    base = {
+        'field1': [
+            {
+                'field2': {
+                    'field3': [
+                        {
+                            'field4': 'val'
+                        },
+                    ]
+                }
+            },
+        ]
+    }
+    converted = dict_to_objdict(base)
+
+    assert type(converted) is ObjDict
+    assert type(converted.field1) is list
+    assert type(converted.field1[0]) is ObjDict
+    assert type(converted.field1[0].field2) is ObjDict
+    assert type(converted.field1[0].field2.field3) is list
+    assert type(converted.field1[0].field2.field3[0]) is ObjDict
+    assert type(converted.field1[0].field2.field3[0].field4) is str
+    assert converted.field1[0].field2.field3[0].field4 == 'val'
 
 
 def test_objdict_to_dict():


### PR DESCRIPTION
Addressing

> 1. When dictionary is defined inside a list, then it's not properly converted to internal dictionary
> implementation ObjDict.

from #1294.