### PR TITLE
CoreDNS upgrade process fixed

### DIFF
--- a/CHANGELOG-0.8.md
+++ b/CHANGELOG-0.8.md
@@ -7,7 +7,7 @@
 - [#1754](https://github.com/epiphany-platform/epiphany/issues/1754) - Fix Vault installation for setup without K8s
 - [#1640](https://github.com/epiphany-platform/epiphany/issues/1640) - Default disk size for repository machine increased to 64 GB (AWS and Azure)
 - [#1774](https://github.com/epiphany-platform/epiphany/issues/1774) - [epicli upgrade] Filebeat stops working when legacy Elasticsearch (v6) is used for storing logs
-- [#1775](https://github.com/epiphany-platform/epiphany/issues/1775) - [epicli upgrade] Can't upgrade a 0.6.0 epiphany cluster to develop with "--wait-for-pods" flag.
+- [#1775](https://github.com/epiphany-platform/epiphany/issues/1775) - [epicli upgrade] Cannot upgrade Epiphany cluster in version 0.6.x when using "--wait-for-pods" flag.
 
 ## [0.8.0rc1] 2020-10-08
 

--- a/CHANGELOG-0.8.md
+++ b/CHANGELOG-0.8.md
@@ -7,6 +7,7 @@
 - [#1754](https://github.com/epiphany-platform/epiphany/issues/1754) - Fix Vault installation for setup without K8s
 - [#1640](https://github.com/epiphany-platform/epiphany/issues/1640) - Default disk size for repository machine increased to 64 GB (AWS and Azure)
 - [#1774](https://github.com/epiphany-platform/epiphany/issues/1774) - [epicli upgrade] Filebeat stops working when legacy Elasticsearch (v6) is used for storing logs
+- [#1775](https://github.com/epiphany-platform/epiphany/issues/1775) - [epicli upgrade] Cannot upgrade a 0.6.0 epiphany cluster to develop with "--wait-for-pods" flag.
 
 ## [0.8.0rc1] 2020-10-08
 

--- a/CHANGELOG-0.8.md
+++ b/CHANGELOG-0.8.md
@@ -7,7 +7,7 @@
 - [#1754](https://github.com/epiphany-platform/epiphany/issues/1754) - Fix Vault installation for setup without K8s
 - [#1640](https://github.com/epiphany-platform/epiphany/issues/1640) - Default disk size for repository machine increased to 64 GB (AWS and Azure)
 - [#1774](https://github.com/epiphany-platform/epiphany/issues/1774) - [epicli upgrade] Filebeat stops working when legacy Elasticsearch (v6) is used for storing logs
-- [#1775](https://github.com/epiphany-platform/epiphany/issues/1775) - [epicli upgrade] Cannot upgrade a 0.6.0 epiphany cluster to develop with "--wait-for-pods" flag.
+- [#1775](https://github.com/epiphany-platform/epiphany/issues/1775) - [epicli upgrade] Can't upgrade a 0.6.0 epiphany cluster to develop with "--wait-for-pods" flag.
 
 ## [0.8.0rc1] 2020-10-08
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/files/coredns-configmap.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/files/coredns-configmap.yml
@@ -1,5 +1,5 @@
 # Based on https://github.com/kubernetes/kubernetes/blob/v1.18.6/cluster/addons/dns/coredns/coredns.yaml.in
-# Hosts plugin added, value in label for addon manager changed from "EnsureExists" to "Reconcile" in order to stick to original state of CoreDNS addon
+# Hosts plugin added
 
 apiVersion: v1
 kind: ConfigMap

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/files/coredns-configmap.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/files/coredns-configmap.yml
@@ -1,5 +1,5 @@
 # Based on https://github.com/kubernetes/kubernetes/blob/v1.18.6/cluster/addons/dns/coredns/coredns.yaml.in
-# Hosts plugin added
+# Hosts plugin added, value in label for addon manager changed from "EnsureExists" to "Reconcile" in order to stick to original state of CoreDNS addon
 
 apiVersion: v1
 kind: ConfigMap

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/files/coredns-configmap.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/files/coredns-configmap.yml
@@ -1,11 +1,13 @@
 # Based on https://github.com/kubernetes/kubernetes/blob/v1.18.6/cluster/addons/dns/coredns/coredns.yaml.in
-# Hosts plugin added and addon manager label removed since in epiphany we do not use addon manager
+# Hosts plugin added
 
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: coredns
   namespace: kube-system
+  labels:
+      addonmanager.kubernetes.io/mode: Reconcile
 data:
   Corefile: |
     .:53 {

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/files/coredns-configmap.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/files/coredns-configmap.yml
@@ -7,7 +7,7 @@ metadata:
   name: coredns
   namespace: kube-system
   labels:
-      addonmanager.kubernetes.io/mode: Reconcile
+      addonmanager.kubernetes.io/mode: EnsureExists
 data:
   Corefile: |
     .:53 {

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/files/coredns-configmap.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kubernetes_master/files/coredns-configmap.yml
@@ -1,5 +1,5 @@
 # Based on https://github.com/kubernetes/kubernetes/blob/v1.18.6/cluster/addons/dns/coredns/coredns.yaml.in
-# with hosts plugin added
+# Hosts plugin added and addon manager label removed since in epiphany we do not use addon manager
 
 apiVersion: v1
 kind: ConfigMap

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master0.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master0.yml
@@ -96,11 +96,11 @@
   include_tasks: utils/wait.yml
 
 # 'kubeadm upgrade apply' overwrites Epiphany's customized CoreDNS so we patch it again.
-# This task should be run each time K8s is upgraded to the upper version.
+# This task restores 'hosts' plugin and should be run each time K8s was upgraded in order to support "--wait-for-pods" epicli feature (issue #1218).
 - name: k8s/master0 | Customize CoreDNS
   include_tasks: upgrade-coredns.yml
   when:
-    - version is version('1.17.4', '>=') # adds 'hosts' plugin
+    - version is version('1.17.4', '>=') # Epiphany v0.6.0+
 
 - name: Upgrade CNI plugin (deployment then local pod)
   when:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master0.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master0.yml
@@ -100,7 +100,7 @@
 - name: k8s/master0 | Customize CoreDNS for latest Kubernetes ({{ version }})
   include_tasks: upgrade-coredns.yml
   when:
-    - upgrade_to_final_version
+    - version is version('1.17.4', '>=')
 
 - name: Upgrade CNI plugin (deployment then local pod)
   when:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master0.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master0.yml
@@ -96,11 +96,11 @@
   include_tasks: utils/wait.yml
 
 # 'kubeadm upgrade apply' overwrites Epiphany's customized CoreDNS so we patch it again.
-# This task should be run each time K8s is upgraded to the latest version.
-- name: k8s/master0 | Customize CoreDNS for latest Kubernetes ({{ version }})
+# This task should be run each time K8s is upgraded to the upper version.
+- name: k8s/master0 | Customize CoreDNS
   include_tasks: upgrade-coredns.yml
   when:
-    - version is version('1.17.4', '>=')
+    - version is version('1.17.4', '>=') # adds 'hosts' plugin
 
 - name: Upgrade CNI plugin (deployment then local pod)
   when:


### PR DESCRIPTION
Related to the bug #1218 

- We need to upgrade CoreDNS during every single k8s version upgrade, not only during the final part of upgrade (for the target version of K8s).
- Added comment to config file of CoreDNS
- Upgrade CoreDNS for K8s v1.17.4 or greater, since we use K8s v1.17.4 in Epiphany v0.6.0. In lower versions, we don't have pgpool and pgbouncer.
