### PR TITLE
kubernetes_master: making api urls customizable in local kubeconfig

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
@@ -34,7 +34,7 @@
             dest: "{{ inventory_dir }}/kubeconfig"
             mode: u=rw,g=,o=
           vars:
-            # Update server api urls inside kubernetes secrets (in memory)
+            # Update api server urls inside kubernetes_secrets (in memory)
             secret: >-
               {{ kubernetes_secrets.secret | combine({"clusters": _updated_clusters}, recursive=true) }}
             # Use values from specification to update api server urls.
@@ -73,5 +73,5 @@
             dest: "/home/{{ admin_user.name }}/.kube/config"
             mode: u=rw,g=,o=
           vars:
-            # Use unmodified kubernetes secrets
+            # Use unmodified kubernetes_secrets
             secret: "{{ kubernetes_secrets.secret }}"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
@@ -2,6 +2,7 @@
 - name: Check if kubernetes-secrets.yml file exists
   delegate_to: localhost
   become: false
+  run_once: true
   stat:
     path: "{{ vault_location }}/kubernetes-secrets.yml"
     get_attributes: false
@@ -11,22 +12,49 @@
 
 - name: Create kubeconfig files
   when: stat_kubernetes_secrets_yml.stat.exists
+  always:
+    - name: Remove kubernetes secrets from facts
+      set_fact:
+        kubernetes_secrets: null
   block:
     - name: Create local kubeconfig file
       delegate_to: localhost
       become: false
       block:
         - name: Load vars from kubernetes-secrets.yml file
+          run_once: true
           include_vars:
             file: "{{ vault_location }}/kubernetes-secrets.yml"
+            name: kubernetes_secrets
 
         - name: Create local kubeconfig file
+          run_once: true
           template:
             src: kubeconfig.j2
             dest: "{{ inventory_dir }}/kubeconfig"
             mode: u=rw,g=,o=
           vars:
-            api_server_as_localhost: true
+            # Update server api urls inside kubernetes secrets (in memory)
+            secret: >-
+              {{ kubernetes_secrets.secret | combine({"clusters": _updated_clusters}, recursive=true) }}
+            # Use values from specification to update api server urls.
+            # If those values are undefined or "falsy" then nothing gets replaced.
+            _updated_clusters: >-
+              {%- set output = [] -%}
+              {%- for cluster in kubernetes_secrets.secret.clusters -%}
+                {%- set url = cluster.api_url | urlsplit -%}
+                {{-
+                  output.append(cluster | combine({
+                    "api_url": "%s://%s:%d%s" | format(
+                      url.scheme,
+                      specification.advanced.kubeconfig.local.api_server.hostname | default(url.hostname, true),
+                      specification.advanced.kubeconfig.local.api_server.port | default(url.port, true),
+                      url.path,
+                    ),
+                  }, recursive=true))
+                -}}
+              {%- endfor -%}
+              {{- output -}}
 
     # Please notice this task file can be executed from other playbooks,
     # hence the fallback "default(groups.kubernetes_master.0)" must be defined.
@@ -44,3 +72,6 @@
             src: kubeconfig.j2
             dest: "/home/{{ admin_user.name }}/.kube/config"
             mode: u=rw,g=,o=
+          vars:
+            # Use unmodified kubernetes secrets
+            secret: "{{ kubernetes_secrets.secret }}"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/templates/kubeconfig.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/templates/kubeconfig.j2
@@ -8,15 +8,9 @@ users:
 {% endfor %}
 clusters:
 {% for cluster in secret.clusters %}
-{%   if api_server_as_localhost is defined and api_server_as_localhost is sameas true %}
-{#     localhost is used for SSH tunnel #}
-{%     set api_server_url = cluster.api_url | regex_replace('://(?P<host>.+):(?P<port>\\d+)$', '://127.0.0.1:\\g<port>') %}
-{%   else %}
-{%     set api_server_url = cluster.api_url %}
-{% endif %}
 - cluster:
     certificate-authority-data: {{ cluster.ca_data }}
-    server: {{ api_server_url }}
+    server: {{ cluster.api_url }}
   name: {{ cluster.name }}
 {% endfor %}
 contexts:

--- a/core/src/epicli/data/common/defaults/configuration/kubernetes-master.yml
+++ b/core/src/epicli/data/common/defaults/configuration/kubernetes-master.yml
@@ -34,7 +34,13 @@ specification:
       renew: false
     etcd_args:
       encrypted: yes
-
+    kubeconfig:
+      local:
+        api_server:
+          # uncomment if you want a custom hostname (you can use jinja2/ansible expressions here, for example "{{ groups.kubernetes_master[0] }}")
+          hostname: 127.0.0.1
+          # uncomment if you want a custom port
+          # port: 3446
 #  image_registry_secrets:
 #  - email: emaul@domain.com
 #    name: secretname

--- a/core/src/epicli/data/common/defaults/configuration/kubernetes-master.yml
+++ b/core/src/epicli/data/common/defaults/configuration/kubernetes-master.yml
@@ -37,7 +37,7 @@ specification:
     kubeconfig:
       local:
         api_server:
-          # uncomment if you want a custom hostname (you can use jinja2/ansible expressions here, for example "{{ groups.kubernetes_master[0] }}")
+          # change if you want a custom hostname (you can use jinja2/ansible expressions here, for example "{{ groups.kubernetes_master[0] }}")
           hostname: 127.0.0.1
           # uncomment if you want a custom port
           # port: 3446


### PR DESCRIPTION
Basically, removing the hardcoded `api_server_as_localhost: true` flag 👍😇 The real problem manifested itself when HA mode was used. So there were 2 options "localhost" or "127.0.0.1" depending on the value of the flag. :)