### PR TITLE
[v0.5] Epicli does not create PostgreSQL SET_BY_AUTOMATION values correctly

### DIFF
--- a/CHANGELOG-0.5.md
+++ b/CHANGELOG-0.5.md
@@ -6,6 +6,10 @@
 
 - [#1302](https://github.com/epiphany-platform/epiphany/issues/1302) - Ability to update control plane certificates expiration date
 
+### Fixed
+
+- [#1372](https://github.com/epiphany-platform/epiphany/issues/1372) - Epicli does not create PostgreSQL SET\_BY\_AUTOMATION values correctly
+
 ## [0.5.5] 2020-10-07
 
 ### Fixed

--- a/core/src/epicli/data/common/ansible/playbooks/roles/postgresql/templates/postgresql-epiphany.conf.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/postgresql/templates/postgresql-epiphany.conf.j2
@@ -19,7 +19,7 @@
 {%       for parameter in subgroup.parameters %}
 {#         use of 'parameter_value' is workaround since we don't have Jinja's {% do %} statement enabled (required to update dictionaries) #}
 {%         set parameter_value = parameter.value %}
-{%         if parameter.name == 'shared_preload_libraries' and parameter.value == 'SET_BY_AUTOMATION' %}
+{%         if parameter.name == 'shared_preload_libraries' and parameter.value|lower == 'autoconfigured' %}
 {%           set shared_preload_libraries = [] %}
 {#           shared_preload_libraries from runtime, including those that were set outside Epiphany managed config #}
 {%           if runtime_shared_preload_libraries is defined and runtime_shared_preload_libraries %}

--- a/core/src/epicli/data/common/ansible/playbooks/roles/postgresql/templates/postgresql-epiphany.conf.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/postgresql/templates/postgresql-epiphany.conf.j2
@@ -19,7 +19,7 @@
 {%       for parameter in subgroup.parameters %}
 {#         use of 'parameter_value' is workaround since we don't have Jinja's {% do %} statement enabled (required to update dictionaries) #}
 {%         set parameter_value = parameter.value %}
-{%         if parameter.name == 'shared_preload_libraries' and parameter.value|lower == 'autoconfigured' %}
+{%         if parameter.name == 'shared_preload_libraries' and parameter.value|upper in ['AUTOCONFIGURED', 'SET_BY_AUTOMATION'] %}
 {%           set shared_preload_libraries = [] %}
 {#           shared_preload_libraries from runtime, including those that were set outside Epiphany managed config #}
 {%           if runtime_shared_preload_libraries is defined and runtime_shared_preload_libraries %}

--- a/core/src/epicli/data/common/defaults/configuration/postgresql.yml
+++ b/core/src/epicli/data/common/defaults/configuration/postgresql.yml
@@ -23,7 +23,7 @@ specification:
           - name: Kernel Resource Usage
             parameters:
               - name: shared_preload_libraries
-                value: SET_BY_AUTOMATION
+                value: AUTOCONFIGURED
                 comment: set by automation
       - name: ERROR REPORTING AND LOGGING
         subgroups:


### PR DESCRIPTION
- Rename SET_BY_AUTOMATION to AUTOCONFIGURED for shared_preload_libraries