### PR TITLE
Create kubeconfig file for Epiphany container

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
@@ -17,6 +17,23 @@
       become: false
       include_vars:
         file: "{{ vault_location }}/kubernetes-secrets.yml"
+ 
+    - name: Create kubeconfig file for local usages
+      delegate_to: localhost
+      become: false
+      template:
+        src: kubeconfig.j2
+        dest: "{{ vault_location }}/../admin.conf"
+        mode: u=rw,go=r
+
+    - name: Replace private IP with public IP
+      delegate_to: localhost
+      replace:
+        path: "{{ vault_location }}/../admin.conf"
+        after: '://'
+        before: ':6443'
+        regexp: '^(.+)$'
+        replace: "localhost"
 
     # Please notice this task file can be executed from other playbooks,
     # hence the fallback "default(groups.kubernetes_master.0)" must be defined.

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
@@ -9,7 +9,7 @@
     get_mime: false
   register: stat_kubernetes_secrets_yml
 
-- name: Set kubeconfig to server
+- name: Create kubeconfig
   when: stat_kubernetes_secrets_yml.stat.exists
   become: false
   block:
@@ -22,11 +22,10 @@
       delegate_to: localhost
       template:
         src: kubeconfig.j2
-        dest: "{{ vault_location }}/../admin.conf"
+        dest: "{{ inventory_dir }}/admin.conf"
         mode: u=rw,g=,o=
       vars:
-        api_server_url: https://127.0.0.1:6443
-
+        api_server_as_localhost: true
 
     # Please notice this task file can be executed from other playbooks,
     # hence the fallback "default(groups.kubernetes_master.0)" must be defined.
@@ -37,10 +36,8 @@
             path: "/home/{{ admin_user.name }}/.kube/"
             state: directory
 
-        - name: Create kubeconfig file
+        - name: Create kubeconfig file for server
           template:
             src: kubeconfig.j2
             dest: "/home/{{ admin_user.name }}/.kube/config"
             mode: u=rw,g=,o=
-          vars:
-            api_server_url: "{{ secret.clusters[0].api_url }}"           

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
@@ -11,24 +11,24 @@
 
 - name: Set kubeconfig to server
   when: stat_kubernetes_secrets_yml.stat.exists
+  become: false
   block:
     - name: Include vars of Kubernetes secrets
       delegate_to: localhost
-      become: false
       include_vars:
         file: "{{ vault_location }}/kubernetes-secrets.yml"
  
     - name: Create kubeconfig file for local usages
       delegate_to: localhost
-      become: false
       template:
         src: kubeconfig.j2
         dest: "{{ vault_location }}/../admin.conf"
-        mode: u=rw,go=r
+        mode: u=rw,g=r
+      vars:
+        api_server_url: https://127.0.0.1:6443
 
     - name: Replace IP address with localhost for tunnel usage
       delegate_to: localhost
-      become: false
       replace:
         path: "{{ vault_location }}/../admin.conf"
         after: '://'
@@ -50,3 +50,6 @@
             src: kubeconfig.j2
             dest: "/home/{{ admin_user.name }}/.kube/config"
             mode: u=rw,go=r
+          vars:
+            api_server_url: "{{ cluster.api_url }}"
+            

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
@@ -22,7 +22,7 @@
       delegate_to: localhost
       template:
         src: kubeconfig.j2
-        dest: "{{ inventory_dir }}/admin.conf"
+        dest: "{{ inventory_dir }}/kubeconfig"
         mode: u=rw,g=,o=
       vars:
         api_server_as_localhost: true

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
@@ -18,12 +18,12 @@
       include_vars:
         file: "{{ vault_location }}/kubernetes-secrets.yml"
  
-    - name: Create kubeconfig file for local usages
+    - name: Create kubeconfig file for localhost
       delegate_to: localhost
       template:
         src: kubeconfig.j2
         dest: "{{ vault_location }}/../admin.conf"
-        mode: u=rw,g=r
+        mode: u=rw,g=,o=
       vars:
         api_server_url: https://127.0.0.1:6443
 
@@ -41,7 +41,6 @@
           template:
             src: kubeconfig.j2
             dest: "/home/{{ admin_user.name }}/.kube/config"
-            mode: u=rw,go=r
+            mode: u=rw,g=,o=
           vars:
-            api_server_url: "{{ secret.clusters[0].api_url }}"
-            
+            api_server_url: "{{ secret.clusters[0].api_url }}"           

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
@@ -27,14 +27,6 @@
       vars:
         api_server_url: https://127.0.0.1:6443
 
-    - name: Replace IP address with localhost for tunnel usage
-      delegate_to: localhost
-      replace:
-        path: "{{ vault_location }}/../admin.conf"
-        after: '://'
-        before: ':6443'
-        regexp: '^(.+)$'
-        replace: "localhost"
 
     # Please notice this task file can be executed from other playbooks,
     # hence the fallback "default(groups.kubernetes_master.0)" must be defined.
@@ -51,5 +43,5 @@
             dest: "/home/{{ admin_user.name }}/.kube/config"
             mode: u=rw,go=r
           vars:
-            api_server_url: "{{ cluster.api_url }}"
+            api_server_url: "{{ secret.clusters[0].api_url }}"
             

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
@@ -26,7 +26,7 @@
         dest: "{{ vault_location }}/../admin.conf"
         mode: u=rw,go=r
 
-    - name: Replace private IP with public IP
+    - name: Replace IP address with localhost for tunnel usage
       delegate_to: localhost
       replace:
         path: "{{ vault_location }}/../admin.conf"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
@@ -28,6 +28,7 @@
 
     - name: Replace IP address with localhost for tunnel usage
       delegate_to: localhost
