### PR TITLE
Upgrade rabbitmq

### DIFF
--- a/CHANGELOG-0.9.md
+++ b/CHANGELOG-0.9.md
@@ -20,6 +20,7 @@
 
 - [#1770](https://github.com/epiphany-platform/epiphany/issues/1770) - Upgrade Filebeat to the latest version (7.9.2)
 - [#1848](https://github.com/epiphany-platform/epiphany/issues/1848) - Update Ansible to v2.8.17
+- [#1854](https://github.com/epiphany-platform/epiphany/issues/1854) - Upgrade component to the latest version: RabbitMQ
 
 ### Breaking changes
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/Debian.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/Debian.yml
@@ -1,5 +1,6 @@
+---
 - name: Install Rabbitmq packages
-  apt: 
+  apt:
     name:
       - init-system-helpers
       - socat
@@ -7,5 +8,5 @@
       - adduser
       - logrotate
       - rabbitmq-server
-    update_cache: yes 
+    update_cache: yes
     state: present

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/Debian.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/Debian.yml
@@ -1,4 +1,4 @@
-- name: Install Rabitmq packages
+- name: Install Rabbitmq packages
   apt: 
     name:
       - init-system-helpers

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/Debian.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/Debian.yml
@@ -3,7 +3,7 @@
     name:
       - init-system-helpers
       - socat
-      - erlang-nox
+      - erlang-nox=1:23.1-1
       - adduser
       - logrotate
       - rabbitmq-server

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/Debian.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/Debian.yml
@@ -4,7 +4,7 @@
     name:
       - init-system-helpers
       - socat
-      - erlang-nox=1:23.1*
+      - erlang-nox=1:23.1.*
       - adduser
       - logrotate
       - rabbitmq-server=3.8.9*

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/RedHat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/RedHat.yml
@@ -3,6 +3,8 @@
     name:
       - socat
       - logrotate
-      - erlang-21.3.* # order matters, check RabbitMQ/Erlang version compatibility matrix before modification
-      - rabbitmq-server-3.8.3
+      # order matters, check RabbitMQ/Erlang version compatibility matrix before modification
+      # https://www.rabbitmq.com/which-erlang.html#compatibility-matrix
+      - erlang-23.*
+      - rabbitmq-server-3.8.9
     state: present

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/RedHat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/RedHat.yml
@@ -4,7 +4,6 @@
       - socat
       - logrotate
       # order matters, check RabbitMQ/Erlang version compatibility matrix before modification
-      # https://www.rabbitmq.com/which-erlang.html#compatibility-matrix
-      - erlang-23.*
+      - erlang-23.1.*
       - rabbitmq-server-3.8.9
     state: present

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/RedHat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/RedHat.yml
@@ -1,3 +1,4 @@
+---
 - name: Install Rabbitmq packages
   yum:
     name:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/configure-rabbitmq.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/configure-rabbitmq.yml
@@ -38,7 +38,7 @@
     prefix: /usr/lib/rabbitmq
     state: enabled
     new_only: no
-  with_items: "{{ specification.rabbitmq_plugins }}"
+  loop: "{{ specification.rabbitmq_plugins }}"
 
 - name: Restart RabbitMQ
   service: name=rabbitmq-server state=restarted

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/cookie-setup/master.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/cookie-setup/master.yml
@@ -1,12 +1,11 @@
 ---
-
 - name: Set default value for user defined cookie variable
-  set_fact: 
+  set_fact:
     is_cookie_user_defined: False
   changed_when: false
 
 - name: Check if cookie is user defined
-  set_fact: 
+  set_fact:
     is_cookie_user_defined: True
   when:
     - specification is defined
@@ -15,9 +14,9 @@
   changed_when: false
 
 - name: Set cookie variable if user defined
-  set_fact: 
+  set_fact:
     erlang_cookie: "{{ specification.cluster.cookie }}"
-  when: is_cookie_user_defined == True
+  when: is_cookie_user_defined | bool
   changed_when: false
 
 - name: Check that the .erlang.cookie file exists on master
@@ -26,32 +25,32 @@
   register: stat_result
   changed_when: false
 
-- name: Read cookie file if exists 
-  shell: cat /var/lib/rabbitmq/.erlang.cookie
+- name: Read cookie file if exists
+  command: cat /var/lib/rabbitmq/.erlang.cookie
   become: yes
   register: cookie_file_content
   changed_when: false
   when:
-    - is_cookie_user_defined == False
-    - stat_result.stat.exists == True 
+    - not (is_cookie_user_defined | bool)
+    - stat_result.stat.exists | bool
 
 - name: Set erlang_cookie variable
-  set_fact: 
+  set_fact:
     erlang_cookie: "{{ cookie_file_content.stdout }}"
   changed_when: false
-  when: 
-    - is_cookie_user_defined == False
-    - stat_result.stat.exists == True 
+  when:
+    - not (is_cookie_user_defined | bool)
+    - stat_result.stat.exists | bool
     - cookie_file_content is defined
 
-- name: Generate cookie on RabbitMQ master if not user defined and not exist 
-  set_fact: 
+- name: Generate cookie on RabbitMQ master if not user defined and not exist
+  set_fact:
     erlang_cookie: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}"
   changed_when: false
-  when: 
-    - is_cookie_user_defined == False
+  when:
+    - not (is_cookie_user_defined | bool)
     - groups['rabbitmq'][0] == inventory_hostname
-    - stat_result.stat.exists == False 
+    - not (stat_result.stat.exists | bool)
 
 - name: Update RabbitMQ erlang cookie
   template:
@@ -64,4 +63,4 @@
 
 - name: Restart RabbitMQ
   service: name=rabbitmq-server state=restarted
-  when: cookie.changed or stat_result.stat.exists == False 
+  when: cookie.changed or not (stat_result.stat.exists | bool)

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/cookie-setup/nodes.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/cookie-setup/nodes.yml
@@ -1,14 +1,13 @@
 ---
-
 - name: Read cookie from RabbitMQ master
-  shell: cat /var/lib/rabbitmq/.erlang.cookie
+  command: cat /var/lib/rabbitmq/.erlang.cookie
   become: yes
   register: cookie_file_content
   delegate_to: "{{ groups['rabbitmq'][0] }}"
   changed_when: false
 
 - name: Set erlang_cookie variable
-  set_fact: 
+  set_fact:
     erlang_cookie: "{{ cookie_file_content.stdout }}"
   when: cookie_file_content is defined
   changed_when: false

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/join-cluster.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/join-cluster.yml
@@ -3,16 +3,18 @@
   set_fact:
     rabbitmq_master: "{{ groups['rabbitmq'][0] }}"
 
-- name: Stop rabbitmq
-  become: yes
-  command: rabbitmqctl stop_app
+- name: Join nodes to the cluster
   when: rabbitmq_master != inventory_hostname
+  block:
+    - name: Stop rabbitmq
+      become: yes
+      command: rabbitmqctl stop_app
 
-- name: Add node to cluster
-  become: yes
-  command: rabbitmqctl join_cluster rabbit@{{ rabbitmq_master.split('.')[0] }}
-  when: rabbitmq_master != inventory_hostname
+    - name: Add node to cluster
+      become: yes
+      command: rabbitmqctl join_cluster rabbit@{{ rabbitmq_master.split('.')[0] }}
 
-- name: Start rabbitmq
-  become: yes
-  command: rabbitmqctl start_app
+    - name: Start rabbitmq
+      become: yes
+      command: rabbitmqctl start_app
+

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/set-ulimits.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/set-ulimits.yml
@@ -2,9 +2,9 @@
 - name: Configure system settings, file descriptors and number of threads for RabbitMQ
   pam_limits:
     domain: "{{ specification.rabbitmq_user }}"
-    limit_type: "{{item.limit_type}}"
-    limit_item: "{{item.limit_item}}"
-    value: "{{item.value}}"
+    limit_type: "{{ item.limit_type }}"
+    limit_item: "{{ item.limit_item }}"
+    value: "{{ item.value }}"
   loop:
     - {
         limit_type: "-",

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/set-ulimits.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/set-ulimits.yml
@@ -5,7 +5,7 @@
     limit_type: "{{item.limit_type}}"
     limit_item: "{{item.limit_item}}"
     value: "{{item.value}}"
-  with_items:
+  loop:
     - {
         limit_type: "-",
         limit_item: "nofile",

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
@@ -34,7 +34,7 @@ ebtables
 elasticsearch-curator-5.8.1
 elasticsearch-oss-6.8.5 # for elasticsearch role
 elasticsearch-oss-7.9.1 # for opendistroforelasticsearch & logging roles
-erlang-21.3.8.7
+erlang-23.1.4
 ethtool
 filebeat-7.9.2
 firewalld
@@ -89,7 +89,7 @@ python-slip-dbus # for firewalld
 python-ipaddress
 python-backports
 quota # for nfs-utils
-rabbitmq-server-3.8.3
+rabbitmq-server-3.8.9
 rh-haproxy18
 rh-haproxy18-haproxy-syspaths
 postgresql10-server
@@ -177,7 +177,7 @@ brainsam/pgbouncer:1.12
 # TODO remove?
 jboss/keycloak:4.8.3.Final
 jboss/keycloak:9.0.0
-rabbitmq:3.8.3
+rabbitmq:3.8.9
 # K8s upgrade
 ## v1.14.6
 k8s.gcr.io/kube-apiserver:v1.14.6

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
@@ -34,7 +34,7 @@ ebtables
 elasticsearch-curator-5.8.1
 elasticsearch-oss-6.8.5 # for elasticsearch role
 elasticsearch-oss-7.9.1 # for opendistroforelasticsearch & logging roles
-erlang-23.1.4
+erlang-23.1.4 # must be compatible with rabbitmq version
 ethtool
 filebeat-7.9.2
 firewalld

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
@@ -33,7 +33,7 @@ ebtables
 elasticsearch-curator-5.8.1
 elasticsearch-oss-6.8.5 # for elasticsearch role
 elasticsearch-oss-7.9.1 # for opendistroforelasticsearch & logging roles
-erlang-23.1.4
+erlang-23.1.4 # must be compatible with rabbitmq version
 ethtool
 filebeat-7.9.2
 firewalld

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
@@ -33,7 +33,7 @@ ebtables
 elasticsearch-curator-5.8.1
 elasticsearch-oss-6.8.5 # for elasticsearch role
 elasticsearch-oss-7.9.1 # for opendistroforelasticsearch & logging roles
-erlang-21.3.8.7
+erlang-23.1.4
 ethtool
 filebeat-7.9.2
 firewalld
@@ -86,7 +86,7 @@ python-psycopg2
 python-setuptools
 python-slip-dbus # for firewalld
 quota # for nfs-utils
-rabbitmq-server-3.8.3
+rabbitmq-server-3.8.9
 rh-haproxy18
 rh-haproxy18-haproxy-syspaths
 postgresql10-server
@@ -174,7 +174,7 @@ brainsam/pgbouncer:1.12
 # TODO remove?
 jboss/keycloak:4.8.3.Final
 jboss/keycloak:9.0.0
-rabbitmq:3.8.3
+rabbitmq:3.8.9
 # K8s upgrade
 ## v1.14.6
 k8s.gcr.io/kube-apiserver:v1.14.6

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/add-repositories.sh
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/add-repositories.sh
@@ -13,8 +13,10 @@ wget -qO - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
 
 wget -qO - https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc | apt-key add -
-echo "deb http://dl.bintray.com/rabbitmq-erlang/debian bionic erlang-21.x" | tee /etc/apt/sources.list.d/erlang-21.x.list
 echo "deb https://dl.bintray.com/rabbitmq/debian bionic main" | tee /etc/apt/sources.list.d/rabbitmq.list
+
+wget -O- https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | apt-key add -
+echo "deb https://packages.erlang-solutions.com/ubuntu bionic contrib" | tee -a /etc/apt/sources.list.d/rabbitmq.list
 
 wget -qO -  https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" | tee /etc/apt/sources.list.d/docker-ce.list
@@ -23,7 +25,7 @@ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
 echo "deb https://artifacts.elastic.co/packages/oss-7.x/apt stable main" | tee /etc/apt/sources.list.d/elastic-7.x.list
 
 wget -qO - https://d3g5vo6xdbdb9a.cloudfront.net/GPG-KEY-opendistroforelasticsearch | sudo apt-key add -
-echo "deb https://d3g5vo6xdbdb9a.cloudfront.net/apt stable main" | tee -a   /etc/apt/sources.list.d/opendistroforelasticsearch.list
+echo "deb https://d3g5vo6xdbdb9a.cloudfront.net/apt stable main" | tee -a /etc/apt/sources.list.d/opendistroforelasticsearch.list
 
 wget -qO - https://dl.2ndquadrant.com/gpg-key.asc | apt-key add -
 echo "deb https://dl.2ndquadrant.com/default/release/apt bionic-2ndquadrant main" | tee -a /etc/apt/sources.list.d/2ndquadrant-dl-default-release.list

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/add-repositories.sh
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/add-repositories.sh
@@ -13,10 +13,8 @@ wget -qO - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
 
 wget -qO - https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc | apt-key add -
-echo "deb https://dl.bintray.com/rabbitmq/debian bionic main" | tee /etc/apt/sources.list.d/rabbitmq.list
-
-wget -O- https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | apt-key add -
-echo "deb https://packages.erlang-solutions.com/ubuntu bionic contrib" | tee -a /etc/apt/sources.list.d/rabbitmq.list
+echo "deb http://dl.bintray.com/rabbitmq-erlang/debian bionic erlang-23.x" | tee /etc/apt/sources.list.d/erlang-21.x.list
+echo "deb https://dl.bintray.com/rabbitmq/debian bionic main" | tee -a /etc/apt/sources.list.d/rabbitmq.list
 
 wget -qO -  https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" | tee /etc/apt/sources.list.d/docker-ce.list

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
@@ -15,7 +15,7 @@ ebtables
 elasticsearch-curator 5.8.1
 elasticsearch-oss 6.8.5 # for elasticsearch role
 elasticsearch-oss 7.9.1 # for opendistroforelasticsearch & logging roles
-erlang-nox 1:23.1 # must be compatible with rabbitmq version
+erlang-nox 1:23.1.4 # must be compatible with rabbitmq version
 ethtool
 filebeat 7.9.2
 firewalld

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
@@ -47,7 +47,7 @@ python-pip
 python-psycopg2
 python-selinux
 python-setuptools
-rabbitmq-server 3.8.3
+rabbitmq-server 3.8.9
 smbclient
 samba-common
 smbclient
@@ -203,7 +203,7 @@ brainsam/pgbouncer:1.12
 # TODO remove?
 jboss/keycloak:4.8.3.Final
 jboss/keycloak:9.0.0
-rabbitmq:3.8.3
+rabbitmq:3.8.9
 # K8s upgrade
 ## v1.14.6
 k8s.gcr.io/kube-apiserver:v1.14.6

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
@@ -15,7 +15,7 @@ ebtables
 elasticsearch-curator 5.8.1
 elasticsearch-oss 6.8.5 # for elasticsearch role
 elasticsearch-oss 7.9.1 # for opendistroforelasticsearch & logging roles
-erlang-nox
+erlang-nox 1:23.1 # must be compatible with rabbitmq version
 ethtool
 filebeat 7.9.2
 firewalld

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/handlers/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart RabbitMQ service
+  service:
+    name: rabbitmq-server
+    state: restarted

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/filebeat.yml
@@ -14,7 +14,7 @@
           {{ _names | ternary(true, false) }}
       vars:
         _names: >-
-          {{ helm_list.stdout | from_json 
+          {{ helm_list.stdout | from_json
                               | map(attribute='name')
                               | select('==', specification.helm_chart_name)
                               | list }}
@@ -24,7 +24,7 @@
     - filebeat_release_exists
     - k8s_as_cloud_service is defined
     - k8s_as_cloud_service
-  block: 
+  block:
     - name: Include uninstall task for Filebeat as DaemonSet in default namespace for "k8s as cloud service"
       include_role:
         name: filebeat

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kafka/update-properties.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kafka/update-properties.yml
@@ -1,13 +1,13 @@
 ---
 - name: Check if current_kafka_version property is defined
   shell: >-
-    set -o pipefail && 
+    set -o pipefail &&
     grep "^CURRENT_KAFKA_VERSION" /opt/kafka/config/server.properties
   register: current_kafka_version_property
   failed_when:
     - result.rc == 2
   changed_when: False
-  args: 
+  args:
     executable: /bin/bash
 
 - name: Add current_kafka_version property

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/reconfigure-rabbitmq-app.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/kubernetes/reconfigure-rabbitmq-app.yml
@@ -7,8 +7,9 @@
   block:
     - name: after-patching | Get rabbitmq namespace
       shell: |-
-        kubectl get statefulsets.apps --all-namespaces -o=jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.spec.template.spec.containers[].image}{"\n"}{end}'|
-        awk '/rabbitmq/ {print $1}'
+        kubectl get statefulsets.apps --all-namespaces \
+          -o=jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.spec.template.spec.containers[].image}{"\n"}{end}' \
+        | awk '/rabbitmq/ {print $1}'
       changed_when: false
       register: rabbit_mq_namespace
       args:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
@@ -22,7 +22,7 @@
           {{ _names | ternary(true, false) }}
       vars:
         _names: >-
-          {{ helm_list.stdout | from_json 
+          {{ helm_list.stdout | from_json
                               | map(attribute='name')
                               | select('==', specification.helm_chart_name)
                               | list }}
@@ -32,7 +32,7 @@
     - node_exporter_release_exists
     - k8s_as_cloud_service is defined
     - k8s_as_cloud_service
-  block: 
+  block:
     - name: Include uninstall task for Node Exporter as DaemonSet in default namespace for "k8s as cloud service"
       include_role:
         name: node_exporter

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: "rabbitmq/{{ ansible_os_family }}.yml"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq/Debian.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install Rabbitmq packages
   apt:
     name:
-      - erlang-nox=1:23.1*
+      - erlang-nox=1:23.1.*
       - rabbitmq-server=3.8.9*
     update_cache: yes
     state: present

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq/Debian.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq/Debian.yml
@@ -2,11 +2,9 @@
 - name: Install Rabbitmq packages
   apt:
     name:
-      - init-system-helpers
-      - socat
       - erlang-nox=1:23.1*
-      - adduser
-      - logrotate
       - rabbitmq-server=3.8.9*
     update_cache: yes
     state: present
+  notify:
+    - Restart RabbitMQ service

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq/Debian.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq/Debian.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install Rabbitmq packages
+- name: RabbitMQ | Update packages
   apt:
     name:
       - erlang-nox=1:23.1.*

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq/RedHat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq/RedHat.yml
@@ -1,0 +1,9 @@
+---
+- name: RabbitMQ | Update packages
+  yum:
+    name:
+      - erlang-23.1.*
+      - rabbitmq-server-3.8.9
+    state: present
+  notify:
+    - Restart RabbitMQ service

--- a/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/upgrade.yml
@@ -152,6 +152,14 @@
         tasks_from: kafka
       vars: { lock_file: /var/tmp/kafka-upgrade-in-progress.flag }
 
+- hosts: rabbitmq
+  become: true
+  become_method: sudo
+  tasks:
+    - import_role:
+        name: upgrade
+        tasks_from: rabbitmq
+
 - hosts: haproxy
   become: true
   become_method: sudo

--- a/core/src/epicli/data/common/defaults/configuration/applications.yml
+++ b/core/src/epicli/data/common/defaults/configuration/applications.yml
@@ -27,7 +27,7 @@ specification:
 
   - name: rabbitmq
     enabled: false
-    image_path: rabbitmq:3.8.3
+    image_path: rabbitmq:3.8.9
     use_local_image_registry: true
     #image_pull_secret_name: regcred # optional
     service:

--- a/core/src/epicli/data/common/defaults/configuration/image-registry.yml
+++ b/core/src/epicli/data/common/defaults/configuration/image-registry.yml
@@ -10,8 +10,8 @@ specification:
     generic:
       - name: "jboss/keycloak:9.0.0"
         file_name: keycloak-9.0.0.tar
-      - name: "rabbitmq:3.8.3"
-        file_name: rabbitmq-3.8.3.tar
+      - name: "rabbitmq:3.8.9"
+        file_name: rabbitmq-3.8.9.tar
       - name: "apacheignite/ignite:2.5.0"
         file_name: ignite-2.5.0.tar
       - name: "kubernetesui/dashboard:v2.0.3"

--- a/core/src/epicli/data/common/defaults/configuration/rabbitmq.yml
+++ b/core/src/epicli/data/common/defaults/configuration/rabbitmq.yml
@@ -2,7 +2,7 @@ kind: configuration/rabbitmq
 title: "RabbitMQ"
 name: default
 specification:
-  version: 3.8.3
+  version: 3.8.9
   rabbitmq_user: rabbitmq
   rabbitmq_group: rabbitmq
 

--- a/core/src/epicli/data/common/defaults/configuration/rabbitmq.yml
+++ b/core/src/epicli/data/common/defaults/configuration/rabbitmq.yml
@@ -2,7 +2,6 @@ kind: configuration/rabbitmq
 title: "RabbitMQ"
 name: default
 specification:
-  version: 3.8.9
   rabbitmq_user: rabbitmq
   rabbitmq_group: rabbitmq
 

--- a/docs/home/COMPONENTS.md
+++ b/docs/home/COMPONENTS.md
@@ -13,7 +13,7 @@ Note that versions are default versions and can be changed in certain cases thro
 | Canal                     | 3.15.0  | https://github.com/projectcalico/calico               | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Kafka                     | 2.3.1   | https://github.com/apache/kafka                       | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Zookeeper                 | 3.4.12  | https://github.com/apache/zookeeper                   | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
-| RabbitMQ                  | 3.8.3   | https://github.com/rabbitmq/rabbitmq-server           | [Mozilla Public License](https://www.mozilla.org/en-US/MPL/)      |
+| RabbitMQ                  | 3.8.9   | https://github.com/rabbitmq/rabbitmq-server           | [Mozilla Public License](https://www.mozilla.org/en-US/MPL/)      |
 | Docker-ce                 | 18.09   | https://github.com/docker/docker-ce/                  | [Apache License](https://www.apache.org/licenses/LICENSE-1.0)     |
 | KeyCloak                  | 9.0.0   | https://github.com/keycloak/keycloak                  | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Elasticsearch OSS         | 7.9.1   | https://github.com/elastic/elasticsearch              | https://github.com/elastic/elasticsearch/blob/master/LICENSE.txt  |


### PR DESCRIPTION
Task #1854 

* updated rabbitmq and erlang according to [compatibility matrix](https://www.rabbitmq.com/which-erlang.html#compatibility-matrix)
* added upgrade part for rabbitmq
* rabbitmq installed in k8s can be updated by `epicli apply`
* fixed most of linter warnings related to rabbitmq