### PR TITLE
Add SSH tunnel for using Helm chart repo from Epiphany container

### DIFF
--- a/CHANGELOG-0.8.md
+++ b/CHANGELOG-0.8.md
@@ -12,6 +12,7 @@
 - [#765](https://github.com/epiphany-platform/epiphany/issues/765) - Added multiline support for logs statements in Filebeat
 - [#1618](https://github.com/epiphany-platform/epiphany/issues/1618) - Add kubectl and Helm to epicli and devcontainer images
 - [#1225](https://github.com/epiphany-platform/epiphany/issues/1225) - Add OS_PATCHING.md with information about patching RHEL OS
+- [#1656](https://github.com/epiphany-platform/epiphany/issues/1225) - [FEATURE REQUEST] Helm part of local usage
 
 ### Updated
 

--- a/CHANGELOG-0.8.md
+++ b/CHANGELOG-0.8.md
@@ -12,7 +12,7 @@
 - [#765](https://github.com/epiphany-platform/epiphany/issues/765) - Added multiline support for logs statements in Filebeat
 - [#1618](https://github.com/epiphany-platform/epiphany/issues/1618) - Add kubectl and Helm to epicli and devcontainer images
 - [#1225](https://github.com/epiphany-platform/epiphany/issues/1225) - Add OS_PATCHING.md with information about patching RHEL OS
-- [#1656](https://github.com/epiphany-platform/epiphany/issues/1225) - [FEATURE REQUEST] Helm part of local usage
+- [#1656](https://github.com/epiphany-platform/epiphany/issues/1656) - Run Helm tasks from Epiphany container
 
 ### Updated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY --from=build-epicli-wheel /src/core/src/epicli/dist/ /epicli/
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-        autossh curl gcc jq libffi-dev make musl-dev openssh-client procps psmisc ruby-full sudo tar unzip vim \
+        autossh curl gcc jq libcap2-bin libffi-dev make musl-dev openssh-client procps psmisc ruby-full sudo tar unzip vim \
 \
     && echo "Installing helm binary ..." \
     && curl -fsSLO https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
@@ -36,6 +36,8 @@ RUN apt-get update \
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin/kubectl \
     && kubectl version --client \
+\
+    && setcap 'cap_net_bind_service=+ep' /usr/bin/ssh \
 \
     && gem install \
         rake rspec_junit_formatter serverspec \

--- a/core/src/epicli/.devcontainer/Dockerfile
+++ b/core/src/epicli/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN chmod +x /config-pre.sh \
     && apt-get install --no-install-recommends -y \
         apt-utils dialog 2>&1 \
     && apt-get install --no-install-recommends -y \
-        autossh curl gcc jq libffi-dev make musl-dev openssh-client procps psmisc ruby-full sudo tar unzip vim \
+        autossh curl gcc jq libcap2-bin libffi-dev make musl-dev openssh-client procps psmisc ruby-full sudo tar unzip vim \
         \
         git git-lfs lsb-release \
 \
@@ -35,6 +35,8 @@ RUN chmod +x /config-pre.sh \
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin/kubectl \
     && kubectl version --client \
+\
+    && setcap 'cap_net_bind_service=+ep' /usr/bin/ssh \
 \
     && gem install \
         rake rspec_junit_formatter serverspec \

--- a/core/src/epicli/cli/engine/ansible/AnsibleRunner.py
+++ b/core/src/epicli/cli/engine/ansible/AnsibleRunner.py
@@ -72,7 +72,12 @@ class AnsibleRunner(Step):
 
         self.logger.info('Setting up SSH tunnel for kubectl')
         self.ansible_command.run_playbook_with_retries(inventory=inventory_path,
-                                                       playbook_path=self.playbook_path('sshtunnel_setup'),
+                                                       playbook_path=self.playbook_path('sshtunnel_setup_k8s'),
+                                                       retries=1)
+
+        self.logger.info('Setting up SSH tunnel for helm')
+        self.ansible_command.run_playbook_with_retries(inventory=inventory_path,
+                                                       playbook_path=self.playbook_path('sshtunnel_setup_helm'),
                                                        retries=1)
 
         self.logger.info('Setting up repository for cluster provisioning. This will take a while...')
@@ -85,7 +90,11 @@ class AnsibleRunner(Step):
 
     def post_flight(self, inventory_path):
         self.ansible_command.run_playbook_with_retries(inventory=inventory_path,
-                                                       playbook_path=self.playbook_path('sshtunnel_teardown'),
+                                                       playbook_path=self.playbook_path('sshtunnel_teardown_k8s'),
+                                                       retries=1)
+
+        self.ansible_command.run_playbook_with_retries(inventory=inventory_path,
+                                                       playbook_path=self.playbook_path('sshtunnel_teardown_helm'),
                                                        retries=1)
 
         self.ansible_command.run_playbook(inventory=inventory_path,

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
-k8s_api_server:
-  autossh_log_file_path: /tmp/autossh-k8s-api-server-tunnel.log
-  autossh_pid_file_path: /tmp/autossh-k8s-api-server-tunnel.pid
+autossh_log_file_path: /tmp/autossh-tunnel.log
+autossh_pid_file_path : /tmp/autossh-tunnel.pid

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/defaults/main.yml
@@ -1,3 +1,0 @@
----
-autossh_log_file_path: /tmp/autossh-tunnel.log
-autossh_pid_file_path : /tmp/autossh-tunnel.pid

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/set_facts_helm.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/set_facts_helm.yml
@@ -1,0 +1,13 @@
+---
+- name: Set helm autossh log and pid files
+  set_fact:
+    autossh_log_file_path: /tmp/autossh-helm-repository-tunnel.log
+    autossh_pid_file_path: /tmp/autossh-helm-repository-tunnel.pid
+
+- name: Set helm repository secure port
+  set_fact:
+    ssh_tunnel_port: 80
+
+- name: Set IP of the repository (from inventory)
+  set_fact:
+    ssh_tunnel_ip: "{{ hostvars[groups.repository[0]].ansible_host }}"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/set_facts_k8s.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/set_facts_k8s.yml
@@ -1,4 +1,9 @@
 ---
+- name: Set K8s autossh log and pid files
+  set_fact:
+    autossh_log_file_path: /tmp/autossh-k8s-api-server-tunnel.log
+    autossh_pid_file_path: /tmp/autossh-k8s-api-server-tunnel.pid
+
 - name: Get K8s API server secure port
   block:
     - name: Get K8s API server's secure port from configuration
@@ -15,10 +20,10 @@
 
 - name: Set K8s API server secure port
   set_fact:
-    k8s_api_server_port: >-
+    ssh_tunnel_port: >-
       {{ 6443 if (k8s_master_config.specification is undefined) else
          k8s_master_config.specification.advanced.api_server_args['secure-port'] }}
 
 - name: Set IP of first K8s master (from inventory)
   set_fact:
-    k8s_master_ip: "{{ hostvars[groups.kubernetes_master[0]].ansible_host }}"
+    ssh_tunnel_ip: "{{ hostvars[groups.kubernetes_master[0]].ansible_host }}"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/setup.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/setup.yml
@@ -6,7 +6,6 @@
 - name: Start SSH tunnel to {{ssh_tunnel_ip}}:{{ssh_tunnel_port}}
   block:
     - name: Start SSH tunnel to {{ssh_tunnel_ip}}:{{ssh_tunnel_port}}
-      become: true
       shell: >-
         autossh -M 0 -f
         {{ admin_user.name }}@{{ ssh_tunnel_ip }} -L {{ ssh_tunnel_port }}:localhost:{{ ssh_tunnel_port }}

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/setup.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/setup.yml
@@ -3,12 +3,13 @@
 - name: Include SSH tunnel teardown tasks
   include_tasks: teardown.yml
 
-- name: Start SSH tunnel to K8s master
+- name: Start SSH tunnel to {{ssh_tunnel_ip}}:{{ssh_tunnel_port}}
   block:
-    - name: Start SSH tunnel to K8s master
+    - name: Start SSH tunnel to {{ssh_tunnel_ip}}:{{ssh_tunnel_port}}
+      become: true
       shell: >-
         autossh -M 0 -f
-        {{ admin_user.name }}@{{ k8s_master_ip }} -L {{ k8s_api_server_port }}:localhost:{{ k8s_api_server_port }}
+        {{ admin_user.name }}@{{ ssh_tunnel_ip }} -L {{ ssh_tunnel_port }}:localhost:{{ ssh_tunnel_port }}
         -i $(realpath -s {{ admin_user.key_path }}) -4 -N -T
         -o BatchMode=yes -o ControlMaster=no -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=5
         -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
@@ -17,16 +18,16 @@
       register: shell_autossh
       environment: "{{ autossh_env }}"
 
-    - name: Assert port {{ k8s_api_server_port }} is open
+    - name: Assert port {{ ssh_tunnel_port }} is open
       wait_for:
-        port: "{{ k8s_api_server_port }}"
+        port: "{{ ssh_tunnel_port }}"
         state: started
         timeout: 15
         msg: |-
-          Timeout waiting for port {{ k8s_api_server_port }} to respond.
+          Timeout waiting for port {{ ssh_tunnel_port }} to respond.
           Command used to start the tunnel: '{{ shell_autossh.cmd }}'.
           Environment: {{ autossh_env.items() | map('join', '=') | list }}
   vars:
     autossh_env:
-      AUTOSSH_LOGFILE: "{{ k8s_api_server.autossh_log_file_path }}"
-      AUTOSSH_PIDFILE: "{{ k8s_api_server.autossh_pid_file_path }}"
+      AUTOSSH_LOGFILE: "{{ autossh_log_file_path }}"
+      AUTOSSH_PIDFILE: "{{ autossh_pid_file_path  }}"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/setup.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/setup.yml
@@ -30,4 +30,4 @@
   vars:
     autossh_env:
       AUTOSSH_LOGFILE: "{{ autossh_log_file_path }}"
-      AUTOSSH_PIDFILE: "{{ autossh_pid_file_path  }}"
+      AUTOSSH_PIDFILE: "{{ autossh_pid_file_path }}"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/teardown.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/teardown.yml
@@ -1,7 +1,4 @@
 ---
-- name: Include gathering facts tasks
-  include_tasks: set_facts.yml
-
 - name: Check if {{ pid_file }} file exists
   stat:
     path: "{{ pid_file }}"
@@ -10,12 +7,13 @@
     get_mime: false
   register: autossh_pid_file_stat
   vars:
-    pid_file: "{{ k8s_api_server.autossh_pid_file_path }}"
+    pid_file: "{{ autossh_pid_file_path  }}"
 
-- name: Close SSH tunnel to K8s master
+- name: Close SSH tunnel to {{ssh_tunnel_ip}}:{{ssh_tunnel_port}}
   when: autossh_pid_file_stat.stat.exists
   block:
-    - name: Close SSH tunnel to K8s master
+    - name: Close SSH tunnel to {{ssh_tunnel_ip}}:{{ssh_tunnel_port}}
+      become: true
       # kill autossh (ssh is child process), $AUTOSSH_PIDFILE is auto-removed
       shell: |-
         AUTOSSH_PID=$(<$AUTOSSH_PIDFILE)
@@ -24,15 +22,15 @@
         kill "$AUTOSSH_PID"
       register: shell_output
       environment:
-        AUTOSSH_PIDFILE: "{{ k8s_api_server.autossh_pid_file_path }}"
+        AUTOSSH_PIDFILE: "{{ autossh_pid_file_path  }}"
 
     - name: Print shell output
       debug:
         var: shell_output.stdout_lines
 
-- name: Assert port {{ k8s_api_server_port }} is free
+- name: Assert port {{ ssh_tunnel_port }} is free
   wait_for:
-    port: "{{ k8s_api_server_port }}"
+    port: "{{ ssh_tunnel_port }}"
     state: stopped
     timeout: 5
-    msg: Port {{ k8s_api_server_port }} is already in use
+    msg: Port {{ ssh_tunnel_port }} is already in use

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/teardown.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/teardown.yml
@@ -26,6 +26,13 @@
     - name: Print shell output
       debug:
         var: shell_output.stdout_lines
+  rescue:
+    - name: Removing PID after failing to close the autossh process
+      # if we fail to kill autossh we might have an $AUTOSSH_PIDFILE file
+      # but no process, so lets remove it and continue
+      file:
+        state: absent
+        path: "{{ autossh_pid_file_path }}"
 
 - name: Assert port {{ ssh_tunnel_port }} is free
   wait_for:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/teardown.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/teardown.yml
@@ -16,33 +16,31 @@
       # kill autossh (ssh is child process), $AUTOSSH_PIDFILE is auto-removed
       shell: |-
         AUTOSSH_PID=$(<$AUTOSSH_PIDFILE)
-        echo "Processes to kill:"
-        pstree -p "$AUTOSSH_PID"
-        kill "$AUTOSSH_PID"
+        PID_PROCESS_NAME=$(ps -q $AUTOSSH_PID -o comm=)
+        if [ "$PID_PROCESS_NAME" == "autossh" ]; then
+          echo "Processes to kill:"
+          pstree -p "$AUTOSSH_PID"
+          kill "$AUTOSSH_PID"
+        else
+          echo "autossh process from PID file not found ($AUTOSSH_PID)"
+          exit 3
+        fi
       register: shell_output
+      changed_when: shell_output.rc != 3
+      failed_when: shell_output.rc not in [0, 3]
       environment:
         AUTOSSH_PIDFILE: "{{ autossh_pid_file_path }}"
 
     - name: Print shell output
       debug:
         var: shell_output.stdout_lines
-  rescue:
-    # if we fail to kill autossh we might have an $AUTOSSH_PIDFILE file
-    # but no process, so lets check if the PID is not from any
-    # autossh process and if not remove it.
-    - name: Get PID process name
-      shell: |-
-        AUTOSSH_PID=$(<$AUTOSSH_PIDFILE)
-        ps -p $AUTOSSH_PID -o comm= || true
-      register: shell_output
-      environment:
-        AUTOSSH_PIDFILE: "{{ autossh_pid_file_path }}"
 
-    - name: Clean up PID file after failing to close the autossh process
+    # autossh leaves PID file when killed with SIGKILL
+    - name: Clean up orphaned PID file
       file:
         state: absent
         path: "{{ autossh_pid_file_path }}"
-      when: '"autossh" not in shell_output.stdout'
+      when: shell_output.rc == 3
 
 - name: Assert port {{ ssh_tunnel_port }} is free
   wait_for:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/teardown.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/teardown.yml
@@ -27,12 +27,22 @@
       debug:
         var: shell_output.stdout_lines
   rescue:
-    - name: Removing PID after failing to close the autossh process
-      # if we fail to kill autossh we might have an $AUTOSSH_PIDFILE file
-      # but no process, so lets remove it and continue
+    # if we fail to kill autossh we might have an $AUTOSSH_PIDFILE file
+    # but no process, so lets check if the PID is not from any
+    # autossh process and if not remove it.
+    - name: Get PID process name
+      shell: |-
+        AUTOSSH_PID=$(<$AUTOSSH_PIDFILE)
+        ps -p $AUTOSSH_PID -o comm= || true
+      register: shell_output
+      environment:
+        AUTOSSH_PIDFILE: "{{ autossh_pid_file_path }}"
+
+    - name: Clean up PID file after failing to close the autossh process
       file:
         state: absent
         path: "{{ autossh_pid_file_path }}"
+      when: '"autossh" not in shell_output.stdout'
 
 - name: Assert port {{ ssh_tunnel_port }} is free
   wait_for:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/teardown.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/teardown.yml
@@ -7,7 +7,7 @@
     get_mime: false
   register: autossh_pid_file_stat
   vars:
-    pid_file: "{{ autossh_pid_file_path  }}"
+    pid_file: "{{ autossh_pid_file_path }}"
 
 - name: Close SSH tunnel to {{ssh_tunnel_ip}}:{{ssh_tunnel_port}}
   when: autossh_pid_file_stat.stat.exists

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/teardown.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/teardown.yml
@@ -13,7 +13,6 @@
   when: autossh_pid_file_stat.stat.exists
   block:
     - name: Close SSH tunnel to {{ssh_tunnel_ip}}:{{ssh_tunnel_port}}
-      become: true
       # kill autossh (ssh is child process), $AUTOSSH_PIDFILE is auto-removed
       shell: |-
         AUTOSSH_PID=$(<$AUTOSSH_PIDFILE)

--- a/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/teardown.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/sshtunnel/tasks/teardown.yml
@@ -22,7 +22,7 @@
         kill "$AUTOSSH_PID"
       register: shell_output
       environment:
-        AUTOSSH_PIDFILE: "{{ autossh_pid_file_path  }}"
+        AUTOSSH_PIDFILE: "{{ autossh_pid_file_path }}"
 
     - name: Print shell output
       debug:

--- a/core/src/epicli/data/common/ansible/playbooks/sshtunnel_setup_helm.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/sshtunnel_setup_helm.yml
@@ -1,0 +1,18 @@
+# Ansible playbook to set up SSH tunnel for helm operations
+
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: false
+  tasks:
+    - include_role:
+        name: sshtunnel
+        tasks_from: "{{ item }}.yml"
+      when:
+        - groups.repository is defined
+        - groups.repository | length > 0
+      loop:
+        - set_facts_helm
+        - setup
+  module_defaults:
+    shell:
+      executable: /bin/bash

--- a/core/src/epicli/data/common/ansible/playbooks/sshtunnel_setup_k8s.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/sshtunnel_setup_k8s.yml
@@ -6,10 +6,13 @@
   tasks:
     - include_role:
         name: sshtunnel
-        tasks_from: setup
+        tasks_from: "{{ item }}.yml"
       when:
         - groups.kubernetes_master is defined
         - groups.kubernetes_master | length > 0
+      loop:
+        - set_facts_k8s
+        - setup
   module_defaults:
     shell:
       executable: /bin/bash

--- a/core/src/epicli/data/common/ansible/playbooks/sshtunnel_teardown_helm.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/sshtunnel_teardown_helm.yml
@@ -1,0 +1,18 @@
+# Ansible playbook to close SSH tunnel opened for helm operations
+
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: false
+  tasks:
+    - include_role:
+        name: sshtunnel
+        tasks_from: "{{ item }}.yml"
+      when:
+        - groups.repository is defined
+        - groups.repository | length > 0
+      loop:
+        - set_facts_helm
+        - teardown
+  module_defaults:
+    shell:
+      executable: /bin/bash

--- a/core/src/epicli/data/common/ansible/playbooks/sshtunnel_teardown_k8s.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/sshtunnel_teardown_k8s.yml
@@ -6,10 +6,13 @@
   tasks:
     - include_role:
         name: sshtunnel
-        tasks_from: teardown
+        tasks_from: "{{ item }}.yml"
       when:
         - groups.kubernetes_master is defined
         - groups.kubernetes_master | length > 0
+      loop:
+        - set_facts_k8s
+        - teardown
   module_defaults:
     shell:
       executable: /bin/bash


### PR DESCRIPTION
Sets up the SSH connection for the local helm to use the remote repository. Note that changes to use it are done in #1687 