### PR TITLE
Fix missing K8s metadata for Filebeat 7

### DIFF
--- a/CHANGELOG-0.8.md
+++ b/CHANGELOG-0.8.md
@@ -39,3 +39,4 @@
 
 - Repository machine was introduced (ref #1640)
 - Change cluster configuration manifest in order to be compatible with changes in #1640 [example] (https://github.com/epiphany-platform/epiphany/blob/develop/core/src/epicli/data/common/defaults/epiphany-cluster.yml)
+- Filebeat renamed fields in 7.0, see [here](https://www.elastic.co/guide/en/beats/libbeat/current/breaking-changes-7.0.html#_field_name_changes). The `source` field was removed and replaced with `log.file.path`.

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
@@ -114,19 +114,20 @@ filebeat.inputs:
 
   processors:
     - add_docker_metadata:
+        labels.dedot: false
     - rename:
         fields:
-          - from: docker.container.labels.io.kubernetes.container.name
+          - from: container.labels.io.kubernetes.container.name
             to: kubernetes.container.name
-          - from: docker.container.labels.io.kubernetes.pod.name
+          - from: container.labels.io.kubernetes.pod.name
             to: kubernetes.pod.name
-          - from: docker.container.labels.io.kubernetes.pod.namespace
+          - from: container.labels.io.kubernetes.pod.namespace
             to: kubernetes.namespace
         ignore_missing: true
         fail_on_error: true
     - drop_fields:
         fields:
-          - docker # Drop all fields added by 'add_docker_metadata' that were not renamed
+          - container # Drop all fields added by 'add_docker_metadata' that were not renamed
 {% endif %}
 
 # ============================== Filebeat modules ==============================

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
@@ -102,12 +102,13 @@ filebeat.inputs:
 # K8s metadata are fetched from Docker labels to not make Filebeat on worker nodes dependent on K8s master
 # since Filebeat should start even if K8s master is not available.
 
-- type: docker
+- type: container
   enabled: true
-  containers.ids: "*"
-  {% if specification.docker_input.multiline is defined -%}
+  paths:
+    - /var/lib/docker/containers/*/*.log
+  {% if specification.container_input.multiline is defined -%}
   multiline:
-  {% for k, v in specification.docker_input.multiline.items() %}
+  {% for k, v in specification.container_input.multiline.items() %}
   {{ k }}: {{ v }}
   {% endfor %}
   {% endif %}

--- a/docs/home/howto/LOGGING.md
+++ b/docs/home/howto/LOGGING.md
@@ -90,5 +90,5 @@ By default postgresql block is provided, you can use it as example:
       negate: true
       match: after
 ```
-Currently supported inputs: `common_input`,`postgresql_input`,`docker_input`  
+Currently supported inputs: `common_input`,`postgresql_input`,`container_input`  
 More details about multiline options you can find in the [official documentation](https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html)


### PR DESCRIPTION
- Update fields provided by `add_docker_metadata` processor
- Use `container` input instead of `docker` ([deprecated in Filebeat 7.2.0](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-docker.html))
- Add info about breaking changes in Filebeat 7 