### PR TITLE
Modified apiserver certificate SAN update process 

### DIFF
--- a/CHANGELOG-0.8.md
+++ b/CHANGELOG-0.8.md
@@ -11,3 +11,4 @@
 ### Fixed
 
 - Fix for changing Terraform templates between Epicli apply runs on Azure.
+- [#1520](https://github.com/epiphany-platform/epiphany/issues/1520) - Added additional SANs to k8s-apiserver certificates to run kubectl outside the cluster

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/main.yml
@@ -41,7 +41,7 @@
         update:
           apiServer:
             certSANs: >-
-              {{ groups['kubernetes_master'] | map('extract', hostvars, ['ansible_host']) | list
+              {{ groups['kubernetes_master'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list
               + [ 'localhost', '127.0.0.1' ] }}
       include_role:
         name: kubernetes_common

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/templates/kubeadm-config.yml.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/templates/kubeadm-config.yml.j2
@@ -13,7 +13,7 @@ apiServer:
     - localhost
     - 127.0.0.1
 {% for host in groups['kubernetes_master'] %}
-    - {{ hostvars[host]['ansible_host'] }}
+    - {{ hostvars[host]['ansible_default_ipv4']['address'] }}
 {% endfor %}
   extraArgs: # https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
 {% if specification.advanced.etcd_args.encrypted | bool %}


### PR DESCRIPTION
As discussed with @przemyslavic and @sk4zuzu, only private IPs have to be used to access k8s cluster. This fix is related to #1520.