### PR TITLE
Fix postgres hot_standby setting

### DIFF
--- a/CHANGELOG-0.9.md
+++ b/CHANGELOG-0.9.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- [#1273](https://github.com/epiphany-platform/epiphany/issues/1273) - PostgreSQL replication with repmgr: hot_standby not set in config file
+
 ### Updated
 
 - [#1770](https://github.com/epiphany-platform/epiphany/issues/1770) - Upgrade Filebeat to the latest version (7.9.2)

--- a/core/src/epicli/data/common/ansible/playbooks/roles/postgresql/tasks/replication-Debian.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/postgresql/tasks/replication-Debian.yml
@@ -41,15 +41,6 @@
   when:
     - groups['postgresql'][1] == inventory_hostname
 
-- name: Turn on hot_standby
-  replace:
-    path: "{{ pg_config_dir[ansible_os_family] }}/postgresql.conf"
-    regexp: "^#hot_standby = on"
-    replace: "hot_standby = on"
-    backup: yes
-  when:
-    - groups['postgresql'][1] == inventory_hostname
-
 - name: Create pgpass file
   template:
     src: pgpass.j2

--- a/core/src/epicli/data/common/ansible/playbooks/roles/postgresql/tasks/replication-RedHat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/postgresql/tasks/replication-RedHat.yml
@@ -42,14 +42,6 @@
   when:
     - groups['postgresql'][1] == inventory_hostname
 
-- name: Turn on hot_standby
-  replace:
-    path: "{{ pg_config_dir[ansible_os_family] }}/postgresql.conf"
-    regexp: "^#hot_standby = on"
-    replace: "hot_standby = on"
-  when:
-    - groups['postgresql'][1] == inventory_hostname
-
 - name: Create pgpass file
   template:
     src: pgpass.j2

--- a/core/src/epicli/data/common/ansible/playbooks/roles/postgresql/tasks/replication-repmgr-Debian.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/postgresql/tasks/replication-repmgr-Debian.yml
@@ -107,15 +107,6 @@
     - is_master_already_registered.stdout == ""
 
 # Slave:
-- name: Turn on hot_standby
-  replace:
-    path: "{{ pg_config_dir[ansible_os_family] }}/postgresql.conf"
-    regexp: "^#hot_standby = on"
-    replace: "hot_standby = on"
-    backup: yes
-  when:
-    - groups['postgresql'][1] == inventory_hostname
-
 - name: Check if node is already registered in repmgr
   become_user: postgres
   shell: >-

--- a/core/src/epicli/data/common/ansible/playbooks/roles/postgresql/tasks/replication-repmgr-RedHat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/postgresql/tasks/replication-repmgr-RedHat.yml
@@ -91,15 +91,6 @@
     - is_master_already_registered.stdout == ""
 
 # Slave:
-- name: Turn on hot_standby
-  replace:
-    path: "{{ pg_config_dir[ansible_os_family] }}/postgresql.conf"
-    regexp: "^#hot_standby = on"
-    replace: "hot_standby = on"
-    backup: yes
-  when:
-    - groups['postgresql'][1] == inventory_hostname
-
 - name: Check if node is already registered in repmgr
   become_user: postgres
   shell: >-

--- a/core/src/epicli/data/common/defaults/configuration/postgresql.yml
+++ b/core/src/epicli/data/common/defaults/configuration/postgresql.yml
@@ -60,6 +60,12 @@ specification:
                 value: 34
                 comment: number of WAL files held for standby servers
                 when: replication
+          - name: Standby Servers # ignored on master server
+            parameters:
+              - name: hot_standby
+                value: 'on'
+                comment: must be 'on' for repmgr needs, ignored on primary but recommended in case primary becomes standby
+                when: replication
   extensions:
     pgaudit:
       enabled: no

--- a/core/src/epicli/data/common/tests/spec/postgresql/postgresql_spec.rb
+++ b/core/src/epicli/data/common/tests/spec/postgresql/postgresql_spec.rb
@@ -473,31 +473,31 @@ end
 if replicated && (listInventoryHosts("postgresql")[1].include? host_inventory['hostname'])
   describe 'Cleaning up' do
     it "Delegating drop table query to master node" do
-      Net::SSH.start(listInventoryIPs("postgresql")[0], ENV['user'], keys: [ENV['keypath']], :keys_only => TRUE) do|ssh|
+      Net::SSH.start(listInventoryIPs("postgresql")[0], ENV['user'], keys: [ENV['keypath']], :keys_only => true) do|ssh|
         result = ssh.exec!("sudo su - postgres -c \"psql -t -c 'DROP TABLE serverspec_test.test;'\" 2>&1")
         expect(result).to match 'DROP TABLE'
       end
     end
     it "Delegating drop table query to master node", :if => pgbouncer_enabled  do
-      Net::SSH.start(listInventoryIPs("postgresql")[0], ENV['user'], keys: [ENV['keypath']], :keys_only => TRUE) do|ssh|
+      Net::SSH.start(listInventoryIPs("postgresql")[0], ENV['user'], keys: [ENV['keypath']], :keys_only => true) do|ssh|
         result = ssh.exec!("sudo su - postgres -c \"psql -t -c 'DROP TABLE serverspec_test.pgbtest;'\" 2>&1")
         expect(result).to match 'DROP TABLE'
       end
     end
     it "Delegating drop schema query to master node" do
-      Net::SSH.start(listInventoryIPs("postgresql")[0], ENV['user'], keys: [ENV['keypath']], :keys_only => TRUE) do|ssh|
+      Net::SSH.start(listInventoryIPs("postgresql")[0], ENV['user'], keys: [ENV['keypath']], :keys_only => true) do|ssh|
         result = ssh.exec!("sudo su - postgres -c \"psql -t -c 'DROP SCHEMA serverspec_test;'\" 2>&1")
         expect(result).to match 'DROP SCHEMA'
       end
     end
     it "Delegating drop user query to master node", :if => pgbouncer_enabled do
-      Net::SSH.start(listInventoryIPs("postgresql")[0], ENV['user'], keys: [ENV['keypath']], :keys_only => TRUE) do|ssh|
+      Net::SSH.start(listInventoryIPs("postgresql")[0], ENV['user'], keys: [ENV['keypath']], :keys_only => true) do|ssh|
         result = ssh.exec!("sudo su - postgres -c \"psql -t -c 'DROP USER #{pg_user};'\" 2>&1")
         expect(result).to match 'DROP ROLE'
       end
     end
     it "Removing test user from userlist.txt", :if => pgbouncer_enabled do
-      Net::SSH.start(listInventoryIPs("postgresql")[0], ENV['user'], keys: [ENV['keypath']], :keys_only => TRUE) do|ssh|
+      Net::SSH.start(listInventoryIPs("postgresql")[0], ENV['user'], keys: [ENV['keypath']], :keys_only => true) do|ssh|
         result = ssh.exec!("sudo su - -c \"sed -i '/#{pg_pass}/d' /etc/pgbouncer/userlist.txt && cat /etc/pgbouncer/userlist.txt\" 2>&1")
         expect(result).not_to match "#{pg_pass}"
       end

--- a/core/src/epicli/data/common/tests/spec/postgresql/postgresql_spec.rb
+++ b/core/src/epicli/data/common/tests/spec/postgresql/postgresql_spec.rb
@@ -313,7 +313,7 @@ if replicated
     if os[:family] == 'redhat'
       describe 'Checking PostgreSQL config files for secondary node' do
         let(:disable_sudo) { false }
-        describe command("cat /var/lib/pgsql/10/data/postgresql.conf | grep hot_standby") do
+        describe command("cat /var/lib/pgsql/10/data/postgresql-epiphany.conf | grep hot_standby") do
           its(:stdout) { should match /^hot_standby = on/ }
           its(:exit_status) { should eq 0 }
         end
@@ -326,7 +326,7 @@ if replicated
     elsif os[:family] == 'ubuntu'
       describe 'Checking PostgreSQL config files for secondary node' do
         let(:disable_sudo) { false }
-        describe command("cat /etc/postgresql/10/main/postgresql.conf | grep hot_standby") do
+        describe command("cat /etc/postgresql/10/main/postgresql-epiphany.conf | grep hot_standby") do
           its(:stdout) { should match /^hot_standby = on/ }
           its(:exit_status) { should eq 0 }
         end
@@ -340,7 +340,7 @@ if replicated
 
     describe 'Checking the state of replica nodes' do
       let(:disable_sudo) { false }
-      describe command("su - postgres -c \"psql -t -c 'SELECT status, conninfo  from pg_stat_wal_receiver;'\"") do
+      describe command("su - postgres -c \"psql -t -c 'SELECT status, conninfo FROM pg_stat_wal_receiver;'\"") do
         its(:stdout) { should match /\bstreaming\b/ }
         its(:stdout) { should match /\buser=#{replication_user}\b/ }
         its(:exit_status) { should eq 0 }

--- a/core/src/epicli/data/common/tests/spec/postgresql/postgresql_spec.rb
+++ b/core/src/epicli/data/common/tests/spec/postgresql/postgresql_spec.rb
@@ -507,7 +507,7 @@ end
 
 ### Tests for PGAudit
 
-if pgaudit_enabled
+if pgaudit_enabled && countInventoryHosts("logging") > 0
 
   if !replicated || (replicated && (listInventoryHosts("postgresql")[1].include? host_inventory['hostname']))
 

--- a/docs/home/HOWTO.md
+++ b/docs/home/HOWTO.md
@@ -74,7 +74,7 @@
 - [Databases](./howto/DATABASES.md)
   - [How to migrate from PostgreSQL installed from Software Collections to installed from PostgreSQL repository](./howto/DATABASES.md#how-to-migrate-from-postgresql-installed-from-software-collections-to-installed-from-postgresql-repository)
   - [How to configure PostgreSQL](./howto/DATABASES.md#how-to-configure-postgresql)
-  - [How to configure PostgreSQL replication](./howto/DATABASES.md#how-to-configure-postgresql-replication)
+  - [How to configure PostgreSQL replication](./howto/DATABASES.md#how-to-set-up-postgresql-ha-replication-with-repmgr-cluster)
   - [How to set up PostgreSQL connection pooling](./howto/DATABASES.md#how-to-set-up-postgresql-connection-pooling)
   - [How to register database standby in repmgr cluster](./howto/DATABASES.md#how-to-register-database-standby-in-repmgr-cluster)
   - [How to switchover database nodes](./howto/DATABASES.md#how-to-switchover-database-nodes)

--- a/docs/home/howto/DATABASES.md
+++ b/docs/home/howto/DATABASES.md
@@ -118,20 +118,26 @@ name: default
 specification:
   config_file:
     parameter_groups:
-    ...
-    # Block below is optional, you can use it to override default values
-    - name: REPLICATION
-      subgroups:
-        - name: Sending Server(s)
-          parameters:
-            - name: max_wal_senders
-              value: 10 # default value
-              comment: maximum number of simultaneously running WAL sender processes
-              when: replication # default value
-            - name: wal_keep_segments
-              value: 34 # default value
-              comment: number of WAL files held for standby servers
-              when: replication
+      ...
+      # This block is optional, you can use it to override default values
+      - name: REPLICATION
+        subgroups:
+          - name: Sending Server(s)
+            parameters:
+              - name: max_wal_senders
+                value: 10 # default value
+                comment: maximum number of simultaneously running WAL sender processes
+                when: replication # default value
+              - name: wal_keep_segments
+                value: 34 # default value
+                comment: number of WAL files held for standby servers
+                when: replication
+          - name: Standby Servers
+            parameters:
+              - name: hot_standby
+                value: 'on' # default value
+                comment: capability to run read-only queries on standby server
+                when: replication
   extensions:
     ...
     replication:
@@ -178,18 +184,26 @@ title: PostgreSQL
 specification:
   config_file:
     parameter_groups:
-    # Block below is optional, you can use it to override default values
-    - name: REPLICATION
-      subgroups:
-        - name: Sending Server(s)
-          parameters:
-            - name: max_wal_senders
-              value: 10 # default value
-              comment: maximum number of simultaneously running WAL sender processes
-            - name: wal_keep_segments
-              value: 34 # default value
-              comment: number of WAL files held for standby servers
-    ...
+      ...
+      # This block is optional, you can use it to override default values
+      - name: REPLICATION
+        subgroups:
+          - name: Sending Server(s)
+            parameters:
+              - name: max_wal_senders
+                value: 10 # default value
+                comment: maximum number of simultaneously running WAL sender processes
+                when: replication
+              - name: wal_keep_segments
+                value: 34 # default value
+                comment: number of WAL files held for standby servers
+                when: replication
+          - name: Standby Servers
+            parameters:
+              - name: hot_standby
+                value: 'on' # default value
+                comment: must be 'on' for repmgr needs, ignored on primary but recommended in case primary becomes standby
+                when: replication
   extensions:
     ...
     replication:
@@ -201,7 +215,7 @@ specification:
       use_repmgr: true
       repmgr_database: repmgr
       shared_preload_libraries:
-      - repmgr
+        - repmgr
 ```
 If `enabled` is set to `yes` in `replication`, then Epiphany will automatically create cluster of primary and secondary server
 with replication user with name and password specified in data.yaml. This is only possible for configurations containing two
@@ -283,19 +297,19 @@ provider: aws
 name: default
 specification:
   applications:
-  [...]
+  ...
 
 ## --- pgpool ---
 
   - name: pgpool
     enabled: yes
-    [...]
+    ...
     namespace: postgres-pool
     service:
       name: pgpool
       port: 5432
     replicas: 3
-    [...]
+    ...
     resources: # Adjust to your configuration, see https://www.pgpool.net/docs/41/en/html/resource-requiremente.html
       limits:
         # cpu: 900m # Set according to your env
@@ -336,7 +350,7 @@ specification:
 
   - name: pgbouncer
     enabled: yes
-    [...]
+    ...
     namespace: postgres-pool
     service:
       name: pgbouncer
@@ -426,7 +440,7 @@ For example, having 2 pods (with MAX_CLIENT_CONN = 150) allows for up to 300 cli
 ```yaml
     pgbouncer:
       env:
-        [...]
+        ...
         MAX_CLIENT_CONN: 150
         DEFAULT_POOL_SIZE: 25
         RESERVE_POOL_SIZE: 25

--- a/docs/home/howto/DATABASES.md
+++ b/docs/home/howto/DATABASES.md
@@ -94,7 +94,7 @@ PgBouncer listens on standard port 6432. Basic configuration is just template, w
 
 PgBouncer can be also installed (together with Pgpool) in K8s cluster. See [How to set up PgBouncer, PgPool and PostgreSQL parameters](#how-to-set-up-pgbouncer-pgpool-and-postgresql-parameters).
 
-## How to setup PostgreSQL HA replication with repmgr cluster
+## How to set up PostgreSQL HA replication with repmgr cluster
 
 This component can be used as a part of PostgreSQL clustering configured by Epiphany. In order to configure PostgreSQL HA 
 replication, add to your data.yaml a block similar to the one below to core section:
@@ -480,12 +480,17 @@ DROP EXTENSION IF EXISTS pgaudit;
 
 ## How to configure PostgreSQL replication
 
+#### Note
+
+This feature is deprecated and will be removed.
+Use [PostgreSQL HA replication with repmgr](#how-to-set-up-postgresql-ha-replication-with-repmgr-cluster) instead.
+
 #### Attention
 
 In version 0.6.0 because of delivering full HA for PostgreSQL we needed to change configuration for PostgreSQL native
 replication.
 
-You need to change old configuration file from the one visible below:
+You need to change old configuration file from the one like this:
 
 ```yaml
 kind: configuration/postgresql

--- a/docs/home/howto/DATABASES.md
+++ b/docs/home/howto/DATABASES.md
@@ -76,83 +76,6 @@ sudo -u postgres -i
 Then configure database server using psql according to your needs and
 [PostgreSQL documentation](https://www.postgresql.org/docs/).
 
-## How to configure PostgreSQL replication
-
-#### Attention
-
-In version 0.6.0 because of delivering full HA for PostgreSQL we needed to change configuration for PostgreSQL native
-replication.
-
-You need to change old configuration file from the one visible below:
-
-```yaml
-kind: configuration/postgresql
-name: default
-title: PostgreSQL
-provider: aws
-specification:
-  replication:
-    enabled: yes
-    user: your_postgresql_replication_user
-    password: your_postgresql_replication_password
-    max_wal_senders: 10 # (optional) - default value 5
-    wal_keep_segments: 34 # (optional) - default value 32
-```
-
-to one described below.
-
-old value | new value |
---- | --- |
-specification.replication.enabled | specification.extensions.enabled |
-specification.replication.user | specification.extensions.replication_user_name |
-specification.replication.password | specification.extensions.replication_user_password |
-specification.replication.max_wal_senders | defined in subgroups section |
-specification.replication.wal_keep_segments | defined in subgroups section |
-
-In order to configure PostgreSQL replication, add to your data.yaml a block similar to the one below to core section:
-
-```yaml
-kind: configuration/postgresql
-title: PostgreSQL
-name: default
-specification:
-  config_file:
-    parameter_groups:
-      ...
-      # This block is optional, you can use it to override default values
-      - name: REPLICATION
-        subgroups:
-          - name: Sending Server(s)
-            parameters:
-              - name: max_wal_senders
-                value: 10 # default value
-                comment: maximum number of simultaneously running WAL sender processes
-                when: replication # default value
-              - name: wal_keep_segments
-                value: 34 # default value
-                comment: number of WAL files held for standby servers
-                when: replication
-          - name: Standby Servers
-            parameters:
-              - name: hot_standby
-                value: 'on' # default value
-                comment: capability to run read-only queries on standby server
-                when: replication
-  extensions:
-    ...
-    replication:
-      enabled: true
-      replication_user_name: your_postgresql_replication_user
-      replication_user_password: your_postgresql_replication_password
-      use_repmgr: false
-      shared_preload_libraries: []
-    ...
-```
-
-If `enabled` is set to `yes` in `replication`, then Epiphany will automatically create cluster of primary and secondary server
-with replication user with name and password specified in data.yaml. This is only possible for configurations containing two
-PostgreSQL servers.
-
 ## How to set up PostgreSQL connection pooling
 
 PostgreSQL connection pooling in Epiphany is served by PgBouncer application. This might be added as a feature if needed.
@@ -554,6 +477,83 @@ To remove the extension from database, run:
 ```sql
 DROP EXTENSION IF EXISTS pgaudit;
 ```
+
+## How to configure PostgreSQL replication
+
+#### Attention
+
+In version 0.6.0 because of delivering full HA for PostgreSQL we needed to change configuration for PostgreSQL native
+replication.
+
+You need to change old configuration file from the one visible below:
+
+```yaml
+kind: configuration/postgresql
+name: default
+title: PostgreSQL
+provider: aws
+specification:
+  replication:
+    enabled: yes
+    user: your_postgresql_replication_user
+    password: your_postgresql_replication_password
+    max_wal_senders: 10 # (optional) - default value 5
+    wal_keep_segments: 34 # (optional) - default value 32
+```
+
+to one described below.
+
+old value | new value |
+--- | --- |
+specification.replication.enabled | specification.extensions.enabled |
+specification.replication.user | specification.extensions.replication_user_name |
+specification.replication.password | specification.extensions.replication_user_password |
+specification.replication.max_wal_senders | defined in subgroups section |
+specification.replication.wal_keep_segments | defined in subgroups section |
+
+In order to configure PostgreSQL replication, add to your data.yaml a block similar to the one below to core section:
+
+```yaml
+kind: configuration/postgresql
+title: PostgreSQL
+name: default
+specification:
+  config_file:
+    parameter_groups:
+      ...
+      # This block is optional, you can use it to override default values
+      - name: REPLICATION
+        subgroups:
+          - name: Sending Server(s)
+            parameters:
+              - name: max_wal_senders
+                value: 10 # default value
+                comment: maximum number of simultaneously running WAL sender processes
+                when: replication # default value
+              - name: wal_keep_segments
+                value: 34 # default value
+                comment: number of WAL files held for standby servers
+                when: replication
+          - name: Standby Servers
+            parameters:
+              - name: hot_standby
+                value: 'on' # default value
+                comment: capability to run read-only queries on standby server
+                when: replication
+  extensions:
+    ...
+    replication:
+      enabled: true
+      replication_user_name: your_postgresql_replication_user
+      replication_user_password: your_postgresql_replication_password
+      use_repmgr: false
+      shared_preload_libraries: []
+    ...
+```
+
+If `enabled` is set to `yes` in `replication`, then Epiphany will automatically create cluster of primary and secondary server
+with replication user with name and password specified in data.yaml. This is only possible for configurations containing two
+PostgreSQL servers.
 
 ## How to start working with OpenDistro for Elasticsearch
 

--- a/docs/home/howto/DATABASES.md
+++ b/docs/home/howto/DATABASES.md
@@ -505,9 +505,9 @@ to one described below.
 
 old value | new value |
 --- | --- |
-specification.replication.enabled | specification.extensions.enabled |
-specification.replication.user | specification.extensions.replication_user_name |
-specification.replication.password | specification.extensions.replication_user_password |
+specification.replication.enabled | specification.extensions.replication.enabled |
+specification.replication.user | specification.extensions.replication.replication_user_name |
+specification.replication.password | specification.extensions.replication.replication_user_password |
 specification.replication.max_wal_senders | defined in subgroups section |
 specification.replication.wal_keep_segments | defined in subgroups section |
 


### PR DESCRIPTION
- Set hot_standby via postgresql-epiphany.conf
- Adjust tests for hot_standby setting
- Do not run PGAudit tests when there is no logging host
- Fix Ruby constants deprecation warnings
- Move section with legacy replication down
- Fix setting paths for legacy replication in docs
- Treat PostgreSQL native replication as deprecated 