### PR TITLE
make-download-requirements-more-stable

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/download-requirements.sh
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/download-requirements.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
 
 if [[ $# -lt 1 ]]; then
   usage

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/download-requirements.sh
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/download-requirements.sh
@@ -147,7 +147,17 @@ else
     printf "\n"
     # download images using skopeo
     while IFS= read -r image_name; do
-        download_image "${image_name}" "${dst_dir_images}"
+        let "trycount=0"
+        while [ $trycount -lt 5 ]; do
+            let "trycount=$trycount + 1"
+            download_image "${image_name}" "${dst_dir_images}"
+            if [ $? == 0 ]; then
+                break
+            else
+                echo "skopeo download failed. Retry in 5 secs for 5 times"
+                sleep 5
+            fi
+        done
     done <<< "${images}"
 fi
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/download-requirements.sh
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/download-requirements.sh
@@ -147,17 +147,11 @@ else
     printf "\n"
     # download images using skopeo
     while IFS= read -r image_name; do
-        let "trycount=0"
-        while [ $trycount -lt 5 ]; do
-            let "trycount=$trycount + 1"
+        download_image "${image_name}" "${dst_dir_images}"
+        if [ $? != 0 ]; then
+            echo "Skopeo download error, retrying..."
             download_image "${image_name}" "${dst_dir_images}"
-            if [ $? == 0 ]; then
-                break
-            else
-                echo "skopeo download failed. Retry in 5 secs for 5 times"
-                sleep 5
-            fi
-        done
+        fi
     done <<< "${images}"
 fi
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/tasks/setup.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/tasks/setup.yml
@@ -39,9 +39,6 @@
         dest: /tmp/epi-download-requirements/download-requirements.sh
         mode: a+x
 
-    - name: Download Epiphany requirements
-      include_tasks: download-requirements.yml
-
   when:
     - not offline_mode
     - not custom_repository_url
@@ -71,6 +68,15 @@
     force: no # if target exists it will skip, default is 'yes'
   when:
     - offline_mode
+    - not custom_repository_url
+    - inventory_hostname in target_repository_hostnames
+
+# Put it down here as the script download-requirements.sh relies on some files
+# in the folder /tmp/epi-repository-setup-scripts that until now it should be available
+- name: Download Epiphany requirements
+  include_tasks: download-requirements.yml
+  when:
+    - not offline_mode
     - not custom_repository_url
     - inventory_hostname in target_repository_hostnames
 


### PR DESCRIPTION
- Change the order of executing the task download-requirements.yml after we populate the directory /tmp/epi-repository-setup-scripts.

I have hit a situation (many times when re-run from the current system) that this role failed because the script
core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/download-requirements.sh

this part

```
repos_backup_file="/tmp/epi-repository-setup-scripts/enable-system-repos.sh"
if [[ ! -f /etc/apt/sources.list ]]; then
    if [[ -f /var/tmp/enabled-system-repos.tar ]] && [[ -f ${repos_backup_file} ]]; then
        echol "OS repositories seems missing, restoring..."
        ${repos_backup_file}
    else
        echol "/etc/apt/sources.list seems missing, you either know what you're doing or you need to fix your repositories"
    fi
fi

```

It comes to the the part `/etc/apt/sources.list seems missing, you either know what you're doing or you need to fix your repositories`

As you can see this relies on the /tmp/epi-repository-setup-scripts/enable-system-repos.sh.

- Set DEBIAN_FRONTEND=noninteractive for download-requirements.sh

A similar PR has been addressed this issues but in different place and because
that run before this stage the problem is hidden because these dependencies
packages are already install (libssl). However if you re-run it on existing
system it might happen again. Or in some combination situation it happened
again.

IMHO there is no side effect of adding this change to be sure we are not
prompted by apt for whatever reason.