### PR TITLE
Use pki config from manifest for apiserver certificates

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/apiserver-certificates.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/apiserver-certificates.yml
@@ -1,25 +1,25 @@
 ---
-- name: Copy /etc/kubernetes/pki/apiserver.{crt,key}
+- name: Copy apiserver.{crt,key}
   copy:
     dest: "{{ item }}.OLD"
     src: "{{ item }}"
     remote_src: true
   loop:
-    - /etc/kubernetes/pki/apiserver.crt
-    - /etc/kubernetes/pki/apiserver.key
+    - "{{ specification.advanced.certificates.location }}/apiserver.crt"
+    - "{{ specification.advanced.certificates.location }}/apiserver.key"
 
-- name: Delete /etc/kubernetes/pki/apiserver.{crt,key}
+- name: Delete apiserver.{crt,key}
   file:
     path: "{{ item }}"
     state: absent
   loop:
-    - /etc/kubernetes/pki/apiserver.crt
-    - /etc/kubernetes/pki/apiserver.key
+    - "{{ specification.advanced.certificates.location }}/apiserver.crt"
+    - "{{ specification.advanced.certificates.location }}/apiserver.key"
 
-- name: Render new certificates /etc/kubernetes/pki/apiserver.{crt,key}
+- name: Render new certificates apiserver.{crt,key}
   shell: |
     kubeadm init phase certs apiserver \
       --config /etc/kubeadm/kubeadm-config.yml
   args:
     executable: /bin/bash
-    creates: /etc/kubernetes/pki/apiserver.key
+    creates: "{{ specification.advanced.certificates.location }}/apiserver.key"


### PR DESCRIPTION
These changes are related to #1556, but as I knew about this configuration parameter only during #1595 implementation, PR is created now.