### PR TITLE
Add docker_version variable support

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/docker/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/docker/defaults/main.yml
@@ -4,4 +4,6 @@ docker_logging:
     max_file_size: 10m # The maximum size of the log before it is rolled. A positive integer plus a modifier representing the unit of measure (k, m, or g)
     max_files: 2       # The maximum number of log files that can be present
 
-docker_version: "18.09.*"
+docker_version: 
+  Debian: "5:18.09.*"
+  RedHat: "18.09.*"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/docker/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/docker/defaults/main.yml
@@ -4,4 +4,8 @@ docker_logging:
     max_file_size: 10m # The maximum size of the log before it is rolled. A positive integer plus a modifier representing the unit of measure (k, m, or g)
     max_files: 2       # The maximum number of log files that can be present
 
-docker_version: 18.09.6
+docker_version: "5:18.09.*"
+docker_cli_version: "5:18.09.*"
+
+docker_version_rh: "3:18.09.*"
+docker_cli_version_rh: "1:19.03.*"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/docker/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/docker/defaults/main.yml
@@ -4,8 +4,4 @@ docker_logging:
     max_file_size: 10m # The maximum size of the log before it is rolled. A positive integer plus a modifier representing the unit of measure (k, m, or g)
     max_files: 2       # The maximum number of log files that can be present
 
-docker_version: "5:18.09.*"
-docker_cli_version: "5:18.09.*"
-
-docker_version_rh: "3:18.09.*"
-docker_cli_version_rh: "1:19.03.*"
+docker_version: "18.09.*"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/docker/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/docker/tasks/main.yml
@@ -1,25 +1,20 @@
 ---
 # Docker (used by master & worker as dependency)
 
-- name: Install Docker for Debian family
+- name:  Install docker packages
   package:
-    name: "{{ item }}"
+    name: "{{ packages[ansible_os_family] }}"
     state: present
-  loop:
-    - apt-transport-https
-    - ca-certificates
-    - containerd.io
-    - docker-ce-cli={{ docker_cli_version }}
-    - docker-ce={{ docker_version }}
-  when: ansible_os_family == "Debian"
-
-- name: Install Docker for RedHat family
-  package:
-    name: "{{ item }}"
-    state: present
-  loop:
-      - docker-ce-cli-{{ docker_cli_version_rh }}
-      - docker-ce-{{ docker_version_rh }}
-  when: ansible_os_family == "RedHat"
+  vars:
+    packages:
+      RedHat:
+      - docker-ce-cli-{{ docker_version }}
+      - docker-ce-{{ docker_version }}
+      Debian:
+      - apt-transport-https
+      - ca-certificates
+      - containerd.io
+      - docker-ce-cli=5:{{ docker_version }}
+      - docker-ce=5:{{ docker_version }}
 
 - include_tasks: configure-docker.yml

--- a/core/src/epicli/data/common/ansible/playbooks/roles/docker/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/docker/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Docker (used by master & worker as dependency)
 
-- name: Install docker packages
+- name: Install Docker packages
   package:
     name: "{{ packages[ansible_os_family] }}"
     state: present

--- a/core/src/epicli/data/common/ansible/playbooks/roles/docker/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/docker/tasks/main.yml
@@ -8,13 +8,13 @@
   vars:
     packages:
       RedHat:
-      - docker-ce-cli-{{ docker_version }}
-      - docker-ce-{{ docker_version }}
+      - docker-ce-cli-{{ docker_version.RedHat }}
+      - docker-ce-{{ docker_version.RedHat }}
       Debian:
       - apt-transport-https
       - ca-certificates
       - containerd.io
-      - docker-ce-cli=5:{{ docker_version }}
-      - docker-ce=5:{{ docker_version }}
+      - docker-ce-cli={{ docker_version.Debian }}
+      - docker-ce={{ docker_version.Debian }}
 
 - include_tasks: configure-docker.yml

--- a/core/src/epicli/data/common/ansible/playbooks/roles/docker/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/docker/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Docker (used by master & worker as dependency)
 
-- name:  Install docker packages
+- name: Install docker packages
   package:
     name: "{{ packages[ansible_os_family] }}"
     state: present

--- a/core/src/epicli/data/common/ansible/playbooks/roles/docker/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/docker/tasks/main.yml
@@ -11,8 +11,6 @@
       - docker-ce-cli-{{ docker_version.RedHat }}
       - docker-ce-{{ docker_version.RedHat }}
       Debian:
-      - apt-transport-https
-      - ca-certificates
       - containerd.io
       - docker-ce-cli={{ docker_version.Debian }}
       - docker-ce={{ docker_version.Debian }}

--- a/core/src/epicli/data/common/ansible/playbooks/roles/docker/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/docker/tasks/main.yml
@@ -9,8 +9,8 @@
     - apt-transport-https
     - ca-certificates
     - containerd.io
-    - docker-ce-cli=5:18.09.*
-    - docker-ce=5:18.09.*
+    - docker-ce-cli={{ docker_cli_version }}
+    - docker-ce={{ docker_version }}
   when: ansible_os_family == "Debian"
 
 - name: Install Docker for RedHat family
@@ -18,8 +18,8 @@
     name: "{{ item }}"
     state: present
   loop:
-      - docker-ce-cli-18.09.*
-      - docker-ce-18.09.*
+      - docker-ce-cli-{{ docker_cli_version_rh }}
+      - docker-ce-{{ docker_version_rh }}
   when: ansible_os_family == "RedHat"
 
 - include_tasks: configure-docker.yml


### PR DESCRIPTION
Tested in AWS on Ubuntu, RedHat and deployment works properly.
Docker version for RedHat adjusted as per version available in our repo.
QUESTION: Should I test it on Azure and on Baremetal also in both version Ubuntu/Redhat?