### PR TITLE
Fix rabbitmq installation

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/join-cluster.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/join-cluster.yml
@@ -3,7 +3,7 @@
   command: rabbitmqctl {{ long_names }} stop_app
 
 - name: Add node to cluster
-  command: rabbitmqctl {{ long_names }} join_cluster rabbit@{{ rabbitmq_master }}
+  command: rabbitmqctl {{ long_names }} join_cluster rabbit@{{ rabbitmq_master.split('.')[0] }}
 
 - name: Start application
   command: rabbitmqctl {{ long_names }} start_app

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/join-cluster.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/join-cluster.yml
@@ -1,9 +1,9 @@
 ---
 - name: Stop application
-  command: rabbitmqctl stop_app
+  command: rabbitmqctl {{ long_names }} stop_app
 
 - name: Add node to cluster
-  command: rabbitmqctl join_cluster rabbit@{{ rabbitmq_master.split('.')[0] }}
+  command: rabbitmqctl {{ long_names }} join_cluster rabbit@{{ rabbitmq_master }}
 
 - name: Start application
-  command: rabbitmqctl start_app
+  command: rabbitmqctl {{ long_names }} start_app

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/join-cluster.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/join-cluster.yml
@@ -1,9 +1,9 @@
 ---
 - name: Stop application
-  command: rabbitmqctl {{ long_names }} stop_app
+  command: rabbitmqctl stop_app
 
 - name: Add node to cluster
-  command: rabbitmqctl {{ long_names }} join_cluster rabbit@{{ rabbitmq_master.split('.')[0] }}
+  command: rabbitmqctl join_cluster rabbit@{{ rabbitmq_master.split('.')[0] }}
 
 - name: Start application
-  command: rabbitmqctl {{ long_names }} start_app
+  command: rabbitmqctl start_app

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
-- name: Set facts
+- name: Set rabbitmq_master fact
   set_fact:
     rabbitmq_master: "{{ groups['rabbitmq'][0] }}"
-    long_names: "{% if specification.rabbitmq_use_longname|bool %}--longnames{% else %}{% endif %}"
 
 - include_tasks: "install-packages-{{ ansible_os_family | lower }}.yml"
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
-- name: Set rabbitmq_master fact
+- name: Set facts
   set_fact:
     rabbitmq_master: "{{ groups['rabbitmq'][0] }}"
+    long_names: "{% if specification.rabbitmq_use_longname|bool %}--longnames{% else %}{% endif %}"
 
 - include_tasks: "install-packages-{{ ansible_os_family | lower }}.yml"
 
@@ -9,6 +10,13 @@
   when:
     - specification.cluster.is_clustered | bool
     - inventory_hostname == rabbitmq_master
+
+- name: Set erlang_cookie fact for nodes
+  when:
+    - specification.cluster.is_clustered | bool
+    - inventory_hostname != rabbitmq_master
+  set_fact:
+    erlang_cookie: "{{ hostvars[rabbitmq_master]['erlang_cookie'] }}"
 
 # Cookie is updated on master in previous step
 - include_tasks: "update-erlang-cookie.yml"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/set-erlang-cookie.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/set-erlang-cookie.yml
@@ -38,9 +38,6 @@
       when: not cookie_file_stat.stat.exists
       set_fact:
         erlang_cookie: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}"
-      delegate_to: "{{ item }}"
-      delegate_facts: true
-      loop: "{{ ansible_play_hosts }}"
 
 # Cookie must be applied on master first 
 - include_tasks: "update-erlang-cookie.yml"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq.yml
@@ -1,8 +1,4 @@
 ---
-- name: RabbitMQ | Set rabbitmq_master fact
-  set_fact:
-    rabbitmq_master: "{{ groups['rabbitmq'][0] }}"
-
 - name: RabbitMQ | Check version
   command: rabbitmqctl version
   register: rabbitmq_version_current
@@ -11,6 +7,15 @@
 - name: RabbitMQ | Include defaults from rabbitmq role
   include_vars:
     file: roles/rabbitmq/defaults/main.yml
