### PR TITLE
Certificate bundle enhancement for VSCode devcontainer (#1314)

### DIFF
--- a/core/src/epicli/.devcontainer/Dockerfile
+++ b/core/src/epicli/.devcontainer/Dockerfile
@@ -7,6 +7,7 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
 COPY cert/cert.md cert/*.crt /usr/local/share/ca-certificates/
+COPY cert/*.pem /
 COPY cert/config-pre.sh /
 COPY cert/config-post.sh /
 COPY requirements.txt /

--- a/core/src/epicli/.devcontainer/Dockerfile
+++ b/core/src/epicli/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
 COPY cert/cert.md cert/*.crt /usr/local/share/ca-certificates/
-COPY cert/*.pem /
+COPY cert/cert.md cert/*.pem /
 COPY cert/config-pre.sh /
 COPY cert/config-post.sh /
 COPY requirements.txt /

--- a/core/src/epicli/.devcontainer/cert/cert.md
+++ b/core/src/epicli/.devcontainer/cert/cert.md
@@ -1,4 +1,6 @@
-# Custom CA certificate
+# Custom CA certificate/bundle
 
-In this folder you can place a CA certificate which will be installed in the devcontainer. 
-It can have any name but it needs to have the crt extension.
+Note that for the comments below the filenames of the certificate(s)/bundle do not matter, only the extensions. The certificate(s)/bundle need to be placed here before building the devcontainer.
+
+1. If you have one CA certificate you can add it here with the ```crt``` extension.
+2. If you have multiple certificates in a chain/bundle you need to add them here individually with the ```crt``` extension and also add the single bundle with the ```pem``` extension containing the same certificates. This is needed unfortunally because not all tools inside the container except the single bundle.

--- a/core/src/epicli/.devcontainer/cert/config-post.sh
+++ b/core/src/epicli/.devcontainer/cert/config-post.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
 if ls /usr/local/share/ca-certificates/*.crt 1> /dev/null 2>&1; then
-  echo "Setup cert for Ansible, AWS..."
-  pattern="/usr/local/share/ca-certificates/*.crt"
-  files=( $pattern )
-  f="${files[0]}"
   mkdir "/home/vscode/.aws/"
+  if ls /*.pem 1> /dev/null 2>&1; then
+    pattern="/*.pem"
+    files=( $pattern )
+    f="${files[0]}"
+    echo "Setup AWS ca-bundle $f"
+    echo -e "[default]\nca_bundle=$f" >> "/home/vscode/.aws/config"
+  else 
+    pattern="/usr/local/share/ca-certificates/*.crt"
+    files=( $pattern )
+    f="${files[0]}"
+    echo "Setup AWS cert $f"
+    echo -e "[default]\nca_bundle=$f" >> "/home/vscode/.aws/config"
+  fi
+  echo "Setup Ansible SSH timeout settings"
   echo -e "[defaults]\ntimeout=0" >> "/home/vscode/.ansible.cfg"
-  echo -e "[default]\nca_bundle=$f" >> "/home/vscode/.aws/config"
 else
-     echo "No cert to setup"
+  echo "No cert/ca-bundle to setup"
 fi
 

--- a/core/src/epicli/.devcontainer/cert/config-post.sh
+++ b/core/src/epicli/.devcontainer/cert/config-post.sh
@@ -14,8 +14,6 @@ if ls /usr/local/share/ca-certificates/*.crt 1> /dev/null 2>&1; then
     echo "Setup AWS cert $f"
     echo -e "[default]\nca_bundle=$f" >> "/home/vscode/.aws/config"
   fi
-  echo "Setup Ansible SSH timeout settings"
-  echo -e "[defaults]\ntimeout=0" >> "/home/vscode/.ansible.cfg"
 else
   echo "No cert/ca-bundle to setup"
 fi

--- a/core/src/epicli/.devcontainer/cert/config-pre.sh
+++ b/core/src/epicli/.devcontainer/cert/config-pre.sh
@@ -1,16 +1,28 @@
 #!/bin/bash
 
 if ls /usr/local/share/ca-certificates/*.crt 1> /dev/null 2>&1; then
-  echo "Setup cert for System, PIP..."
   pattern="/usr/local/share/ca-certificates/*.crt"
   files=( $pattern )
-  f="${files[0]}"
-  echo "Processing cert $f"
-  chmod 644 $f
-  pip config set global.cert $f
-  pip config list
+  for i in "${files[@]}"
+  do
+    chmod 644 $i
+  done
+  if ls /*.pem 1> /dev/null 2>&1; then
+    pattern="/*.pem"
+    files=( $pattern )
+    f="${files[0]}"
+    echo "Setting PIP ca-bundle $f"
+    chmod 644 $f
+    pip config set global.cert $f
+    pip config list
+  else 
+    f="${files[0]}"
+    echo "Setting PIP cert $f"
+    pip config set global.cert $f
+    pip config list
+  fi
   update-ca-certificates
 else
-     echo "No cert to setup"
+  echo "No cert/ca-bundle to setup"
 fi
 

--- a/core/src/epicli/cli/engine/ansible/AnsibleCommand.py
+++ b/core/src/epicli/cli/engine/ansible/AnsibleCommand.py
@@ -28,6 +28,9 @@ class AnsibleCommand:
 
         cmd.append(hosts)
 
+        if Config().debug > 0:
+            cmd.append(ansible_verbosity[Config().debug])
+
         self.logger.info('Running: "' + ' '.join(module) + '"')
 
         logpipe = LogPipe(__name__)

--- a/core/src/epicli/cli/engine/providers/azure/APIProxy.py
+++ b/core/src/epicli/cli/engine/providers/azure/APIProxy.py
@@ -34,7 +34,7 @@ class APIProxy:
         name = sp_data['name']
         password = sp_data['password']
         tenant = sp_data['tenant']
-        return self.run(self, f'az login --service-principal -u \'{name}\' -p \'{password}\' --tenant \'{tenant}\'', False)      
+        return self.run(self, f'az login --service-principal -u \'{name}\' -p "{password}" --tenant \'{tenant}\'', False)      
 
     def set_active_subscribtion(self, subscription_id):
         self.run(self, f'az account set --subscription {subscription_id}')  

--- a/docs/home/howto/PREREQUISITES.md
+++ b/docs/home/howto/PREREQUISITES.md
@@ -60,45 +60,6 @@ docker run -it -v LOCAL_DIR:/shared --rm epiphanyplatform/epicli:TAG
 
 Where `LOCAL_DIR` should be replaced with the local path to the directory for Epicli input (SSH keys, data yamls) and output (logs, build states).
 
-## Run Epicli directly from OS
-
-*Note: Epicli will only run on Lixux or MacOS and not on Windows. This is because Ansible at this point in time does not work on Windows.*
-
-*Note: You might want to consider installing Epicli in a virtual python enviroment. More information can be found [here](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/).*
-
-1. To be able to run the Epicli from your local OS you have to install:
-
-    - Python 3.7
-    - PIP
-
-2. Install the following Python dependencies (in your virtual environment) using PIP:
-
-    ```bash
-    pip install wheel setuptools twine
-    ```
-
-3. Open a terminal in `/core/src/epicli` and run the following to build the Epicli wheel:
-
-    ```bash
-    ./build-wheel.sh
-    ```
-
-4. Install the Epicli wheel:
-
-    ```bash
-    pip install dist/epicli-VERSION-py3-none-any.whl
-    ```
-
-5. Verify the Epicli installation:
-
-    ```bash
-    epicli --version
-    ```
-
-    This should return the version of the CLI deployed.
-
-Now you can use Epicli directly on your machine.
-
 ## Epicli development
 
 For setting up en Epicli development environment please refer to this dedicated document [here.](./../DEVELOPMENT.md)
@@ -141,7 +102,7 @@ Use: [Checkout as-is, commit Unix-style](https://stackoverflow.com/questions/104
 
 To run Epicli from behind a proxy, enviroment variables need to be set.
 
-When running directly from OS or from a development container (upper and lowercase are needed because of an issue with the Ansible dependency):
+When running a development container (upper and lowercase are needed because of an issue with the Ansible dependency):
 
   ```bash
   export http_proxy="http://PROXY_SERVER:PORT"
@@ -156,10 +117,6 @@ Or when running from a Docker image (upper and lowercase are needed because of a
   docker run -it -v POSSIBLE_MOUNTS... -e HTTP_PROXY=http://PROXY_SERVER:PORT -e HTTPS_PROXY=http://PROXY_SERVER:PORT http_proxy=http://PROXY_SERVER:PORT -e https_proxy=http://PROXY_SERVER:PORT --rm IMAGE_NAME
   ```
 
-### Note about custom CA certificates
-
-In some cases it might be that a company uses custom CA certificates for providing secure connections. To use these with Epicli you can do the following:
-
 ### Note about PostgreSQL preflight check
 
 This reffers only to CentOS/Red Hat installations.
@@ -168,23 +125,25 @@ To prevent installation failure of PostgreSQL 10 server we are checking in prefl
 installation has been installed from PostgreSQL official repository. If this has been installed from Software Collections
 this will make Epiphany deployment fail in preflight mode. For more details please refer to [How to migrate from PostgreSQL installed from Software Collections to installed from PostgreSQL repository](./DATABASES.md#how-to-migrate-from-postgresql-installed-from-software-collections-to-installed-from-postgresql-repository)
 
+### Note about custom CA certificates
+
+In some cases it might be that a company uses custom CA certificates or CA bundles for providing secure connections. To use these with Epicli you can do the following:
 
 #### Devcontainer
 
-Before building the VSCode devcontainer place the *.crt file here: `/epiphany/core/src/epicli/.devcontainer/cert/`. Then the certificate will be included and configured during the build process. After that no additional configuration should be needed.
+Note that for the comments below the filenames of the certificate(s)/bundle do not matter, only the extensions. The certificate(s)/bundle need to be placed here before building the devcontainer.
 
-#### MacOS
+1. If you have one CA certificate you can add it here with the ```crt``` extension.
+2. If you have multiple certificates in a chain/bundle you need to add them here individually with the ```crt``` extension and also add the single bundle with the ```pem``` extension containing the same certificates. This is needed unfortunally because not all tools inside the container accept the single bundle.
 
-Install the certiciate in your keychain as described [here](https://www.sslsupportdesk.com/how-to-import-a-certificate-into-mac-os/).
+#### Epicli release container
 
-#### Epicli container or Debian based OS
-
-If you are running Epicli from one of the prebuild containers or a Debian based OS directly you can do the following to install the certificate:
+If you are running Epicli from one of the prebuild release containers you can do the following to install the certificate(s):
 
   ```bash
-  cp ./path/to/cert.crt /usr/local/share/ca-certificates/
-  chmod 644 /usr/local/share/ca-certificates/cert.crt
+  cp ./path/to/*.crt /usr/local/share/ca-certificates/
+  chmod 644 /usr/local/share/ca-certificates/*.crt
   update-ca-certificates
   ```
 
-*Note: Configuring the CA cert on the prebuild container only works on the `Debian` based ones and NOT on `Alpine` based.*
+If you plan to deploy on AWS you also need to add a seperate configuration for ```Boto3``` which can either be done by a ```config``` file or setting the ```AWS_CA_BUNDLE``` environment variable. More information about for ```Boto3``` can be found [here.](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html)


### PR DESCRIPTION
- Added support for multiple crt certs for /usr/local/share/ca-certificates/
- Added the ability to configure the full CA bundles for PIP and Boto3
- Minor fix for Azure API proxy for SP login where PW contains ' character causing an string escape error
- Added debug flag when running Ansible task
- Updated documentation