### PR TITLE
Do not fail on Kibana upgrade when legacy version is present

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kibana.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kibana.yml
@@ -1,27 +1,34 @@
 ---
-- name: Open Distro for Elasticsearch - Kibana | Get information about installed packages as facts
+- name: Kibana | Get information about installed packages as facts
   package_facts:
     manager: auto
   when: ansible_facts.packages is undefined
 
-- name: Open Distro for Elasticsearch - Kibana | Assert that opendistroforelasticsearch-kibana package is installed
-  assert:
-    that: ansible_facts.packages['opendistroforelasticsearch-kibana'] is defined
-    fail_msg: opendistroforelasticsearch-kibana package not found, nothing to upgrade
-    quiet: true
-
-- name: Open Distro for Elasticsearch - Kibana | Include defaults from kibana role
-  include_vars:
-    file: roles/kibana/defaults/main.yml
-
-- name: Open Distro for Elasticsearch - Kibana  | Print versions
-  debug:
-    msg:
-      - "Installed version: {{ ansible_facts.packages['opendistroforelasticsearch-kibana'][0].version }}"
-      - "Target version: {{ specification.versions[ansible_os_family].opendistro }}"
-
-- name: Open Distro for Elasticsearch - Kibana  | Upgrade
-  import_role:
-    name: kibana
+# Kibana is upgraded only when there is no 'kibana-oss' package (replaced by 'opendistroforelasticsearch-kibana' since v0.5).
+# This condition has been added to not fail when 'epicli upgrade' is run for Epiphany v0.4 cluster.
+# We cannot upgrade Kibana to v7 having Elasticsearch v6.
+- name: Upgrade Kibana
   when:
-    - specification.versions[ansible_os_family].opendistro is version(ansible_facts.packages['opendistroforelasticsearch-kibana'][0].version, '>')
+    - ansible_facts.packages['kibana-oss'] is undefined
+  block:
+    - name: Kibana | Assert that opendistroforelasticsearch-kibana package is installed
+      assert:
+        that: ansible_facts.packages['opendistroforelasticsearch-kibana'] is defined
+        fail_msg: opendistroforelasticsearch-kibana package not found, nothing to upgrade
+        quiet: true
+
+    - name: Kibana | Include defaults from kibana role
+      include_vars:
+        file: roles/kibana/defaults/main.yml
+
+    - name: Kibana | Print versions
+      debug:
+        msg:
+          - "Installed version: {{ ansible_facts.packages['opendistroforelasticsearch-kibana'][0].version }}"
+          - "Target version: {{ specification.versions[ansible_os_family].opendistro }}"
+
+    - name: Kibana | Upgrade
+      import_role:
+        name: kibana
+      when:
+        - specification.versions[ansible_os_family].opendistro is version(ansible_facts.packages['opendistroforelasticsearch-kibana'][0].version, '>')


### PR DESCRIPTION
Kibana is upgraded only when there is no 'kibana-oss' package (replaced by 'opendistroforelasticsearch-kibana' since v0.5).
This condition has been added to not fail when 'epicli upgrade' is run for Epiphany v0.4 cluster.
We cannot upgrade Kibana to v7 having Elasticsearch in legacy version (v6).