### PR TITLE
Start haproxy service after rsyslog

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/haproxy/templates/haproxy-rsyslog.conf.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/haproxy/templates/haproxy-rsyslog.conf.j2
@@ -5,4 +5,4 @@ $UDPServerRun 514
 $template Haproxy,"%msg%n"
 local1.* /var/log/haproxy.log
 ### keep logs in localhost ###
-&~
+&stop

--- a/core/src/epicli/data/common/ansible/playbooks/roles/haproxy/templates/haproxy.cfg.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/haproxy/templates/haproxy.cfg.j2
@@ -31,6 +31,7 @@ defaults
 frontend {{ front.name }}
     {%- if front.https is defined and front.https == True %}
     mode tcp
+    option tcplog
     bind *:{{ front.port }} ssl {% for cert_name in haproxy_certs_names.files %}crt {{ cert_name.path }} {% endfor %}
     {%- else %}
     bind *:{{ front.port }}

--- a/core/src/epicli/data/common/ansible/playbooks/roles/haproxy_runc/templates/haproxy.service.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/haproxy_runc/templates/haproxy.service.j2
@@ -1,6 +1,10 @@
 # {{ ansible_managed }}
 [Unit]
-After=network.target
+Description=HAProxy Load Balancer
+After=network-online.target
+After=rsyslog.service
+Requires=rsyslog.service
+Wants=network-online.target
 
 [Service]
 Type=forking

--- a/core/src/epicli/data/common/ansible/playbooks/roles/haproxy_runc/templates/haproxy.service.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/haproxy_runc/templates/haproxy.service.j2
@@ -9,10 +9,11 @@ Wants=network-online.target
 [Service]
 Type=forking
 WorkingDirectory={{ haproxy_dir }}
-ExecStart={{ runc_binary }} run --detach {{ haproxy_service }}
+ExecStart={{ runc_binary }} run --detach --pid-file /run/{{ haproxy_service }}.pid {{ haproxy_service }}
 ExecReload={{ runc_binary }} kill {{ haproxy_service }} SIGUSR2
-ExecStop={{ runc_binary }} kill {{ haproxy_service }} SIGUSR1
 ExecStopPost={{ runc_binary }} delete {{ haproxy_service }}
+PIDFile=/run/{{ haproxy_service }}.pid
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Fix issue found by automated tests:
If haproxy service starts before rsyslog there is no log file (`/var/log/haproxy.log`).
- Fix HAProxy and rsyslog warnings
- Add automatic restarts for `haproxy` service 