### PR TITLE
rabbitmq: correctly enable/disable rabbitmq-server service (fix)

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/configure-rabbitmq.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/configure-rabbitmq.yml
@@ -44,4 +44,5 @@
   when: specification.stop_service | bool
   service:
     name: rabbitmq-server
+    enabled: false
     state: stopped

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/main.yml
@@ -9,6 +9,7 @@
 - name: Ensure rabbitmq-server service is running
   service:
     name: rabbitmq-server
+    enabled: true
     state: started
   when:
     - not (specification.stop_service | bool)


### PR DESCRIPTION
Tested on Ubuntu and RedHat