+      become: false
       replace:
         path: "{{ vault_location }}/../admin.conf"
         after: '://'

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/main.yml
@@ -48,7 +48,7 @@
         update:
           apiServer:
             certSANs: >-
-              {{ groups['kubernetes_master'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list
+              {{ (groups['kubernetes_master'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list ) + (groups['kubernetes_master'] | map('extract', hostvars, ['ansible_host']) | list ) | unique
               + [ 'localhost', '127.0.0.1' ] }}
       include_role:
         name: kubernetes_common

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/main.yml
@@ -48,8 +48,9 @@
         update:
           apiServer:
             certSANs: >-
-              {{ (groups['kubernetes_master'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list ) + (groups['kubernetes_master'] | map('extract', hostvars, ['ansible_host']) | list ) | unique
-              + [ 'localhost', '127.0.0.1' ] }}
+              {{ (groups['kubernetes_master'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list ) 
+              + (groups['kubernetes_master'] | map('extract', hostvars, ['ansible_host']) | list ) 
+              + [ 'localhost', '127.0.0.1' ] | unique }}
       include_role:
         name: kubernetes_common
         tasks_from: extend-kubeadm-config

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/main.yml
@@ -48,8 +48,8 @@
         update:
           apiServer:
             certSANs: >-
-              {{ (groups['kubernetes_master'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list ) 
-              + (groups['kubernetes_master'] | map('extract', hostvars, ['ansible_host']) | list ) 
+              {{ (groups['kubernetes_master'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list) 
+              + (groups['kubernetes_master'] | map('extract', hostvars, ['ansible_host']) | list) 
               + [ 'localhost', '127.0.0.1' ] | unique }}
       include_role:
         name: kubernetes_common

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/remove-kubeconfig.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/remove-kubeconfig.yml
@@ -11,7 +11,7 @@
 - delegate_to: localhost
   become: false
   block:
-    - name: Clean kubeconfig
+    - name: Clean local kubeconfig
       file:
-        path: "{{ vault_location }}/../admin.conf"
+        path: "{{ inventory_dir }}/admin.conf"
         state: absent

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/remove-kubeconfig.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/remove-kubeconfig.yml
@@ -13,5 +13,5 @@
   block:
     - name: Clean local kubeconfig
       file:
-        path: "{{ inventory_dir }}/admin.conf"
+        path: "{{ inventory_dir }}/kubeconfig"
         state: absent

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/remove-kubeconfig.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/remove-kubeconfig.yml
@@ -7,3 +7,11 @@
       file:
         path: "/home/{{ admin_user.name }}/.kube/config"
         state: absent
+
+- delegate_to: localhost
+  become: false
+  block:
+    - name: Clean kubeconfig
+      file:
+        path: "{{ vault_location }}/../admin.conf"
+        state: absent

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/templates/kubeadm-config.yml.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/templates/kubeadm-config.yml.j2
@@ -10,10 +10,12 @@ controlPlaneEndpoint: "localhost:3446"
 apiServer:
   timeoutForControlPlane: 4m0s
   certSANs:
-    - localhost
-    - 127.0.0.1
+{% set ip_address_list = ['127.0.0.1', 'localhost'] %}
 {% for host in groups['kubernetes_master'] %}
-    - {{ hostvars[host]['ansible_default_ipv4']['address'] }}
+{%   set x = ip_address_list.extend([ hostvars[host]['ansible_default_ipv4']['address'], hostvars[host]['ansible_host'] ]) %}
+{% endfor %}
+{% for ip in ip_address_list|unique %}
+    - {{ ip }}
 {% endfor %}
   extraArgs: # https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
 {% if specification.advanced.etcd_args.encrypted | bool %}

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/templates/kubeadm-config.yml.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/templates/kubeadm-config.yml.j2
@@ -12,7 +12,7 @@ apiServer:
   certSANs:
 {% set ip_address_list = ['127.0.0.1', 'localhost'] %}
 {% for host in groups['kubernetes_master'] %}
-{%   set x = ip_address_list.extend([ hostvars[host]['ansible_default_ipv4']['address'], hostvars[host]['ansible_host'] ]) %}
+{%   set _ = ip_address_list.extend([ hostvars[host]['ansible_default_ipv4']['address'], hostvars[host]['ansible_host'] ]) %}
 {% endfor %}
 {% for ip in ip_address_list|unique %}
     - {{ ip }}

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/templates/kubeconfig.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/templates/kubeconfig.j2
@@ -10,7 +10,7 @@ clusters:
 {% for cluster in secret.clusters %}
 - cluster:
     certificate-authority-data: {{ cluster.ca_data }}
-    server: {{ cluster.api_url }}
+    server: {{ api_server_url }}
   name: {{ cluster.name }}
 {% endfor %}
 contexts:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/templates/kubeconfig.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/templates/kubeconfig.j2
@@ -8,6 +8,12 @@ users:
 {% endfor %}
 clusters:
 {% for cluster in secret.clusters %}
+{%   if api_server_as_localhost is defined and api_server_as_localhost is sameas true %}
+{#     localhost is used for SSH tunnel #}
+{%     set api_server_url = cluster.api_url | regex_replace('://(?P<host>.+):(?P<port>\\d+)$', '://127.0.0.1:\\g<port>') %}
+{%   else %}
+{%     set api_server_url = cluster.api_url %}
+{% endif %}
 - cluster:
     certificate-authority-data: {{ cluster.ca_data }}
     server: {{ api_server_url }}


### PR DESCRIPTION
- Kubeconfig file added for local kubectl and IP in kubeconfig changed to localhost for tunnel usage.
- Public IP added to SAN in order to avoid using insecure flag

Related to task #1615 