### PR TITLE
Updating cloud based OS images

### DIFF
--- a/CHANGELOG-0.7.md
+++ b/CHANGELOG-0.7.md
@@ -13,6 +13,7 @@
 - Update Calico and Canal to v3.13.2
 - [#1180](https://github.com/epiphany-platform/epiphany/issues/1180) - Update list of ports used by Epiphany components
 - [#1310](https://github.com/epiphany-platform/epiphany/issues/1310) - Updated Azure-cli from 2.0.67 to 2.6.0
+- [#1330](https://github.com/epiphany-platform/epiphany/issues/1330) - Update cloud based OS images
 
 ### Fixed
 

--- a/core/src/epicli/data/aws/defaults/infrastructure/virtual-machine.yml
+++ b/core/src/epicli/data/aws/defaults/infrastructure/virtual-machine.yml
@@ -14,7 +14,7 @@ specification:
   tags:
     - version: 0.4.2
   size: t2.micro
-  os_full_name: "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190212.1"
+  os_full_name: "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200611"
   os_type: linux
   ebs_optimized: false
   disks:

--- a/core/src/epicli/data/azure/defaults/infrastructure/virtual-machine.yml
+++ b/core/src/epicli/data/azure/defaults/infrastructure/virtual-machine.yml
@@ -15,7 +15,7 @@ specification:
     publisher: Canonical
     offer: UbuntuServer
     sku: 18.04-LTS
-    version: "18.04.201810030" # Never put latest on anything! Need to always pin the version number but testing we can get away with it
+    version: "18.04.202006101" # Never put latest on anything! Need to always pin the version number but testing we can get away with it
   storage_os_disk:
     delete_on_termination: false
     managed: false


### PR DESCRIPTION
Original issue: [Update cloud based OS images #1330](https://github.com/epiphany-platform/epiphany/issues/1330)

Spike required: [Updating cloud based OS images - configuration required for Azure RHEL LVM images #1355](https://github.com/epiphany-platform/epiphany/issues/1355)