### PR TITLE
Upgrade filebeat to 7.9.2

### DIFF
--- a/CHANGELOG-0.9.md
+++ b/CHANGELOG-0.9.md
@@ -1,0 +1,15 @@
+# Changelog 0.9
+
+## [0.9.0] YYYY-MM-DD
+
+### Added
+
+### Fixed
+
+### Updated
+
+- [#1770](https://github.com/epiphany-platform/epiphany/issues/1770) - Upgrade Filebeat to the latest version (7.9.2)
+
+### Breaking changes
+
+### Known issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Reference for actual cluster component versions can be found [here](docs/home/COMPONENTS.md)
 
+- [CHANGELOG-0.9.x](./CHANGELOG-0.9.md)
 - [CHANGELOG-0.8.x](./CHANGELOG-0.8.md)
 - [CHANGELOG-0.7.x](./CHANGELOG-0.7.md)
 - [CHANGELOG-0.6.x](./CHANGELOG-0.6.md)

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-specification:
-  filebeat_version: "7.8.1"
+filebeat_helm_chart_file_name: filebeat-7.9.2.tgz
+filebeat_version: "7.9.2"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/Debian.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/Debian.yml
@@ -1,17 +1,19 @@
+---
 - name: Install filebeat package
   apt:
     name:
-      - filebeat={{ specification.filebeat_version }}
-    update_cache: yes
+      - filebeat={{ filebeat_version }}
+    update_cache: true
     state: present
+  register: install_filebeat_package
 
 - name: Install auditd package
   apt:
     name:
       - auditd
-    update_cache: yes
+    update_cache: true
     state: present
-  register: result
-  retries: 3 # Installing auditd sometimes fails in post-inst: https://bugs.launchpad.net/ubuntu/+source/auditd/+bug/1848330
+  register: install_auditd_package
+  until: install_auditd_package is success
+  retries: 3  # Installing auditd sometimes fails in post-inst: https://bugs.launchpad.net/ubuntu/+source/auditd/+bug/1848330
   delay: 1
-  until: result is succeeded

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/RedHat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/RedHat.yml
@@ -1,13 +1,16 @@
+---
 - name: Install filebeat package
   yum:
     name:
-      - filebeat-{{ specification.filebeat_version }}
-    update_cache: yes
+      - filebeat-{{ filebeat_version }}
+    update_cache: true
     state: present
+  register: install_filebeat_package
 
 - name: Install auditd package
   yum:
     name:
       - audit
-    update_cache: yes
+    update_cache: true
     state: present
+  register: install_auditd_package

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/configure-auditd.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/configure-auditd.yml
@@ -10,22 +10,27 @@
 - name: Start/restart and enable auditd service
   block:
     - name: Restart auditd service
-      shell: >-
-        service auditd restart
-      args:
-        warn: false
+      systemd:
+        name: auditd
+        state: restarted
       register: result
-      retries: 3 # to avoid error "job for auditd.service failed because a timeout was exceeded"
+      until: result is success
+      retries: 3  # to avoid error "job for auditd.service failed because a timeout was exceeded"
       delay: 1
-      until: result is succeeded
       when: modify_audit_epi_rules.changed
+         or install_auditd_package.changed
 
     - name: Enable and start auditd service
-      service:
+      systemd:
         name: auditd
         state: started
         enabled: true
 
-    - name: Verify auditd is running
-      command: systemctl is-active auditd
-      changed_when: false
+    - name: Wait for auditd service to be running
+      service_facts:
+      until:
+        - ansible_facts.services['auditd.service'].state is defined
+        - ansible_facts.services['auditd.service'].state == "running"
+      retries: 10
+      delay: 1
+      no_log: true  # to reduce log output

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/configure-filebeat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/configure-filebeat.yml
@@ -8,6 +8,8 @@
   register: modify_filebeat_yml
 
 - name: Set Filebeat to be started after Docker
+  when: (groups['kubernetes_master'] is defined and inventory_hostname in groups['kubernetes_master'])
+     or (groups['kubernetes_node'] is defined and inventory_hostname in groups['kubernetes_node'])
   block:
     - name: Create directory (filebeat.service.d)
       file:
@@ -22,14 +24,11 @@
 
     - name: Run systemctl daemon-reload
       systemd:
-        name: filebeat
         daemon_reload: true
       when: modify_filebeat_unit_dependencies.changed
 
-  when: (groups['kubernetes_master'] is defined and inventory_hostname in groups['kubernetes_master'])
-     or (groups['kubernetes_node'] is defined and inventory_hostname in groups['kubernetes_node'])
-
 - name: Start/restart and enable filebeat service
+  when: groups.logging[0] is defined
   block:
     - name: Enable auditd module
       command: filebeat modules enable auditd
@@ -43,6 +42,7 @@
       when: modify_filebeat_yml.changed
          or modify_filebeat_unit_dependencies.changed
          or enable_module.changed
+         or install_filebeat_package.changed
 
     - name: Enable and start filebeat service
       systemd:
@@ -50,18 +50,18 @@
         state: started
         enabled: true
 
-    - name: Verify filebeat is running
-      command: systemctl is-active filebeat
-      changed_when: false
+    - name: Wait for filebeat service to be running
+      service_facts:
+      until:
+        - ansible_facts.services['filebeat.service'].state is defined
+        - ansible_facts.services['filebeat.service'].state == "running"
       retries: 10
       delay: 1
-      register: result
-      until: result is succeeded
-  when: groups['logging'][0] is defined
+      no_log: true  # to reduce log output
 
 - name: Stop and disable filebeat service
   systemd:
     name: filebeat
     state: stopped
     enabled: false
-  when: groups['logging'][0] is undefined
+  when: groups.logging[0] is undefined

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/install-filebeat-as-daemonset.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/install-filebeat-as-daemonset.yml
@@ -1,25 +1,22 @@
 ---
-
 - name: Prepare configuration and upgrade/install Helm chart
   vars:
     # Handling "undefined", "null", "empty" and "boolean" values all at once.
     disable_helm_chart_bool: "{{ specification.disable_helm_chart | default(false, true) | bool }}"
 
+  when: not disable_helm_chart_bool
+
   delegate_to: localhost
   become: false
   run_once: true
-  when: not disable_helm_chart_bool
-  block:
-    - name: Set Filebeat's Chart file name to install
-      set_fact:
-        exporter_chart_file_name: "{{ specification.files.filebeat_helm_chart_file_name }}"
 
+  block:
     - name: Download Filebeat's Chart File
       include_role:
         name: download
         tasks_from: download_file
       vars:
-        file_name: "{{ exporter_chart_file_name }}"
+        file_name: "{{ filebeat_helm_chart_file_name }}"
         repository_url: http://localhost/epirepo
 
     - name: Copy configuration Helm chart file (custom-chart-values.yml.j2)
@@ -28,9 +25,8 @@
         src: custom-chart-values.yml.j2
 
     - name: Install Filebeat using custom Helm chart (custom-chart-values.yml)
-      delegate_to: localhost
       command: |
         helm upgrade --install \
           -f {{ download_directory }}/custom-chart-values.yml \
           {{ specification.helm_chart_name }} \
-          {{ download_directory }}/{{ exporter_chart_file_name }}
+          {{ download_directory }}/{{ filebeat_helm_chart_file_name }}

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/main.yml
@@ -1,21 +1,20 @@
 ---
-
 - name: Include installation tasks for Filebeat as System Service for "classic epiphany cluster"
   include_tasks: install-filebeat-as-system-service.yml
 
 - name: Include installation tasks for Filebeat as DaemonSet for "k8s as cloud service"
-  when: k8s_as_cloud_service is defined and k8s_as_cloud_service
   include_tasks: install-filebeat-as-daemonset.yml
+  when: k8s_as_cloud_service is defined and k8s_as_cloud_service
+
+- name: Include auditd configuration tasks
+  include_tasks: configure-auditd.yml
 
 - name: Set value for setup.kibana.host
   set_fact:
     setup_kibana_host: >-
-      {{ hostvars[groups['kibana'][0]].ansible_default_ipv4.address + ':5601' }}
+      {{ hostvars[groups.kibana[0]].ansible_default_ipv4.address ~ ':5601' }}
   when:
-    - groups['kibana'][0] is defined
-
-- name: Include auditd configuration tasks
-  include_tasks: configure-auditd.yml
+    - groups.kibana[0] is defined
 
 - name: Include filebeat configuration tasks
   include_tasks: configure-filebeat.yml

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/templates/custom-chart-values.yml.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/templates/custom-chart-values.yml.j2
@@ -1,4 +1,5 @@
 ---
+# {{ ansible_managed }}
 
 ###################### Filebeat's Custom Values for Helm Chart #######################
 # You can find the full configuration reference here:
@@ -144,7 +145,7 @@ envFrom: []
 hostPathRoot: /var/lib
 hostNetworking: true
 image: "docker.elastic.co/beats/filebeat-oss"
-imageTag: "7.9.2"
+imageTag: "{{ filebeat_version }}"
 imagePullPolicy: "IfNotPresent"
 imagePullSecrets: []
 
@@ -152,10 +153,8 @@ livenessProbe:
   exec:
     command:
       - sh
-      - -c
-      - |
-        #!/usr/bin/env bash -e
-        curl --fail 127.0.0.1:5066
+      - -ec
+      - curl --fail 127.0.0.1:5066
   failureThreshold: 3
   initialDelaySeconds: 10
   periodSeconds: 10
@@ -165,10 +164,8 @@ readinessProbe:
   exec:
     command:
       - sh
-      - -c
-      - |
-        #!/usr/bin/env bash -e
-        filebeat test output
+      - -ec
+      - filebeat test output
   failureThreshold: 3
   initialDelaySeconds: 10
   periodSeconds: 10

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
@@ -36,7 +36,7 @@ elasticsearch-oss-6.8.5 # for elasticsearch role
 elasticsearch-oss-7.9.1 # for opendistroforelasticsearch & logging roles
 erlang-21.3.8.7
 ethtool
-filebeat-7.8.1
+filebeat-7.9.2
 firewalld
 fontconfig # for grafana
 fping

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
@@ -35,7 +35,7 @@ elasticsearch-oss-6.8.5 # for elasticsearch role
 elasticsearch-oss-7.9.1 # for opendistroforelasticsearch & logging roles
 erlang-21.3.8.7
 ethtool
-filebeat-7.8.1
+filebeat-7.9.2
 firewalld
 fontconfig # for grafana
 fping

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
@@ -17,7 +17,7 @@ elasticsearch-oss 6.8.5 # for elasticsearch role
 elasticsearch-oss 7.9.1 # for opendistroforelasticsearch & logging roles
 erlang-nox
 ethtool
-filebeat 7.8.1
+filebeat 7.9.2
 firewalld
 fping
 gnupg2

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
@@ -14,13 +14,15 @@
   debug:
     msg:
       - "Installed version: {{ ansible_facts.packages['filebeat'][0].version }}"
-      - "Target version: {{ specification.filebeat_version }}"
+      - "Target version: {{ filebeat_version }}"
 
 - name: Update Filebeat
+  when:
+    - filebeat_version is version(ansible_facts.packages['filebeat'][0].version, '>=')
   block:
     - name: Filebeat | Backup configuration file (filebeat.yml)
       copy:
-        remote_src: yes
+        remote_src: true
         src: /etc/filebeat/filebeat.yml
         dest: /etc/filebeat/filebeat.yml.bak_{{ ansible_facts.packages['filebeat'][0].version }}
 
@@ -35,5 +37,3 @@
     - import_role:
         name: filebeat
         tasks_from: configure-filebeat
-  when:
-    - specification.filebeat_version is version(ansible_facts.packages['filebeat'][0].version, '>=')

--- a/core/src/epicli/data/common/defaults/configuration/filebeat.yml
+++ b/core/src/epicli/data/common/defaults/configuration/filebeat.yml
@@ -4,9 +4,6 @@ name: default
 specification:
   helm_chart_name: filebeat
   disable_helm_chart: false
-  files:
-    filebeat_helm_chart_file_name: filebeat-7.9.2.tgz
-  filebeat_version: "7.8.1"
   postgresql_input:
     multiline:
       pattern: >-

--- a/docs/home/COMPONENTS.md
+++ b/docs/home/COMPONENTS.md
@@ -20,7 +20,7 @@ Note that versions are default versions and can be changed in certain cases thro
 | Elasticsearch Curator OSS | 5.8.1   | https://github.com/elastic/curator                    | https://github.com/elastic/curator/blob/master/LICENSE.txt       |
 | Opendistro for Elasticsearch  | 1.10.1   | https://opendistro.github.io/for-elasticsearch/  | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)  |
 | Opendistro for Elasticsearch Kibana  | 1.10.1   | https://opendistro.github.io/for-elasticsearch-docs/docs/kibana/  | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)  |
-| Filebeat                  | 7.8.1   | https://github.com/elastic/beats                      | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| Filebeat                  | 7.9.2   | https://github.com/elastic/beats                      | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Logstash OSS              | 7.8.1   | https://github.com/elastic/logstash                   | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Prometheus                | 2.10.0  | https://github.com/prometheus/prometheus              | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Grafana                   | 6.2.5   | https://github.com/grafana/grafana                    | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |


### PR DESCRIPTION
I tested this in 7 scenarios:
- on-prem ("any" provider) Ubuntu Epiphany starting from `develop`  (running `epicli apply` and `epicli upgrade`)
- on-prem ("any" provider) Centos Epiphany starting from `develop`  (running `epicli apply` and `epicli upgrade`)
- on-prem ("any" provider) RedHat Epiphany starting from `develop`  (running `epicli apply` and `epicli upgrade`)
- cloud with the `k8s_as_cloud_service` flag enabled (to test helm changes) using https://github.com/epiphany-platform/m-generic-epiphany-on-aks module

```shell
m-generic-epiphany-on-aks/examples/basic_flow$ kubectl --kubeconfig shared/build/azepi/kubeconfig get pods
NAME                      READY   STATUS    RESTARTS   AGE
filebeat-filebeat-dtkj6   1/1     Running   0          27m
filebeat-filebeat-s5c9x   1/1     Running   0          27m
node-exporter-w2z86       1/1     Running   0          25m
node-exporter-zt4t6       1/1     Running   0          25m
```

No issues encountered! :+1::innocent:

