### PR TITLE
Kafka - configurable javax.net.debug setting 

### DIFF
--- a/CHANGELOG-0.9.md
+++ b/CHANGELOG-0.9.md
@@ -17,6 +17,7 @@
 - [#1872](https://github.com/epiphany-platform/epiphany/issues/1872) - pythonPath in launch.json is not supported
 - [#1868](https://github.com/epiphany-platform/epiphany/issues/1868) - Repository host runs Ubuntu on Azure/RHEL cluster
 - [#1875](https://github.com/epiphany-platform/epiphany/issues/1875) - epicli upgrade fails when there is no kubernetes_master group in inventory
+- [#1834](https://github.com/epiphany-platform/epiphany/issues/1834) - Kafka - Disable debug logging and make this option configurable
 
 ### Updated
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kafka/templates/kafka.service.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kafka/templates/kafka.service.j2
@@ -2,6 +2,12 @@
 Description=Kafka Daemon
 After=zookeeper.service
 
+{% if specification.kafka_var.javax_net_debug is defined %}
+{%      set javax_debug = '-Djavax.net.debug=' ~ specification.kafka_var.javax_net_debug %}
+{% else %}
+{%      set javax_debug = '' %}
+{% endif %}
+
 [Service]
 Type=simple
 User=kafka
@@ -11,9 +17,9 @@ Restart=on-failure
 Environment="KAFKA_HEAP_OPTS={{ specification.kafka_var.heap_opts }}"
 Environment="LOG_DIR={{ specification.kafka_var.log_dir }}"
 {% if exporter.stat.exists %}
-Environment="KAFKA_OPTS=-Djavax.net.debug=all -javaagent:{{ specification.prometheus_jmx_path }}={{ specification.prometheus_jmx_exporter_web_listen_port }}:{{ specification.prometheus_jmx_config }}"
+Environment="KAFKA_OPTS={{ javax_debug }} -javaagent:{{ specification.prometheus_jmx_path }}={{ specification.prometheus_jmx_exporter_web_listen_port }}:{{ specification.prometheus_jmx_config }}"
 {% else %}
-Environment="KAFKA_OPTS=-Djavax.net.debug=all"
+Environment="KAFKA_OPTS={{ javax_debug }}"
 {% endif %}
 Environment="KAFKA_JMX_OPTS={{ specification.kafka_var.jmx_opts }}"
 ExecStart=/opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/server.properties

--- a/core/src/epicli/data/common/defaults/configuration/kafka.yml
+++ b/core/src/epicli/data/common/defaults/configuration/kafka.yml
@@ -6,6 +6,7 @@ specification:
     enabled: True
     admin: kafka
     admin_pwd: epiphany
+    # javax_net_debug: all # uncomment to activate debugging, other debug options: https://colinpaice.blog/2020/04/05/using-java-djavax-net-debug-to-examine-data-flows-including-tls/
     security:
       ssl:
         enabled: False


### PR DESCRIPTION
Modified kafka.service.j2 to handle configurable `javax_net_debug` which by default will be disabled (commented). 

Tested on ubuntu onprem. 