### PR TITLE
Fixs for changing Terraform templates between Epicli apply runs

### DIFF
--- a/CHANGELOG-0.8.md
+++ b/CHANGELOG-0.8.md
@@ -9,3 +9,5 @@
 - [#846](https://github.com/epiphany-platform/epiphany/issues/846) - Update Filebeat to v7.8.1
 
 ### Fixed
+
+- Fix for changing Terraform templates between Epicli apply runs on Azure.

--- a/core/src/epicli/cli/engine/providers/azure/InfrastructureBuilder.py
+++ b/core/src/epicli/cli/engine/providers/azure/InfrastructureBuilder.py
@@ -174,10 +174,6 @@ class InfrastructureBuilder(Step):
         vm.specification.network_interface_name = network_interface_name
         vm.specification.tags.append({'cluster': cluster_tag(self.cluster_prefix, self.cluster_name)})
         vm.specification.tags.append({component_key: ''})        
-        if vm.specification.os_type == 'linux':
-            # For linux we dont need a PW since we only support SSH. We add something random for Terraform 
-            # to run and later disable password access in Ansible.
-            vm.specification.admin_password = str(uuid.uuid4())
         if vm_config.specification.os_type == 'windows':
             raise NotImplementedError('Windows VMs not supported jet.')
         pub_key_path = self.cluster_model.specification.admin_user.key_path + '.pub'

--- a/core/src/epicli/data/azure/terraform/infrastructure/virtual-machine.j2
+++ b/core/src/epicli/data/azure/terraform/infrastructure/virtual-machine.j2
@@ -27,7 +27,9 @@ resource "azurerm_virtual_machine" "{{ specification.name  }}" {
   os_profile {
     computer_name  = "{{ specification.name }}"
     admin_username = "{{ specification.admin_username }}"
+    {%- if specification.os_type == "windows" %}
     admin_password = "{{ specification.admin_password }}"
+    {%- endif %}
   }  
 
   {%- if specification.os_type == "linux" %}


### PR DESCRIPTION
Small fix done while researching #1570. It does not fix this issue but it does make sure the Terraform templates do not change in subsequent Epicli apply runs with unchanged config yaml

 In this case the generation of a VM password on linux was removed as it is not needed by Terraform or used by Epiphany since we use SSH.

https://www.terraform.io/docs/providers/azurerm/r/virtual_machine.html#admin_password