### PR TITLE
Deterministic hosts order in hostgroup

### DIFF
--- a/core/src/epicli/cli/engine/providers/any/APIProxy.py
+++ b/core/src/epicli/cli/engine/providers/any/APIProxy.py
@@ -23,4 +23,5 @@ class APIProxy:
                 machine_doc = select_first(self.config_docs,
                                            lambda x: x.kind == 'infrastructure/machine' and x.name == machine)
                 result.append(AnsibleHostModel(machine_doc.specification.hostname, machine_doc.specification.ip))
+        result.sort(key=lambda x: x.name, reverse=False)
         return result

--- a/core/src/epicli/cli/engine/providers/aws/APIProxy.py
+++ b/core/src/epicli/cli/engine/providers/aws/APIProxy.py
@@ -11,7 +11,7 @@ class APIProxy:
         credentials = self.cluster_model.specification.cloud.credentials
         self.session = boto3.session.Session(aws_access_key_id=credentials.key,
                                              aws_secret_access_key=credentials.secret,
-                                             region_name=self.cluster_model.specification.cloud.region)        
+                                             region_name=self.cluster_model.specification.cloud.region)
 
     def __enter__(self):
         return self
@@ -51,6 +51,7 @@ class APIProxy:
                 result.append(AnsibleHostModel(instance.public_dns_name, instance.public_ip_address))
             else:
                 result.append(AnsibleHostModel(instance.private_dns_name, instance.private_ip_address))
+        result.sort(key=lambda x: x.name, reverse=False)
         return result
 
     def get_image_id(self, os_full_name):

--- a/core/src/epicli/cli/engine/providers/azure/APIProxy.py
+++ b/core/src/epicli/cli/engine/providers/azure/APIProxy.py
@@ -12,7 +12,7 @@ class APIProxy:
         self.cluster_model = cluster_model
         self.cluster_name = self.cluster_model.specification.name.lower()
         self.cluster_prefix = self.cluster_model.specification.prefix.lower()
-        self.resource_group_name = resource_name(self.cluster_prefix, self.cluster_name, 'rg')        
+        self.resource_group_name = resource_name(self.cluster_prefix, self.cluster_name, 'rg')
         self.config_docs = config_docs
         self.logger = Log(__name__)
 
@@ -34,21 +34,21 @@ class APIProxy:
         name = sp_data['name']
         password = sp_data['password']
         tenant = sp_data['tenant']
-        return self.run(self, f'az login --service-principal -u \'{name}\' -p \'{password}\' --tenant \'{tenant}\'', False)      
+        return self.run(self, f'az login --service-principal -u \'{name}\' -p \'{password}\' --tenant \'{tenant}\'', False)
 
     def set_active_subscribtion(self, subscription_id):
-        self.run(self, f'az account set --subscription {subscription_id}')  
+        self.run(self, f'az account set --subscription {subscription_id}')
 
     def get_active_subscribtion(self):
-        subscription = self.run(self, f'az account show') 
-        return subscription   
-    
+        subscription = self.run(self, f'az account show')
+        return subscription
+
     def create_sp(self, app_name, subscription_id):
         #TODO: make role configurable?
         sp = self.run(self, f'az ad sp create-for-rbac -n \'{app_name}\' --role=\'Contributor\' --scopes=\'/subscriptions/{subscription_id}\'')
         # Sleep for a while. Sometimes the call returns before the rights of the SP are finished creating.
         self.wait(self, 60)
-        return sp  
+        return sp
 
     def get_ips_for_feature(self, component_key):
         look_for_public_ip = self.cluster_model.specification.cloud.use_public_ips
@@ -57,13 +57,14 @@ class APIProxy:
         result = []
         for instance in running_instances:
             if isinstance(instance, list):
-                instance = instance[0]   
+                instance = instance[0]
             name = instance['virtualMachine']['name']
             if look_for_public_ip:
                 ip = instance['virtualMachine']['network']['publicIpAddresses'][0]['ipAddress']
             else:
                 ip = instance['virtualMachine']['network']['privateIpAddresses'][0]
             result.append(AnsibleHostModel(name, ip))
+        result.sort(key=lambda x: x.name, reverse=False)
         return result
 
     def get_storage_account_primary_key(self, storage_account_name):
@@ -71,7 +72,7 @@ class APIProxy:
         return keys[0]['value']
 
     @staticmethod
-    def wait(self, seconds):        
+    def wait(self, seconds):
         for x in range(0, seconds):
             self.logger.info(f'Waiting {seconds} seconds...{x}')
             time.sleep(1)
@@ -100,4 +101,4 @@ class APIProxy:
         else:
             if log_cmd:
                 self.logger.info(f'Done running "{cmd}"')
-            return output            
+            return output


### PR DESCRIPTION
Tested by me. The behavior is now expected order of hosts in host group. The order is sorted by hostname as string sort and does not change in multiple re runs. 