+
+- name: RabbitMQ | Include specification vars from rabbitmq role
+  include_vars:
+    file: roles/rabbitmq/vars/main.yml
+
+- name: RabbitMQ | Set facts
+  set_fact:
+    rabbitmq_master: "{{ groups['rabbitmq'][0] }}"
+    long_names: "{% if specification.rabbitmq_use_longname|bool %}--longnames{% else %}{% endif %}"
 
 - name: RabbitMQ | Offline upgrade
   when: rabbitmq_version_current.stdout != versions.general
@@ -62,11 +67,11 @@
             state: started
 
         - name: RabbitMQ | Stop an app on the node
-          command: rabbitmqctl stop_app
+          command: rabbitmqctl {{ long_names }} stop_app
 
         - name: RabbitMQ | Join a node to the cluster
-          command: rabbitmqctl join_cluster rabbit@{{ rabbitmq_master.split('.')[0] }}
+          command: rabbitmqctl {{ long_names }} join_cluster rabbit@{{ rabbitmq_master }}
 
         - name: RabbitMQ | Start an app on the node
           when: inventory_hostname != rabbitmq_master
-          command: rabbitmqctl start_app
+          command: rabbitmqctl {{ long_names }} start_app

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq.yml
@@ -70,7 +70,7 @@
           command: rabbitmqctl {{ long_names }} stop_app
 
         - name: RabbitMQ | Join a node to the cluster
-          command: rabbitmqctl {{ long_names }} join_cluster rabbit@{{ rabbitmq_master }}
+          command: rabbitmqctl {{ long_names }} join_cluster rabbit@{{ rabbitmq_master.split('.')[0] }}
 
         - name: RabbitMQ | Start an app on the node
           when: inventory_hostname != rabbitmq_master

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq.yml
@@ -8,14 +8,9 @@
   include_vars:
     file: roles/rabbitmq/defaults/main.yml
 
-- name: RabbitMQ | Include specification vars from rabbitmq role
-  include_vars:
-    file: roles/rabbitmq/vars/main.yml
-
-- name: RabbitMQ | Set facts
+- name: RabbitMQ | Set rabbitmq_master fact
   set_fact:
     rabbitmq_master: "{{ groups['rabbitmq'][0] }}"
-    long_names: "{% if specification.rabbitmq_use_longname|bool %}--longnames{% else %}{% endif %}"
 
 - name: RabbitMQ | Offline upgrade
   when: rabbitmq_version_current.stdout != versions.general
@@ -67,11 +62,11 @@
             state: started
 
         - name: RabbitMQ | Stop an app on the node
-          command: rabbitmqctl {{ long_names }} stop_app
+          command: rabbitmqctl stop_app
 
         - name: RabbitMQ | Join a node to the cluster
-          command: rabbitmqctl {{ long_names }} join_cluster rabbit@{{ rabbitmq_master.split('.')[0] }}
+          command: rabbitmqctl join_cluster rabbit@{{ rabbitmq_master.split('.')[0] }}
 
         - name: RabbitMQ | Start an app on the node
           when: inventory_hostname != rabbitmq_master
-          command: rabbitmqctl {{ long_names }} start_app
+          command: rabbitmqctl start_app

--- a/core/src/epicli/data/common/defaults/configuration/rabbitmq.yml
+++ b/core/src/epicli/data/common/defaults/configuration/rabbitmq.yml
@@ -11,7 +11,7 @@ specification:
   ulimit_open_files: 65535
 
   amqp_port: 5672
-  rabbitmq_use_longname: true
+  rabbitmq_use_longname: false
   rabbitmq_policies: []
   rabbitmq_plugins: []
   custom_configurations: []


### PR DESCRIPTION
Task #1854: installation bug fix. Tested locally:
* Installation:
1. AWS + RHEL, Ubuntu
2. Azure + RHEL, Ubuntu
* Upgrade

Long names usage is not supported by our Azure infrastructure as FQDNs are not used there, so default value has been changed.