### PR TITLE
Local kubectl for prometheus and kubectl usage refactoring

### DIFF
--- a/CHANGELOG-0.8.md
+++ b/CHANGELOG-0.8.md
@@ -20,6 +20,7 @@
 - [#1316](https://github.com/epiphany-platform/epiphany/issues/1316) - Upgrade HAProxy to v2.2
 - [#1115](https://github.com/epiphany-platform/epiphany/issues/1115) - Upgrade Node exporter to v1.0.1
 - [#1589](https://github.com/epiphany-platform/epiphany/issues/1589) - Update OS_PATCHING.md with information about patching Ubuntu OS
+- [#1639](https://github.com/epiphany-platform/epiphany/issues/1639) - Use local kubectl in 'prometheus' role
 
 ### Fixed
 

--- a/core/src/epicli/data/common/ansible/playbooks/backup_kubernetes.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/backup_kubernetes.yml
@@ -11,3 +11,5 @@
         - import_role:
             name: backup
             tasks_from: kubernetes
+  environment:
+    KUBECONFIG: "{{ kubeconfig.remote }}"

--- a/core/src/epicli/data/common/ansible/playbooks/group_vars/all.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/group_vars/all.yml
@@ -1,5 +1,10 @@
+---
 local_repository_url: "http://{{ hostvars[groups['repository'][0]]['ansible_default_ipv4']['address'] }}/epirepo"
 repository_url: "{{ custom_repository_url | default(local_repository_url, true) }}"
 
 local_image_registry: "{{ groups['image_registry'] | first }}:5000"
 image_registry_address: "{{ local_image_registry }}" # TODO support custom_image_registry_address with user defined repo
+
+kubeconfig:
+  local: "{{ inventory_dir }}/kubeconfig"
+  remote: /etc/kubernetes/admin.conf

--- a/core/src/epicli/data/common/ansible/playbooks/kubernetes_master.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/kubernetes_master.yml
@@ -16,6 +16,8 @@
     - import_role:
         name: kubernetes_master
         tasks_from: copy-kubeconfig
+  environment:
+    KUBECONFIG: "{{ kubeconfig.remote }}"
 
 - hosts: kubernetes_master
   serial: 1
@@ -30,6 +32,8 @@
     - import_role:
         name: kubernetes_promote
         tasks_from: update-kubelet
+  environment:
+    KUBECONFIG: "{{ kubeconfig.remote }}"
 
 - hosts: kubernetes_master
   become: true

--- a/core/src/epicli/data/common/ansible/playbooks/kubernetes_node.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/kubernetes_node.yml
@@ -16,6 +16,8 @@
     - import_role:
         name: kubernetes_master
         tasks_from: copy-kubeconfig
+  environment:
+    KUBECONFIG: "{{ kubeconfig.remote }}"
 
 - hosts: kubernetes_node
   become: true

--- a/core/src/epicli/data/common/ansible/playbooks/preflight.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/preflight.yml
@@ -1,3 +1,4 @@
+---
 # Ansible playbook that checks if requirements are met
 
 - hosts: all
@@ -6,3 +7,5 @@
   become_method: sudo
   roles:
     - preflight
+  environment:
+    KUBECONFIG: "{{ kubeconfig.remote }}"

--- a/core/src/epicli/data/common/ansible/playbooks/prometheus.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/prometheus.yml
@@ -4,7 +4,7 @@
 - hosts: all
   gather_facts: yes
   tasks: [ ]  
-  
+
 - hosts: prometheus
   become: true
   become_method: sudo

--- a/core/src/epicli/data/common/ansible/playbooks/roles/backup/tasks/kubernetes.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/backup/tasks/kubernetes.yml
@@ -26,15 +26,13 @@
 
   block:
     - name: Get etcd image name
-      shell: |
+      command: |
         kubectl get pods \
           --all-namespaces \
           --output jsonpath={{ jsonpath }}
       vars:
         jsonpath: >-
           "{.items[*].spec.containers[?(@.name=='etcd')].image}"
-      environment:
-        KUBECONFIG: /etc/kubernetes/admin.conf
       register: etcd_image_name
 
     - name: Save etcd image name to a file

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_common/tasks/extend-kubeadm-config.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_common/tasks/extend-kubeadm-config.yml
@@ -1,16 +1,18 @@
 ---
+- name: Assert that update variable is defined
+  assert:
+    that:
+      - update is defined
+    fail_msg: Variable 'update' must be defined.
+
 - name: Collect kubeadm-config
-  shell: |
+  command: |
     kubectl get configmap kubeadm-config \
       --namespace kube-system \
       --output jsonpath={{ jsonpath }}
   vars:
     jsonpath: >-
       '{.data.ClusterConfiguration}'
-  environment:
-    KUBECONFIG: /etc/kubernetes/admin.conf
-  args:
-    executable: /bin/bash
   register: kubeadm_config
   changed_when: false
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_common/tasks/gather-facts.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_common/tasks/gather-facts.yml
@@ -4,7 +4,7 @@
 
 - name: Check if kubeconfig file exists
   stat:
-    path: "{{ lookup('env','KUBECONFIG') }}"
+    path: "{{ ansible_env.KUBECONFIG }}"
     get_attributes: false
     get_checksum: false
     get_mime: false

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_common/tasks/gather-facts.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_common/tasks/gather-facts.yml
@@ -2,18 +2,18 @@
 # Due to inventory generation procedure not being deterministic in general (order of hostnames in group.kubernetes_master may change at any run),
 # we have to make sure some common master node is selected uniformly and later used in "delegate_to" statements (aka "automation_designated_master").
 
-- name: Check if /etc/kubernetes/admin.conf file exists
+- name: Check if kubeconfig file exists
   stat:
-    path: /etc/kubernetes/admin.conf
+    path: "{{ lookup('env','KUBECONFIG') }}"
     get_attributes: false
     get_checksum: false
     get_mime: false
-  register: stat_admin_conf
+  register: stat_kubeconfig
 
-- when: stat_admin_conf.stat.exists
+- when: stat_kubeconfig.stat.exists
   block:
     - name: Get list of all master nodes
-      shell: |
+      command: |
         kubectl get nodes \
           --selector={{ selector }} \
           --output=jsonpath={{ jsonpath }}
@@ -22,10 +22,6 @@
           'node-role.kubernetes.io/master'
         jsonpath: >-
           '{range .items[*]}{.metadata.name}{"\n"}{end}'
-      environment:
-        KUBECONFIG: /etc/kubernetes/admin.conf
-      args:
-        executable: /bin/bash
       register: kubectl_get_master_nodes
       changed_when: false
 
@@ -36,7 +32,7 @@
   vars:
     set_fact:
       master_already_joined: >-
-        {{ stat_admin_conf.stat.exists and (kubectl_get_master_nodes.stdout_lines is defined)
+        {{ stat_kubeconfig.stat.exists and (kubectl_get_master_nodes.stdout_lines is defined)
                                        and (inventory_hostname in kubectl_get_master_nodes.stdout_lines) }}
 
 - name: Collect registered masters

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/any/kubernetes-storage.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/any/kubernetes-storage.yml
@@ -1,1 +1,2 @@
+---
 # Placeholder for storage tasks for 'any' provider

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/aws/kubernetes-storage.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/aws/kubernetes-storage.yml
@@ -19,19 +19,13 @@
 
 - when: kubernetes_common.automation_designated_master == inventory_hostname
   become_user: "{{ admin_user.name }}"
-  environment:
-    KUBECONFIG: "/home/{{ admin_user.name }}/.kube/config"
   block:
     - name: Apply storage yml
-      shell: |
+      command: |
         kubectl apply \
           -f /home/{{ admin_user.name }}/k8s-persistent-volume.yml
-      args:
-        executable: /bin/bash
 
     - name: Apply storage claim yml
-      shell: |
+      command: |
         kubectl apply \
           -f /home/{{ admin_user.name }}/k8s-persistent-volume-claim.yml
-      args:
-        executable: /bin/bash

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/aws/kubernetes-storage.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/aws/kubernetes-storage.yml
@@ -18,7 +18,6 @@
     mode: u=rw,go=r
 
 - when: kubernetes_common.automation_designated_master == inventory_hostname
-  become_user: "{{ admin_user.name }}"
   block:
     - name: Apply storage yml
       command: |

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/azure/kubernetes-storage.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/azure/kubernetes-storage.yml
@@ -27,7 +27,6 @@
     mode: u=rw,go=r
 
 - when: kubernetes_common.automation_designated_master == inventory_hostname
-  become_user: "{{ admin_user.name }}"
   block:
     - name: Apply secret yml
       command: |

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/azure/kubernetes-storage.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/azure/kubernetes-storage.yml
@@ -28,26 +28,18 @@
 
 - when: kubernetes_common.automation_designated_master == inventory_hostname
   become_user: "{{ admin_user.name }}"
-  environment:
-    KUBECONFIG: "/home/{{ admin_user.name }}/.kube/config"
   block:
     - name: Apply secret yml
-      shell: |
+      command: |
         kubectl apply \
           -f /home/{{ admin_user.name }}/k8s-storage-secret.yml
-      args:
-        executable: /bin/bash
 
     - name: Apply storage yml
-      shell: |
+      command: |
         kubectl apply \
           -f /home/{{ admin_user.name }}/k8s-persistent-volume.yml
-      args:
-        executable: /bin/bash
 
     - name: Apply storage claim yml
-      shell: |
+      command: |
         kubectl apply \
           -f /home/{{ admin_user.name }}/k8s-persistent-volume-claim.yml
-      args:
-        executable: /bin/bash

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/cni-plugins/wait-for-cni-plugin.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/cni-plugins/wait-for-cni-plugin.yml
@@ -6,8 +6,6 @@
     kubectl wait --for=condition=Ready pods -l {{ selector }}
     --field-selector=spec.nodeName={{ ansible_fqdn }} -n kube-system --timeout=10s
   changed_when: false
-  environment:
-    KUBECONFIG: /etc/kubernetes/admin.conf
   register: wait_for_cni_plugin
   until: wait_for_cni_plugin is succeeded
   retries: 30

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/copy-kubeconfig.yml
@@ -31,7 +31,7 @@
           run_once: true
           template:
             src: kubeconfig.j2
-            dest: "{{ inventory_dir }}/kubeconfig"
+            dest: "{{ kubeconfig.local }}"
             mode: u=rw,g=,o=
           vars:
             # Update api server urls inside kubernetes_secrets (in memory)

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/deployments/deploy-file.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/deployments/deploy-file.yml
@@ -1,5 +1,7 @@
 ---
-- name: Create directory for files
+# This file is meant to be also used by upgrade role
+
+- name: Ensure that directory for files exists
   become: true
   file:
     path: "{{ epiphany_manifests_dir }}"
@@ -25,5 +27,3 @@
       command: kubectl apply -f {{ dest_path }}
       register: kubectl_apply
       changed_when: kubectl_apply.stdout_lines | map('regex_replace', '^.+ ') | reject('eq', 'unchanged') | list
-      environment:
-        KUBECONFIG: /etc/kubernetes/admin.conf

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/deployments/deploy-template.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/deployments/deploy-template.yml
@@ -1,7 +1,7 @@
 ---
 # This file is meant to be also used by upgrade role
 
-- name: Create directory for files
+- name: Ensure that directory for files exists
   become: true
   file:
     path: "{{ epiphany_manifests_dir }}"
@@ -27,5 +27,3 @@
       command: kubectl apply -f {{ dest_path }}
       register: kubectl_apply
       changed_when: kubectl_apply.stdout_lines | map('regex_replace', '^.+ ') | reject('eq', 'unchanged') | list
-      environment:
-        KUBECONFIG: /etc/kubernetes/admin.conf

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/generate-certificates.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/generate-certificates.yml
@@ -143,19 +143,15 @@
             | list }}
 
     - name: Update conf files with embedded certs
-      environment:
-        KUBECONFIG: "/etc/kubernetes/{{ item }}"
       vars:
         conf_account_mapping:
           admin.conf: "kubernetes-admin"
           scheduler.conf: "system:kube-scheduler"
           controller-manager.conf: "system:kube-controller-manager"
-      shell: |
+      command: |
         kubectl config set-credentials {{ conf_account_mapping[item] }} \
         --client-key {{ specification.advanced.certificates.location }}/{{ item }}.key \
         --client-certificate {{ specification.advanced.certificates.location }}/{{ item }}.crt --embed-certs
-      args:
-        executable: /bin/bash
       with_items: "{{ conf_certificates }}"
 
     - name: Remove conf certificates
@@ -179,10 +175,8 @@
           with_items: "{{ restart_services }}"
 
         - name: Wait until cluster is available
-          environment:
-            KUBECONFIG: /etc/kubernetes/admin.conf
-          shell: kubectl cluster-info
+          command: kubectl cluster-info
           retries: 50
           delay: 1
-          register: output
-          until: output is succeeded
+          register: result
+          until: result is succeeded and "running" in result.stdout

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/generate-certificates.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/generate-certificates.yml
@@ -143,6 +143,8 @@
             | list }}
 
     - name: Update conf files with embedded certs
+      environment:
+        KUBECONFIG: "/etc/kubernetes/{{ item }}"
       vars:
         conf_account_mapping:
           admin.conf: "kubernetes-admin"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/generate-cluster-credentials.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/generate-cluster-credentials.yml
@@ -7,14 +7,10 @@
       - reader
 
 - name: Get tokens from the server
-  environment:
-    KUBECONFIG: "/home/{{ admin_user.name }}/.kube/config"
   shell: |-
     kubectl get secret/$(kubectl get sa {{ item }} --namespace kube-system --output jsonpath='{.secrets[0].name}') \
       --namespace kube-system \
       --output jsonpath='{.data.token}'
-  args:
-    executable: /bin/bash
   register: token_results
   loop: "{{ users }}"
   no_log: true
@@ -24,10 +20,8 @@
   become: false
   environment:
     ANSIBLE_VAULT_PASSWORD_FILE: "{{ vault_tmp_file_location }}"
-  shell: |
+  command: |
     ansible-vault encrypt_string "{{ item.stdout }}"
-  args:
-    executable: /bin/bash
   register: tokens_encrypted
   loop: "{{ token_results.results }}"
   no_log: true
@@ -41,14 +35,10 @@
   no_log: true
 
 - name: Get kubeconfig settings
-  environment:
-    KUBECONFIG: "/home/{{ admin_user.name }}/.kube/config"
-  shell: |
+  command: |
     kubectl config view \
       --flatten \
       --minify
-  args:
-    executable: /bin/bash
   register: config_result
   no_log: true
 
@@ -62,10 +52,8 @@
   become: false
   environment:
     ANSIBLE_VAULT_PASSWORD_FILE: "{{ vault_tmp_file_location }}"
-  shell: |
+  command: |
     ansible-vault encrypt_string "{{ item.cluster['certificate-authority-data'] }}"
-  args:
-    executable: /bin/bash
   register: clusters_ca_data
   loop: "{{ kubeconfig_settings.clusters }}"
   no_log: true

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/master-untaint.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/master-untaint.yml
@@ -5,15 +5,11 @@
       'node-role.kubernetes.io/master'
     jsonpath: >-
       '{range .items[*]}{.metadata.name}{":"}{.spec.taints[?(@.effect == "NoSchedule")].effect}{"\n"}{end}'
-  environment:
-    KUBECONFIG: "/etc/kubernetes/admin.conf"
   shell: |
     kubectl get nodes \
       --selector={{ selector }} \
       --output=jsonpath={{ jsonpath }} \
     | grep :NoSchedule
-  args:
-    executable: /bin/bash
   register: tainted_masters_list
   failed_when: tainted_masters_list.rc == 2
   changed_when: false
@@ -27,12 +23,8 @@
       {{ (tainted_masters_list.stdout_lines | length > 0) and (nodeless or specification.allow_pods_on_master) }}
 
 - name: Untaint all tainted masters
-  environment:
-    KUBECONFIG: "/etc/kubernetes/admin.conf"
-  shell: |
+  command: |
     kubectl taint node {{ item }} node-role.kubernetes.io/master:NoSchedule-
-  args:
-    executable: /bin/bash
   loop: >-
     {{ tainted_masters_list.stdout_lines
     | map('regex_replace', '^([^:][^:]*):.*$', '\1')

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/network-policies.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/network-policies.yml
@@ -3,13 +3,9 @@
   vars:
     jsonpath: >-
       '{.items[?(@.metadata.name == "default-network-policy")].metadata.name}'
-  environment:
-    KUBECONFIG: "/home/{{ admin_user.name }}/.kube/config"
-  shell: |
+  command: |
     kubectl get networkpolicies \
       --output jsonpath={{ jsonpath }}
-  args:
-    executable: /bin/bash
   register: kubectl_result
   failed_when: kubectl_result.rc != 0
   changed_when: false

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/registry-secrets.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/registry-secrets.yml
@@ -1,8 +1,5 @@
 ---
 - name: Apply docker-registry secrets
-  become_user: "{{ admin_user.name }}"
-  environment:
-    KUBECONFIG: "/home/{{ admin_user.name }}/.kube/config"
   shell: |
     kubectl create secret docker-registry '{{ item.name }}' \
       --docker-server '{{ item.server_url }}' \
@@ -13,8 +10,6 @@
       --dry-run \
       -o yaml \
     | kubectl apply -f-
-  args:
-    executable: /bin/bash
   loop: "{{ specification.image_registry_secrets }}"
   when:
     - specification.image_registry_secrets is defined

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/utils/get-deployment-images.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/utils/get-deployment-images.yml
@@ -13,8 +13,6 @@
     --no-headers=true
   register: kubectl_get_images
   changed_when: false
-  environment:
-    KUBECONFIG: /etc/kubernetes/admin.conf
 
 - name: Set list of images as fact
   set_fact:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/utils/patch-object.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/utils/patch-object.yml
@@ -16,5 +16,3 @@
     --patch '{{ patch.content }}'
   register: kubectl_patch
   changed_when: not 'no change' in kubectl_patch.stdout
-  environment:
-    KUBECONFIG: /etc/kubernetes/admin.conf

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_promote/tasks/gather-facts.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_promote/tasks/gather-facts.yml
@@ -2,17 +2,13 @@
 - delegate_to: "{{ kubernetes_common.automation_designated_master }}"
   block:
     - name: Collect live kubeadm ClusterConfiguration object if available
-      shell: |
+      command: |
         kubectl get configmap kubeadm-config \
           --namespace=kube-system \
           --output=jsonpath={{ jsonpath }}
       vars:
         jsonpath: >-
           '{.data.ClusterConfiguration}'
-      environment:
-        KUBECONFIG: /etc/kubernetes/admin.conf
-      args:
-        executable: /bin/bash
       register: ClusterConfiguration
       changed_when: false
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_promote/tasks/update-master.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_promote/tasks/update-master.yml
@@ -47,10 +47,6 @@
           -f-
       vars:
         server: https://localhost:3446
-      environment:
-        KUBECONFIG: /etc/kubernetes/admin.conf
-      args:
-        executable: /bin/bash
 
     - name: Get cluster-info config map
       shell: |
@@ -63,7 +59,3 @@
           -f-
       vars:
         server: https://localhost:3446
-      environment:
-        KUBECONFIG: /etc/kubernetes/admin.conf
-      args:
-        executable: /bin/bash

--- a/core/src/epicli/data/common/ansible/playbooks/roles/preflight_facts/tasks/kubernetes.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/preflight_facts/tasks/kubernetes.yml
@@ -8,7 +8,7 @@
   block:
     - name: Check if kubeconfig file exists
       stat:
-        path: "{{ lookup('env','KUBECONFIG') }}"
+        path: "{{ ansible_env.KUBECONFIG }}"
         get_attributes: false
         get_checksum: false
         get_mime: false

--- a/core/src/epicli/data/common/ansible/playbooks/roles/preflight_facts/tasks/kubernetes.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/preflight_facts/tasks/kubernetes.yml
@@ -6,18 +6,18 @@
 
 - when: inventory_hostname in available_masters
   block:
-    - name: Check if /etc/kubernetes/admin.conf file exists
+    - name: Check if kubeconfig file exists
       stat:
-        path: /etc/kubernetes/admin.conf
+        path: "{{ lookup('env','KUBECONFIG') }}"
         get_attributes: false
         get_checksum: false
         get_mime: false
-      register: stat_admin_conf
+      register: stat_kubeconfig
 
-    - when: stat_admin_conf.stat.exists
+    - when: stat_kubeconfig.stat.exists
       block:
         - name: Get list of all master nodes
-          shell: |
+          command: |
             kubectl get nodes \
               --selector={{ selector }} \
               --output=jsonpath={{ jsonpath }}
@@ -26,17 +26,13 @@
               'node-role.kubernetes.io/master'
             jsonpath: >-
               '{range .items[*]}{.metadata.name}{"\n"}{end}'
-          environment:
-            KUBECONFIG: /etc/kubernetes/admin.conf
-          args:
-            executable: /bin/bash
           register: kubectl_get_master_nodes
           changed_when: false
 
     - name: Decide if current node is a master
       set_fact:
         master_already_joined: >-
-          {{ stat_admin_conf.stat.exists and (kubectl_get_master_nodes.stdout_lines is defined)
+          {{ stat_kubeconfig.stat.exists and (kubectl_get_master_nodes.stdout_lines is defined)
                                          and (inventory_hostname in kubectl_get_master_nodes.stdout_lines) }}
 
 - name: Collect registered masters
@@ -51,14 +47,10 @@
 - when: (registered_masters.0 is defined) and (inventory_hostname == registered_masters.0)
   block:
     - name: Collect live kubeadm ClusterConfiguration object if available
-      shell: |
+      command: |
         kubectl get configmap kubeadm-config \
           --namespace=kube-system \
           --output=yaml
-      environment:
-        KUBECONFIG: /etc/kubernetes/admin.conf
-      args:
-        executable: /bin/bash
       register: kubeadm_config_yaml
       changed_when: false
 
@@ -92,13 +84,9 @@
 - when: (registered_masters.0 is defined) and (inventory_hostname == registered_masters.0)
   block:
     - name: Collect server version of running kubernetes
-      shell: |
+      command: |
         kubectl version \
           --output yaml
-      environment:
-        KUBECONFIG: /etc/kubernetes/admin.conf
-      args:
-        executable: /bin/bash
       register: kubectl_version_yaml
       changed_when: false
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/prometheus/tasks/configure-k8s-apps-monitoring.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/prometheus/tasks/configure-k8s-apps-monitoring.yml
@@ -7,39 +7,23 @@
   set_fact:
     api_server_address: "https://{{ master_hostname }}:6443"
 
-- name: Set Kubernetes credentials
-  import_role:
-    name: kubernetes_master
-    tasks_from: copy-kubeconfig
-  delegate_to: "{{ master_hostname }}"
-
-- name: Deploy rolebinding file to server for prometheus
-  copy:
-    src: k8s-rolebinding.yml
-    dest: "/home/{{ admin_user.name }}/k8s-rolebinding.yml"
-  delegate_to: "{{ master_hostname }}"
-
-- name: apply rolebinding to k8s for prometheus
-  become: yes
-  become_user: "{{ admin_user.name }}"
-  shell: "kubectl apply --kubeconfig=/home/{{ admin_user.name }}/.kube/config -f /home/{{ admin_user.name }}/k8s-rolebinding.yml"
+- name: Apply rolebinding to k8s for prometheus
+  become: false
+  command: "kubectl apply -f {{ role_path }}/files/k8s-rolebinding.yml"
   run_once: true
-  delegate_to: "{{ master_hostname }}"
+  delegate_to: localhost
 
 - name: Get kubernetes bearer token for prometheus
-  become: yes
-  become_user: "{{ admin_user.name }}"
-  shell: "kubectl --kubeconfig=/home/{{ admin_user.name }}/.kube/config describe secret $(kubectl get secrets --namespace=kube-system | grep prometheus | awk '{print $1}') --namespace=kube-system | grep -E '^token' | awk '{print $2}' | head -1"
+  become: false
+  shell: |-
+    kubectl get $(kubectl get secrets -n kube-system -o name | grep prometheus) \
+      -n kube-system \
+      -o jsonpath='{.data.token}' \
+    | base64 -d
   register: kube_token
-  delegate_to: "{{ master_hostname }}"
+  delegate_to: localhost
   run_once: true
 
 - name: Set bearer token variable
   set_fact:
     bearer_token: "{{ kube_token.stdout }}"
-
-- name: Remove Kubernetes credentials
-  import_role:
-    name: kubernetes_master
-    tasks_from: remove-kubeconfig
-  delegate_to: "{{ master_hostname }}"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/prometheus/tasks/configure-k8s-apps-monitoring.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/prometheus/tasks/configure-k8s-apps-monitoring.yml
@@ -7,6 +7,11 @@
   set_fact:
     api_server_address: "https://{{ master_hostname }}:6443"
 
+- name: Set Kubernetes credentials
+  import_role:
+    name: kubernetes_master
+    tasks_from: copy-kubeconfig
+
 - name: Apply rolebinding to k8s for prometheus
   become: false
   command: "kubectl apply -f {{ role_path }}/files/k8s-rolebinding.yml"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/prometheus/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/prometheus/tasks/main.yml
@@ -11,11 +11,14 @@
   set_fact:
     does_k8s_exists: "(groups['kubernetes_master'] | default([])) | length > 0"
 
-- include: configure-k8s-apps-monitoring.yml
+- name: Configure kubernetes monitoring
+  when: does_k8s_exists
   become: true
+  include: configure-k8s-apps-monitoring.yml
+  environment:
+    KUBECONFIG: "{{ kubeconfig.local }}"
   tags:
     - kubernetes
-  when: does_k8s_exists
 
 - name: Gather variables for each operating system
   include_vars: "{{ item }}"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/prometheus/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/prometheus/tasks/main.yml
@@ -13,10 +13,13 @@
 
 - name: Configure kubernetes monitoring
   when: does_k8s_exists
-  become: true
-  include: configure-k8s-apps-monitoring.yml
-  environment:
-    KUBECONFIG: "{{ kubeconfig.local }}"
+  include_tasks:
+    file: configure-k8s-apps-monitoring.yml
+    apply:
+      environment:
+        KUBECONFIG: "{{ kubeconfig.local }}"
+      tags:
+        - kubernetes
   tags:
     - kubernetes
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/downgrade-coredns.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/downgrade-coredns.yml
@@ -23,8 +23,6 @@
 - name: k8s/master | Wait for CoreDNS pods to become ready
   command: >-
     kubectl wait --for=condition=Ready pods -l k8s-app=kube-dns --timeout=10s -n kube-system
-  environment:
-    KUBECONFIG: /etc/kubernetes/admin.conf
   register: wait_for_coredns
   until: wait_for_coredns is succeeded
   retries: 30

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/gather-static-facts.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/gather-static-facts.yml
@@ -9,10 +9,6 @@
                                   or .labels.app == "flannel") | .name'
       register: shell_cni_plugin_query
       changed_when: false
-      environment:
-        KUBECONFIG: /etc/kubernetes/admin.conf
-      args:
-        executable: /bin/bash
 
     - name: k8s | Set CNI plugin as fact
       set_fact:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/get-cluster-version.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/get-cluster-version.yml
@@ -1,7 +1,5 @@
 ---
 - name: Get cluster version
-  environment:
-    KUBECONFIG: /etc/kubernetes/admin.conf
   shell: >-
     set -o pipefail &&
     kubectl version --short -o json | jq --raw-output '.serverVersion.gitVersion'

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/get-kubelet-version.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/get-kubelet-version.yml
@@ -1,7 +1,5 @@
 ---
 - name: Get kubelet version from API server
-  environment:
-    KUBECONFIG: /etc/kubernetes/admin.conf
   command: >-
     kubectl get node {{ inventory_hostname }} -o jsonpath='{.status.nodeInfo.kubeletVersion}'
   register: kubelet_version

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/patch-kubeadm-etcd-encryption.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/patch-kubeadm-etcd-encryption.yml
@@ -15,8 +15,6 @@
   when:
     - command_grep_encryption_flag.rc == 0 # encryption enabled
   run_once: true  # makes no sense to execute it more than once (would be redundant)
-  environment:
-    KUBECONFIG: /etc/kubernetes/admin.conf
   block:
     - name: Get kubeadm-config ConfigMap
       command: |

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/reconfigure-rabbitmq-app.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/reconfigure-rabbitmq-app.yml
@@ -6,8 +6,6 @@
 - name: Delete rabbitmq pods after patching
   block:
     - name: after-patching | Get rabbitmq namespace
-      environment:
-        KUBECONFIG: &KUBECONFIG /etc/kubernetes/admin.conf
       shell: |-
         kubectl get statefulsets.apps --all-namespaces -o=jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.spec.template.spec.containers[].image}{"\n"}{end}'|
         awk '/rabbitmq/ {print $1}'
@@ -16,16 +14,12 @@
       args:
         executable: /bin/bash
     - name: after-patching | Get rabbitmq pod names
-      environment:
-        KUBECONFIG: *KUBECONFIG
       command: kubectl get pod -n {{ rabbit_mq_namespace.stdout }} -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}'
       changed_when: false
       register: rabbit_mq_pod_names
       when:
         - not rabbit_mq_namespace.stdout == ""
     - name: after-patching | Delete rabbitmq pods
-      environment:
-        KUBECONFIG: *KUBECONFIG
       command: kubectl delete pod --namespace {{ rabbit_mq_namespace.stdout }} {{ item }}
       changed_when: false
       loop: "{{ rabbit_mq_pod_names.stdout_lines }}"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/update-kubeadm-image-repository.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/update-kubeadm-image-repository.yml
@@ -1,8 +1,6 @@
 ---
 - name: k8s/master | Patch imageRepository in kubeadm-config ConfigMap
   run_once: true
-  environment:
-    KUBECONFIG: /etc/kubernetes/admin.conf
   block:
     - name: k8s/master | Get kubeadm-config configmap
       command: |

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-cni-plugin-pod.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-cni-plugin-pod.yml
@@ -6,8 +6,6 @@
   register: cni_plugin_ds_update_strategy
   run_once: true
   changed_when: false
-  environment:
-    KUBECONFIG: &KUBECONFIG /etc/kubernetes/admin.conf
   vars:
     selector: "{{ hostvars[groups.kubernetes_master.0].cni_plugin_selector }}"
 
@@ -15,8 +13,6 @@
   when: "'OnDelete' in cni_plugin_ds_update_strategy.stdout_lines"
   vars:
     selector: "{{ hostvars[groups.kubernetes_master.0].cni_plugin_selector }}"
-  environment:
-    KUBECONFIG: *KUBECONFIG
   block:
     - name: k8s | Get list of CNI plugin's expected images
       command: |-

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-k8s-dashboard.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-k8s-dashboard.yml
@@ -29,8 +29,6 @@
     - name: k8s/master | Delete kubernetes-dashboard namespace
       command: >-
         kubectl delete ns kubernetes-dashboard
-      environment:
-        KUBECONFIG: /etc/kubernetes/admin.conf
 
     # Deploy new version of kubernetes-dashboard
     - name: k8s/master | Apply Kubernetes Dashboard

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/utils/drain.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/utils/drain.yml
@@ -11,8 +11,6 @@
     - name: k8s/utils | Drain master or node in preparation for maintenance
       delegate_to: "{{ groups.kubernetes_master[0] }}"
       run_once: true
-      environment:
-        KUBECONFIG: /etc/kubernetes/admin.conf
       command: |
         kubectl drain {{ inventory_hostname }} \
           --ignore-daemonsets \

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/utils/patch-statefulset.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/utils/patch-statefulset.yml
@@ -4,8 +4,6 @@
 # - image_regexp
 
 - name: k8s/utils | Get all statefulsets
-  environment:
-    KUBECONFIG: &KUBECONFIG /etc/kubernetes/admin.conf
   command: |
     kubectl get statefulsets.apps \
       --all-namespaces \
@@ -14,8 +12,6 @@
   changed_when: false
 
 - name: k8s/utils | Patch all statefulsets
-  environment:
-    KUBECONFIG: *KUBECONFIG
   block:
     - name: k8s/utils | Patch statefulset (containers)
       when:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/utils/uncordon.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/utils/uncordon.yml
@@ -11,8 +11,6 @@
     - name: k8s/utils | Uncordon master or node - mark it as schedulable
       delegate_to: "{{ groups.kubernetes_master[0] }}"
       run_once: true
-      environment:
-        KUBECONFIG: /etc/kubernetes/admin.conf
       command: >-
         kubectl uncordon {{ inventory_hostname }}
       register: result

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/utils/wait-for-kube-apiserver.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/utils/wait-for-kube-apiserver.yml
@@ -2,8 +2,6 @@
 - name: k8s/utils | Wait for kubectl to access K8s cluster
   delegate_to: "{{ groups.kubernetes_master[0] }}"
   run_once: true
-  environment:
-    KUBECONFIG: /etc/kubernetes/admin.conf
   command: >-
     kubectl cluster-info
   register: result

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/utils/wait.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/utils/wait.yml
@@ -2,8 +2,6 @@
 - name: k8s/utils | Wait for nodes and pods to be ready
   delegate_to: "{{ groups.kubernetes_master[0] }}"
   run_once: true
-  environment:
-    KUBECONFIG: /etc/kubernetes/admin.conf
   block:
     - name: k8s/utils | Wait for kubectl to find and access K8s cluster
       include_tasks: kubernetes/utils/wait-for-kube-apiserver.yml

--- a/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
@@ -14,6 +14,8 @@
         name: upgrade
         tasks_from: kubernetes/gather-static-facts
       run_once: true
+  environment:
+    KUBECONFIG: "{{ kubeconfig.remote }}"
 
 - hosts: all
   become: true
@@ -31,6 +33,8 @@
     - import_role:
         name: upgrade
         tasks_from: image-registry
+  environment:
+    KUBECONFIG: "{{ kubeconfig.remote }}"
 
 - hosts: kubernetes_master:kubernetes_node
   serial: 1
@@ -41,6 +45,8 @@
         name: upgrade
         tasks_from: kubernetes
       vars: { ver: "1.15.10", cni_ver: "0.7.5", upgrade_to_final_version: false }
+  environment:
+    KUBECONFIG: "{{ kubeconfig.remote }}"
 
 - hosts: kubernetes_master:kubernetes_node
   serial: 1
@@ -51,6 +57,8 @@
         name: upgrade
         tasks_from: kubernetes
       vars: { ver: "1.16.7", cni_ver: "0.7.5", upgrade_to_final_version: false }
+  environment:
+    KUBECONFIG: "{{ kubeconfig.remote }}"
 
 - hosts: kubernetes_master:kubernetes_node
   serial: 1
@@ -61,6 +69,8 @@
         name: upgrade
         tasks_from: kubernetes
       vars: { ver: "1.17.7", cni_ver: "0.8.6", cni_in_kubelet: true, upgrade_to_final_version: false }
+  environment:
+    KUBECONFIG: "{{ kubeconfig.remote }}"
 
 - hosts: kubernetes_master:kubernetes_node
   serial: 1
@@ -71,6 +81,8 @@
         name: upgrade
         tasks_from: kubernetes
       vars: { ver: "1.18.6", cni_ver: "0.8.6", upgrade_to_final_version: true }
+  environment:
+    KUBECONFIG: "{{ kubeconfig.remote }}"
 
 - hosts: elasticsearch
   become: true


### PR DESCRIPTION
In #1655 it was decided not to delegate usage of `kubectl` to localhost for kubernetes roles as there are a lot of places where it can't be changed:

- usage of `kubectl` with `kubelet.conf` that is located only on remote hosts and tasks relate to these hosts:
:small_orange_diamond: core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_common/tasks/gather-facts.yml
:small_orange_diamond: core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/verify-upgrade.yml
- bash completion setup on remote host
:small_orange_diamond: core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/tasks/main.yml
- preflight
:small_orange_diamond: core/src/epicli/data/common/ansible/playbooks/roles/preflight_facts/tasks/kubernetes.yml. Explanation is [here](https://github.com/epiphany-platform/epiphany/pull/1663#discussion_r490091462)
- master-init 
:small_orange_diamond: most of tasks in `master-init.yml`, as `kubernetes-secrets.yml` is used in `copy-cubeconfig.yml`, where local kubeconig is generated, but `kubernetes-secrets.yml` is created almost in the end of `master-init.yml` during cluster deployment

So the size of previous PR was reduced, main changes are:
* Usage of local kubectl for prometheus
* Refactoring to use kubeconfig location value from `group_vars`, mostly set on the play level