### PR TITLE
Installing node exporter and filebeat as daemonsets in custom namespaces

### DIFF
--- a/CHANGELOG-0.9.md
+++ b/CHANGELOG-0.9.md
@@ -11,6 +11,7 @@
 - [#1835](https://github.com/epiphany-platform/epiphany/issues/1835) - Automated tests may give false negative result for PGAudit
 - [#1409](https://github.com/epiphany-platform/epiphany/issues/1409) - custom_image_registry_address setting is not implemented
 - [#1280](https://github.com/epiphany-platform/epiphany/issues/1280) - [RHEL] Pgpool not showing Replication State
+- [#1833](https://github.com/epiphany-platform/epiphany/issues/1833) - DaemonSets of Node Exporter and Filebeat deploy in default namespace
 
 ### Updated
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 filebeat_helm_chart_file_name: filebeat-7.9.2.tgz
 filebeat_version: "7.9.2"
+# Use custom namespace for logging charts such as filebeat in case of k8s as cloud service.
+logging_chart_namespace: epi-logging

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/install-filebeat-as-daemonset.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/install-filebeat-as-daemonset.yml
@@ -26,7 +26,7 @@
 
     - name: Install Filebeat using custom Helm chart (custom-chart-values.yml)
       command: |
-        helm upgrade --install \
+        helm -n {{ logging_chart_namespace }} upgrade --install \
           -f {{ download_directory }}/custom-chart-values.yml \
           {{ specification.helm_chart_name }} \
-          {{ download_directory }}/{{ filebeat_helm_chart_file_name }}
+          {{ download_directory }}/{{ filebeat_helm_chart_file_name }} --create-namespace

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/uninstall-filebeat-as-daemonset.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/uninstall-filebeat-as-daemonset.yml
@@ -6,6 +6,4 @@
   become: false
   run_once: true
 
-  environment: { KUBECONFIG: "{{ vault_location }}/../kubeconfig" }
-
   command: helm uninstall {{ specification.helm_chart_name }}

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/uninstall-filebeat-as-daemonset.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/tasks/uninstall-filebeat-as-daemonset.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Uninstall Helm release "{{ specification.helm_chart_name }}"
+
+  delegate_to: localhost
+  become: false
+  run_once: true
+
+  environment: { KUBECONFIG: "{{ vault_location }}/../kubeconfig" }
+
+  command: helm uninstall {{ specification.helm_chart_name }}

--- a/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/defaults/main.yml
@@ -4,3 +4,5 @@ exporter:
   service:
     description: "Service that runs Prometheus Node Exporter"
     name: prometheus-node-exporter
+# Use custom namespace for monitoring charts such as node exporter in case of k8s as cloud service.
+monitoring_chart_namespace: epi-monitoring

--- a/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/tasks/install-node-exporter-as-daemonset.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/tasks/install-node-exporter-as-daemonset.yml
@@ -36,16 +36,16 @@
         - name: Install Node-Exporter's Helm chart (with custom values.yaml)
           delegate_to: localhost
           shell: |
-            helm upgrade --install \
+            helm -n {{ monitoring_chart_namespace }} upgrade --install \
               -f {{ download_directory }}/{{ specification.helm_chart_name }}_values.yaml \
               {{ specification.helm_chart_name }} \
-              {{ download_directory }}/{{ exporter_chart_file_name }}
+              {{ download_directory }}/{{ exporter_chart_file_name }} --create-namespace
 
     - when: not helm_chart_values_bool
     # ELSE
       block:
         - name: Install Node-Exporter's Helm chart (with default values.yaml)
           shell: |
-            helm upgrade --install \
+            helm -n {{ monitoring_chart_namespace }} upgrade --install \
               {{ specification.helm_chart_name }} \
-              {{ download_directory }}/{{ exporter_chart_file_name }}
+              {{ download_directory }}/{{ exporter_chart_file_name }} --create-namespace

--- a/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/tasks/uninstall-node-exporter-as-daemonset.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/tasks/uninstall-node-exporter-as-daemonset.yml
@@ -6,6 +6,4 @@
   become: false
   run_once: true
 
-  environment: { KUBECONFIG: "{{ vault_location }}/../kubeconfig" }
-
   command: helm uninstall {{ specification.helm_chart_name }}

--- a/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/tasks/uninstall-node-exporter-as-daemonset.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/tasks/uninstall-node-exporter-as-daemonset.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Uninstall Helm release "{{ filebeat_helm_chart_file_name }}"
+- name: Uninstall Helm release "{{ specification.helm_chart_name }}"
 
   delegate_to: localhost
   become: false
@@ -8,4 +8,4 @@
 
   environment: { KUBECONFIG: "{{ vault_location }}/../kubeconfig" }
 
-  command: helm uninstall {{ filebeat_helm_chart_file_name }}
+  command: helm uninstall {{ specification.helm_chart_name }}

--- a/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/tasks/uninstall-node-exporter-as-daemonset.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/tasks/uninstall-node-exporter-as-daemonset.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Uninstall Helm release "{{ filebeat_helm_chart_file_name }}"
+
+  delegate_to: localhost
+  become: false
+  run_once: true
+
+  environment: { KUBECONFIG: "{{ vault_location }}/../kubeconfig" }
+
+  command: helm uninstall {{ filebeat_helm_chart_file_name }}

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
@@ -5,17 +5,21 @@
   run_once: true
   environment: { KUBECONFIG: "{{ vault_location }}/../kubeconfig" }
   command: helm list --output json
-  register: helm_list_releases
+  register: helm_list
 
-- name: Check if exist filebeat release in default namespace, if exist set the filebeat release name
+- name: Check if filebeat release exist in default namespace and set facts
   set_fact:
-    filebeat_release_name: "{{ item.name }}"
-  when: item.name == specification.helm_chart_name
-  with_items: "{{ (helm_list_releases.stdout|from_json) }}"
+    filebeat_release_exists: >-
+      {{ _names | ternary(true, false) }}
+  vars:
+    _names: >-
+      {{ helm_list.stdout|from_json | map(attribute='name')
+                  | select('eq', specification.helm_chart_name)
+                  | list }}
 
 - name: Reinstall Filebeat as DaemonSet from default namespace to custom namespace for "k8s as cloud service"
   when:
-    - filebeat_release_name is defined
+    - filebeat_release_exists
     - k8s_as_cloud_service is defined
     - k8s_as_cloud_service
   block: 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
@@ -13,9 +13,10 @@
       {{ _names | ternary(true, false) }}
   vars:
     _names: >-
-      {{ helm_list.stdout|from_json | map(attribute='name')
-                  | select('eq', specification.helm_chart_name)
-                  | list }}
+      {{ helm_list.stdout | from_json 
+                          | map(attribute='name')
+                          | select('==', specification.helm_chart_name)
+                          | list }}
 
 - name: Reinstall Filebeat as DaemonSet from default namespace to custom namespace for "k8s as cloud service"
   when:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
@@ -1,22 +1,23 @@
 ---
-- name: Filebeat as DaemonSet | Get information about helm releases
+- name: Filebeat as DaemonSet | Prepare fact about helm release
   delegate_to: localhost
   become: false
   run_once: true
-  environment: { KUBECONFIG: "{{ vault_location }}/../kubeconfig" }
-  command: helm list --output json
-  register: helm_list
+  block:
+    - name: Get information about helm releases
+      command: helm list --output json
+      register: helm_list
 
-- name: Check if filebeat release exist in default namespace and set facts
-  set_fact:
-    filebeat_release_exists: >-
-      {{ _names | ternary(true, false) }}
-  vars:
-    _names: >-
-      {{ helm_list.stdout | from_json 
-                          | map(attribute='name')
-                          | select('==', specification.helm_chart_name)
-                          | list }}
+    - name: Check if filebeat release exist in default namespace and set fact
+      set_fact:
+        filebeat_release_exists: >-
+          {{ _names | ternary(true, false) }}
+      vars:
+        _names: >-
+          {{ helm_list.stdout | from_json 
+                              | map(attribute='name')
+                              | select('==', specification.helm_chart_name)
+                              | list }}
 
 - name: Reinstall Filebeat as DaemonSet from default namespace to custom namespace for "k8s as cloud service"
   when:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
@@ -4,12 +4,18 @@
   become: false
   run_once: true
   environment: { KUBECONFIG: "{{ vault_location }}/../kubeconfig" }
-  command: helm list
-  register: check_filebeat_release
+  command: helm list --output json
+  register: helm_list_releases
+
+- name: Check if exist filebeat release in default namespace, if exist set the filebeat release name
+  set_fact:
+    filebeat_release_name: "{{ item.name }}"
+  when: item.name == specification.helm_chart_name
+  with_items: "{{ (helm_list_releases.stdout|from_json) }}"
 
 - name: Reinstall Filebeat as DaemonSet from default namespace to custom namespace for "k8s as cloud service"
   when:
-    - specification.helm_chart_name in check_filebeat_release.stdout
+    - filebeat_release_name is defined
     - k8s_as_cloud_service is defined
     - k8s_as_cloud_service
   block: 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
@@ -16,7 +16,7 @@
       - "Installed version: {{ ansible_facts.packages['filebeat'][0].version }}"
       - "Target version: {{ filebeat_version }}"
 
-- name: Update Filebeat
+- name: Update Filebeat as system service
   when:
     - filebeat_version is version(ansible_facts.packages['filebeat'][0].version, '>=')
   block:
@@ -37,3 +37,16 @@
     - import_role:
         name: filebeat
         tasks_from: configure-filebeat
+
+- name: Reinstall Filebeat as DaemonSet from default to custom namespace for "k8s as cloud service"
+  when: k8s_as_cloud_service is defined and k8s_as_cloud_service
+  block:
+    - name: Include uninstall task for Filebeat as DaemonSet in default namespace for "k8s as cloud service"
+      include_role:
+        name: filebeat
+        tasks_from: uninstall-filebeat-as-daemonset.yml
+
+    - name: Include install task for Filebeat as DaemonSet in custom namespace for "k8s as cloud service"
+      include_role:
+        name: filebeat
+        tasks_from: install-filebeat-as-daemonset.yml

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
@@ -1,26 +1,50 @@
 ---
-- name: Filebeat | Get information about installed packages as facts
+- name: Filebeat as DaemonSet | Get information about helm releases
+  delegate_to: localhost
+  become: false
+  run_once: true
+  environment: { KUBECONFIG: "{{ vault_location }}/../kubeconfig" }
+  command: helm list
+  register: check_filebeat_release
+
+- name: Reinstall Filebeat as DaemonSet from default namespace to custom namespace for "k8s as cloud service"
+  when:
+    - specification.helm_chart_name in check_filebeat_release.stdout
+    - k8s_as_cloud_service is defined
+    - k8s_as_cloud_service
+  block: 
+    - name: Include uninstall task for Filebeat as DaemonSet in default namespace for "k8s as cloud service"
+      include_role:
+        name: filebeat
+        tasks_from: uninstall-filebeat-as-daemonset.yml
+
+    - name: Include install task for Filebeat as DaemonSet in custom namespace for "k8s as cloud service"
+      include_role:
+        name: filebeat
+        tasks_from: install-filebeat-as-daemonset.yml
+
+- name: Filebeat as System Service | Get information about installed packages as facts
   package_facts:
     manager: auto
   when: ansible_facts.packages is undefined
 
-- name: Filebeat | Test if filebeat package is installed
+- name: Filebeat as System Service | Test if filebeat package is installed
   assert:
     that: ansible_facts.packages['filebeat'] is defined
     fail_msg: filebeat package not found, nothing to update
     quiet: true
 
-- name: Filebeat | Print versions
+- name: Filebeat as System Service | Print versions
   debug:
     msg:
       - "Installed version: {{ ansible_facts.packages['filebeat'][0].version }}"
       - "Target version: {{ filebeat_version }}"
 
-- name: Update Filebeat as system service
+- name: Update Filebeat as System Service
   when:
     - filebeat_version is version(ansible_facts.packages['filebeat'][0].version, '>=')
   block:
-    - name: Filebeat | Backup configuration file (filebeat.yml)
+    - name: Filebeat as System Service | Backup configuration file (filebeat.yml)
       copy:
         remote_src: true
         src: /etc/filebeat/filebeat.yml
@@ -37,16 +61,3 @@
     - import_role:
         name: filebeat
         tasks_from: configure-filebeat
-
-- name: Reinstall Filebeat as DaemonSet from default to custom namespace for "k8s as cloud service"
-  when: k8s_as_cloud_service is defined and k8s_as_cloud_service
-  block:
-    - name: Include uninstall task for Filebeat as DaemonSet in default namespace for "k8s as cloud service"
-      include_role:
-        name: filebeat
-        tasks_from: uninstall-filebeat-as-daemonset.yml
-
-    - name: Include install task for Filebeat as DaemonSet in custom namespace for "k8s as cloud service"
-      include_role:
-        name: filebeat
-        tasks_from: install-filebeat-as-daemonset.yml

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
@@ -7,24 +7,25 @@
   include_vars:
     file: roles/node_exporter/vars/main.yml
 
-- name: Node Exporter as DaemonSet | Get information about helm releases
+- name: Node Exporter as DaemonSet | Prepare fact about helm release
   delegate_to: localhost
   become: false
   run_once: true
-  environment: { KUBECONFIG: "{{ vault_location }}/../kubeconfig" }
-  command: helm list --output json
-  register: helm_list
+  block:
+    - name: Get information about helm releases
+      command: helm list --output json
+      register: helm_list
 
-- name: Check if node exporter release exist in default namespace and set facts
-  set_fact:
-    node_exporter_release_exists: >-
-      {{ _names | ternary(true, false) }}
-  vars:
-    _names: >-
-      {{ helm_list.stdout | from_json 
-                          | map(attribute='name')
-                          | select('==', specification.helm_chart_name)
-                          | list }}
+    - name: Check if node exporter release exist in default namespace and set fact
+      set_fact:
+        node_exporter_release_exists: >-
+          {{ _names | ternary(true, false) }}
+      vars:
+        _names: >-
+          {{ helm_list.stdout | from_json 
+                              | map(attribute='name')
+                              | select('==', specification.helm_chart_name)
+                              | list }}
 
 - name: Reinstall Node Exporter as DaemonSet from default namespace to custom namespace for "k8s as cloud service"
   when:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
@@ -90,3 +90,16 @@
         enabled: true
         name: "{{ exporter.service.name }}.service"
         state: started
+
+- name: Reinstall Node Exporter as DaemonSet from default to custom namespace for "k8s as cloud service"
+  when: k8s_as_cloud_service is defined and k8s_as_cloud_service
+  block:
+    - name: Include uninstall task for Node Exporter as DaemonSet in default namespace for "k8s as cloud service"
+      include_role:
+        name: node_exporter
+        tasks_from: uninstall-node-exporter-as-daemonset.yml
+
+    - name: Include install task for Node Exporter as DaemonSet in custom namespace for "k8s as cloud service"
+      include_role:
+        name: node_exporter
+        tasks_from: install-node-exporter-as-daemonset.yml

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
@@ -1,4 +1,12 @@
 ---
+- name: Node Exporter | Include defaults from node_exporter role
+  include_vars:
+    file: roles/node_exporter/defaults/main.yml
+
+- name: Node Exporter | Include specification vars from node_exporter role
+  include_vars:
+    file: roles/node_exporter/vars/main.yml
+
 - name: Node Exporter as DaemonSet | Get information about helm releases
   delegate_to: localhost
   become: false
@@ -26,14 +34,6 @@
 - name: Node Exporter as System Service | Populate service facts
   service_facts:
   when: ansible_facts.services is undefined
-
-- name: Node Exporter as System Service | Include defaults from node_exporter role
-  include_vars:
-    file: roles/node_exporter/defaults/main.yml
-
-- name: Node Exporter as System Service | Include specification vars from node_exporter role
-  include_vars:
-    file: roles/node_exporter/vars/main.yml
 
 - name: Node Exporter as System Service | Test if node exporter service is configured
   assert:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
@@ -12,12 +12,18 @@
   become: false
   run_once: true
   environment: { KUBECONFIG: "{{ vault_location }}/../kubeconfig" }
-  command: helm list
-  register: check_node_exporter_release
+  command: helm list --output json
+  register: helm_list_releases
+
+- name: Check if exist node exporter release in default namespace, if exist set the node exporter release name
+  set_fact:
+    node_exporter_release_name: "{{ item.name }}"
+  when: item.name == specification.helm_chart_name
+  with_items: "{{ (helm_list_releases.stdout|from_json) }}"
 
 - name: Reinstall Node Exporter as DaemonSet from default namespace to custom namespace for "k8s as cloud service"
   when:
-    - specification.helm_chart_name in check_node_exporter_release.stdout
+    - node_exporter_release_name is defined
     - k8s_as_cloud_service is defined
     - k8s_as_cloud_service
   block: 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
@@ -13,17 +13,21 @@
   run_once: true
   environment: { KUBECONFIG: "{{ vault_location }}/../kubeconfig" }
   command: helm list --output json
-  register: helm_list_releases
+  register: helm_list
 
-- name: Check if exist node exporter release in default namespace, if exist set the node exporter release name
+- name: Check if node exporter release exist in default namespace and set facts
   set_fact:
-    node_exporter_release_name: "{{ item.name }}"
-  when: item.name == specification.helm_chart_name
-  with_items: "{{ (helm_list_releases.stdout|from_json) }}"
+    node_exporter_release_exists: >-
+      {{ _names | ternary(true, false) }}
+  vars:
+    _names: >-
+      {{ helm_list.stdout|from_json | map(attribute='name')
+                  | select('eq', specification.helm_chart_name)
+                  | list }}
 
 - name: Reinstall Node Exporter as DaemonSet from default namespace to custom namespace for "k8s as cloud service"
   when:
-    - node_exporter_release_name is defined
+    - node_exporter_release_exists
     - k8s_as_cloud_service is defined
     - k8s_as_cloud_service
   block: 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
@@ -21,9 +21,10 @@
       {{ _names | ternary(true, false) }}
   vars:
     _names: >-
-      {{ helm_list.stdout|from_json | map(attribute='name')
-                  | select('eq', specification.helm_chart_name)
-                  | list }}
+      {{ helm_list.stdout | from_json 
+                          | map(attribute='name')
+                          | select('==', specification.helm_chart_name)
+                          | list }}
 
 - name: Reinstall Node Exporter as DaemonSet from default namespace to custom namespace for "k8s as cloud service"
   when:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
@@ -1,42 +1,66 @@
 ---
-- name: Node Exporter | Populate service facts
+- name: Node Exporter as DaemonSet | Get information about helm releases
+  delegate_to: localhost
+  become: false
+  run_once: true
+  environment: { KUBECONFIG: "{{ vault_location }}/../kubeconfig" }
+  command: helm list
+  register: check_node_exporter_release
+
+- name: Reinstall Node Exporter as DaemonSet from default namespace to custom namespace for "k8s as cloud service"
+  when:
+    - specification.helm_chart_name in check_node_exporter_release.stdout
+    - k8s_as_cloud_service is defined
+    - k8s_as_cloud_service
+  block: 
+    - name: Include uninstall task for Node Exporter as DaemonSet in default namespace for "k8s as cloud service"
+      include_role:
+        name: node_exporter
+        tasks_from: uninstall-node-exporter-as-daemonset.yml
+
+    - name: Include install task for Node Exporter as DaemonSet in custom namespace for "k8s as cloud service"
+      include_role:
+        name: node_exporter
+        tasks_from: install-node-exporter-as-daemonset.yml
+
+- name: Node Exporter as System Service | Populate service facts
   service_facts:
   when: ansible_facts.services is undefined
 
-- name: Node Exporter | Include defaults from node_exporter role
+- name: Node Exporter as System Service | Include defaults from node_exporter role
   include_vars:
     file: roles/node_exporter/defaults/main.yml
 
-- name: Node Exporter | Include specification vars from node_exporter role
+- name: Node Exporter as System Service | Include specification vars from node_exporter role
   include_vars:
     file: roles/node_exporter/vars/main.yml
 
-- name: Node Exporter | Test if node exporter service is configured
+- name: Node Exporter as System Service | Test if node exporter service is configured
   assert:
     that: "'{{ exporter.service.name }}.service' in ansible_facts.services"
     fail_msg: "{{ exporter.service.name }} service is not found"
     quiet: true
 
-- name: Node Exporter | Set exporter_file_name fact
+- name: Node Exporter as System Service | Set exporter_file_name fact
   set_fact:
     exporter_file_name: "node_exporter-{{ exporter.version }}.linux-amd64.tar.gz"
 
-- name: Node Exporter | Collect version
+- name: Node Exporter as System Service | Collect version
   shell: >-
     /opt/node_exporter/node_exporter --version 2>&1
   register: exporter_current_version_out
 
-- name: Node Exporter | Set exporter_current_version fact
+- name: Node Exporter as System Service | Set exporter_current_version fact
   set_fact:
     exporter_current_version: "{{ exporter_current_version_out.stdout_lines[0] | regex_replace('^.*version ([0-9.]+) .*$', '\\1') }}"
 
-- name: Node Exporter | Print version
+- name: Node Exporter as System Service | Print version
   debug:
     msg:
       - "Installed version: {{ exporter_current_version }}"
       - "Target version: {{ exporter.version }}"
 
-- name: Node Exporter | Upgrade block
+- name: Node Exporter as System Service | Upgrade block
   when: exporter.version != exporter_current_version
   block:
     - name: Node Exporter | Download binaries
@@ -46,17 +70,17 @@
       vars:
         file_name: "{{ exporter_file_name }}"
 
-    - name: Node Exporter | Stop exporter
+    - name: Node Exporter as System Service | Stop exporter
       systemd:
         name: "{{ exporter.service.name }}.service"
         state: stopped
 
-    - name: Node Exporter | Remove /opt/node_exporter directory
+    - name: Node Exporter as System Service | Remove /opt/node_exporter directory
       file:
         path: /opt/node_exporter
         state: absent
 
-    - name: Node Exporter | Create empty /opt/node_exporter directory
+    - name: Node Exporter as System Service | Create empty /opt/node_exporter directory
       file:
         path: /opt/node_exporter
         owner: root
@@ -64,7 +88,7 @@
         mode: '0750'
         state: directory
 
-    - name: Node Exporter | Unpack binary
+    - name: Node Exporter as System Service | Unpack binary
       unarchive:
         remote_src: true
         src: "{{ download_directory }}/{{ exporter_file_name }}"
@@ -76,7 +100,7 @@
         group: node_exporter
       check_mode: false
 
-    - name: Node Exporter | Update systemd service configuration
+    - name: Node Exporter as System Service | Update systemd service configuration
       template:
         src: roles/node_exporter/templates/prometheus-node-exporter.service.j2
         dest: "/etc/systemd/system/{{ exporter.service.name }}.service"
@@ -84,22 +108,9 @@
         group: root
         mode: '0644'
 
-    - name: Node Exporter | Start exporter
+    - name: Node Exporter as System Service | Start exporter
       systemd:
         daemon_reload: true
         enabled: true
         name: "{{ exporter.service.name }}.service"
         state: started
-
-- name: Reinstall Node Exporter as DaemonSet from default to custom namespace for "k8s as cloud service"
-  when: k8s_as_cloud_service is defined and k8s_as_cloud_service
-  block:
-    - name: Include uninstall task for Node Exporter as DaemonSet in default namespace for "k8s as cloud service"
-      include_role:
-        name: node_exporter
-        tasks_from: uninstall-node-exporter-as-daemonset.yml
-
-    - name: Include install task for Node Exporter as DaemonSet in custom namespace for "k8s as cloud service"
-      include_role:
-        name: node_exporter
-        tasks_from: install-node-exporter-as-daemonset.yml

--- a/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
@@ -108,6 +108,8 @@
         name: upgrade
         tasks_from: filebeat
       when: groups.logging is defined # do not upgrade if there is legacy Elasticsearch (v6)
+  environment:
+    KUBECONFIG: "{{ kubeconfig.local }}"
 
 - hosts: logging
   become: true
@@ -165,3 +167,5 @@
     - import_role:
         name: upgrade
         tasks_from: node-exporter
+  environment:
+    KUBECONFIG: "{{ kubeconfig.local }}"


### PR DESCRIPTION
Fix related to bug : #1833 

- Installing Node Exporter and FileBeat as DaemonSets in custom namespaces.
- DaemonSets for k8s as cloud service