### PR TITLE
Change SET_BY_AUTOMATION -> autoconfigured for configurable settings

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/applications/templates/pgpool/configmaps.yml.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/applications/templates/pgpool/configmaps.yml.j2
@@ -7,7 +7,7 @@ metadata:
     app: pgpool
   namespace: {{ data.namespace }}
 data:
-{% if data.pgpool.env.PGPOOL_BACKEND_NODES is undefined or data.pgpool.env.PGPOOL_BACKEND_NODES == 'SET_BY_AUTOMATION' %}
+{% if data.pgpool.env.PGPOOL_BACKEND_NODES is undefined or data.pgpool.env.PGPOOL_BACKEND_NODES|lower == 'autoconfigured' %}
   PGPOOL_BACKEND_NODES: "{% for node in groups['postgresql'] %}{{ loop.index0 }}:{{ hostvars[groups['postgresql'][loop.index0]].ansible_hostname }}:5432{% if not loop.last %},{% endif %}{% endfor %}"
 {% else %}
   PGPOOL_BACKEND_NODES: "{{ data.pgpool.env.PGPOOL_BACKEND_NODES }}"
@@ -259,7 +259,7 @@ data:
 
     # - Backend Connection Settings -
 
-{% if data.pgpool.env.PGPOOL_BACKEND_NODES is undefined or data.pgpool.env.PGPOOL_BACKEND_NODES == 'SET_BY_AUTOMATION' %}
+{% if data.pgpool.env.PGPOOL_BACKEND_NODES is undefined or data.pgpool.env.PGPOOL_BACKEND_NODES|lower == 'autoconfigured' %}
 {%   for node in groups['postgresql'] %}
     backend_hostname{{ loop.index0 }} = '{{ hostvars[groups['postgresql'][loop.index0]].ansible_hostname }}'
                                       # Host name or IP address to connect to for backend {{ loop.index0 }}
@@ -829,7 +829,7 @@ data:
     # TYPE   DATABASE        USER{% for n in range(data.pgpool.env.PGPOOL_SR_CHECK_USER|length) %}{{" "}}{% endfor %}ADDRESS             METHOD
     host     all             {{ data.pgpool.env.PGPOOL_SR_CHECK_USER }}    127.0.0.1/32        trust
 
-{% if data.pgpool.pool_hba_conf is defined and data.pgpool.pool_hba_conf and data.pgpool.pool_hba_conf != 'SET_BY_AUTOMATION' %}
+{% if data.pgpool.pool_hba_conf is defined and data.pgpool.pool_hba_conf and data.pgpool.pool_hba_conf|lower != 'autoconfigured' %}
     # Records from Epiphany configuration
     {{ data.pgpool.pool_hba_conf | indent(4) }}
 {% else %}

--- a/core/src/epicli/data/common/ansible/playbooks/roles/postgresql/templates/postgresql-epiphany.conf.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/postgresql/templates/postgresql-epiphany.conf.j2
@@ -22,7 +22,7 @@
                                                      and specification.extensions[parameter.when].enabled) %}
 {#         use of 'parameter_value' is workaround since we don't have Jinja's {% do %} statement enabled (required to update dictionaries) #}
 {%         set parameter_value = parameter.value %}
-{%         if parameter.name == 'shared_preload_libraries' and parameter.value == 'SET_BY_AUTOMATION' %}
+{%         if parameter.name == 'shared_preload_libraries' and parameter.value|lower == 'autoconfigured' %}
 {%           set shared_preload_libraries = [] %}
 {#           shared_preload_libraries from runtime, including those that were set outside Epiphany managed config #}
 {%           if runtime_shared_preload_libraries is defined and runtime_shared_preload_libraries %}

--- a/core/src/epicli/data/common/defaults/configuration/applications.yml
+++ b/core/src/epicli/data/common/defaults/configuration/applications.yml
@@ -109,7 +109,7 @@ specification:
     pgpool:
       # https://github.com/bitnami/bitnami-docker-pgpool#configuration + https://github.com/bitnami/bitnami-docker-pgpool#environment-variables
       env:
-        PGPOOL_BACKEND_NODES: SET_BY_AUTOMATION # you can use custom value like '0:pg-node-1:5432,1:pg-node-2:5432'
+        PGPOOL_BACKEND_NODES: autoconfigured # you can use custom value like '0:pg-node-1:5432,1:pg-node-2:5432'
         # Postgres users
         PGPOOL_POSTGRES_USERNAME: epi_pgpool_postgres_admin # with SUPERUSER role to use connection slots reserved for superusers for K8s liveness probes, also for user synchronization
         PGPOOL_SR_CHECK_USER: epi_pgpool_sr_check # with pg_monitor role, for streaming replication checks and health checks
@@ -133,7 +133,7 @@ specification:
         connection_life_time = 900
         reserved_connections = 1
       # https://www.pgpool.net/docs/41/en/html/auth-pool-hba-conf.html
-      pool_hba_conf: SET_BY_AUTOMATION
+      pool_hba_conf: autoconfigured
 
 ## --- pgbouncer ---
 

--- a/core/src/epicli/data/common/defaults/configuration/postgresql.yml
+++ b/core/src/epicli/data/common/defaults/configuration/postgresql.yml
@@ -21,7 +21,7 @@ specification:
           - name: Kernel Resource Usage
             parameters:
               - name: shared_preload_libraries
-                value: SET_BY_AUTOMATION
+                value: AUTOCONFIGURED
                 comment: set by automation
       - name: ERROR REPORTING AND LOGGING
         subgroups:

--- a/docs/home/howto/DATABASES.md
+++ b/docs/home/howto/DATABASES.md
@@ -306,7 +306,7 @@ specification:
     pgpool:
       # https://github.com/bitnami/bitnami-docker-pgpool#configuration + https://github.com/bitnami/bitnami-docker-pgpool#environment-variables
       env:
-        PGPOOL_BACKEND_NODES: SET_BY_AUTOMATION # you can use custom value like '0:pg-node-1:5432,1:pg-node-2:5432'
+        PGPOOL_BACKEND_NODES: autoconfigured # you can use custom value like '0:pg-node-1:5432,1:pg-node-2:5432'
         # Postgres users
         PGPOOL_POSTGRES_USERNAME: epi_pgpool_postgres_admin # with SUPERUSER role to use connection slots reserved for superusers for K8s liveness probes, also for user synchronization
         PGPOOL_SR_CHECK_USER: epi_pgpool_sr_check # with pg_monitor role, for streaming replication checks and health checks
@@ -330,7 +330,7 @@ specification:
         connection_life_time = 600
         reserved_connections = 1
       # https://www.pgpool.net/docs/41/en/html/auth-pool-hba-conf.html
-      pool_hba_conf: SET_BY_AUTOMATION
+      pool_hba_conf: autoconfigured
 
 ## --- pgbouncer ---
 


### PR DESCRIPTION
The `SET_BY_AUTOMATION` value is a keyword reserved for `epicli`. It's used for settings that are meant to be set only automatically and cannot be used for other purposes.