### PR TITLE
SSH tunnel: Support for relative paths in admin_user.key_path

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 k8s_api_server:
+  autossh_log_file_path: /tmp/autossh-k8s-api-server-tunnel.log
   autossh_pid_file_path: /tmp/autossh-k8s-api-server-tunnel.pid

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/setup.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/setup.yml
@@ -4,17 +4,29 @@
   include_tasks: teardown.yml
 
 - name: Start SSH tunnel to K8s master
-  shell: >-
-    autossh -M 0 -f
-    {{ admin_user.name }}@{{ k8s_master_ip }} -L {{ k8s_api_server_port }}:localhost:{{ k8s_api_server_port }}
-    -i {{ admin_user.key_path }} -4 -N
-    -o ServerAliveInterval=30 -o ServerAliveCountMax=5 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-  environment:
-    AUTOSSH_PIDFILE: "{{ k8s_api_server.autossh_pid_file_path }}"
+  block:
+    - name: Start SSH tunnel to K8s master
+      shell: >-
+        autossh -M 0 -f
+        {{ admin_user.name }}@{{ k8s_master_ip }} -L {{ k8s_api_server_port }}:localhost:{{ k8s_api_server_port }}
+        -i $(readlink -f {{ admin_user.key_path }}) -4 -N -T
+        -o BatchMode=yes -o ControlMaster=no -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=5
+        -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+      args:
+        chdir: "{{ lookup('env', 'PWD') }}" # chdir + readlink is to support relative path in admin_user.key_path
+      register: shell_autossh
+      environment: "{{ autossh_env }}"
 
-- name: Assert port {{ k8s_api_server_port }} is open
-  wait_for:
-    port: "{{ k8s_api_server_port }}"
-    state: started
-    timeout: 20
-    msg: Timeout waiting for port {{ k8s_api_server_port }} to respond
+    - name: Assert port {{ k8s_api_server_port }} is open
+      wait_for:
+        port: "{{ k8s_api_server_port }}"
+        state: started
+        timeout: 15
+        msg: |-
+          Timeout waiting for port {{ k8s_api_server_port }} to respond.
+          Command used to start the tunnel: '{{ shell_autossh.cmd }}'
+          Environment: {{ autossh_env }}
+  vars:
+    autossh_env:
+      AUTOSSH_LOGFILE: "{{ k8s_api_server.autossh_log_file_path }}"
+      AUTOSSH_PIDFILE: "{{ k8s_api_server.autossh_pid_file_path }}"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/setup.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/setup.yml
@@ -9,11 +9,11 @@
       shell: >-
         autossh -M 0 -f
         {{ admin_user.name }}@{{ k8s_master_ip }} -L {{ k8s_api_server_port }}:localhost:{{ k8s_api_server_port }}
-        -i $(readlink -f {{ admin_user.key_path }}) -4 -N -T
+        -i $(realpath -s {{ admin_user.key_path }}) -4 -N -T
         -o BatchMode=yes -o ControlMaster=no -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=5
         -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
       args:
-        chdir: "{{ lookup('env', 'PWD') }}" # chdir + readlink is to support relative path in admin_user.key_path
+        chdir: "{{ lookup('env', 'PWD') }}" # chdir + realpath to support relative path in admin_user.key_path
       register: shell_autossh
       environment: "{{ autossh_env }}"
 
@@ -24,8 +24,8 @@
         timeout: 15
         msg: |-
           Timeout waiting for port {{ k8s_api_server_port }} to respond.
-          Command used to start the tunnel: '{{ shell_autossh.cmd }}'
-          Environment: {{ autossh_env }}
+          Command used to start the tunnel: '{{ shell_autossh.cmd }}'.
+          Environment: {{ autossh_env.items() | map('join', '=') | list }}
   vars:
     autossh_env:
       AUTOSSH_LOGFILE: "{{ k8s_api_server.autossh_log_file_path }}"


### PR DESCRIPTION
1) Adds support for relative paths in `admin_user.key_path`, for example:
```
specification:
  admin_user:
    key_path: clusters/ssh/id_rsa
```
2) Adds SSH options:
- -T
- -o BatchMode=yes -o ControlMaster=no -o ExitOnForwardFailure=yes
3) Prints `autossh` command when port assertion fails. 