### PR TITLE
Update curator debian version to 5.8.3

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 specification:
-  curator_version: "5.8.1" # used by upgrade playbook
+  curator_version: "5.8.3" # used by upgrade playbook
 
 elasticsearch_host_ip: "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
@@ -12,7 +12,7 @@ curl
 docker-ce 5:19.03.14
 docker-ce-cli 5:19.03.14
 ebtables
-elasticsearch-curator 5.8.1
+elasticsearch-curator 5.8.3
 elasticsearch-oss 6.8.5 # for elasticsearch role
 elasticsearch-oss 7.9.1 # for opendistroforelasticsearch & logging roles
 
@@ -199,6 +199,7 @@ https://github.com/prometheus/alertmanager/releases/download/v0.17.0/alertmanage
 https://github.com/prometheus/haproxy_exporter/releases/download/v0.10.0/haproxy_exporter-0.10.0.linux-amd64.tar.gz
 https://github.com/prometheus/node_exporter/releases/download/v1.0.1/node_exporter-1.0.1.linux-amd64.tar.gz
 https://github.com/prometheus/prometheus/releases/download/v2.10.0/prometheus-2.10.0.linux-amd64.tar.gz
+# what is that for? I thought we install curator from apt package.
 https://packages.elastic.co/curator/5/debian9/pool/main/e/elasticsearch-curator/elasticsearch-curator_5.5.4_amd64.deb
 https://archive.apache.org/dist/ignite/2.7.6/apache-ignite-2.7.6-bin.zip
 https://releases.hashicorp.com/vault/1.4.0/vault_1.4.0_linux_amd64.zip

--- a/core/src/epicli/data/common/defaults/configuration/elasticsearch-curator.yml
+++ b/core/src/epicli/data/common/defaults/configuration/elasticsearch-curator.yml
@@ -2,7 +2,7 @@ kind: configuration/elasticsearch-curator
 title: Elasticsearch Curator
 name: default
 specification:
-  curator_version: "5.8.1"
+  curator_version: "5.8.3"
   delete_indices_cron_jobs:
     - description: Delete indices older than N days
       cron:


### PR DESCRIPTION
My regression test failed complaining the version does nto exists. Login into to the server run manually I got

```
root@de-stdbase-kubernetes-master-vm-0:~# /tmp/epi-download-requirements/download-requirements.sh /var/www/html/epirepo
Reading package lists... Done
Building dependency tree
Reading state information... Done
curl is already the newest version (7.58.0-2ubuntu3.12).
gpg is already the newest version (2.2.4-1ubuntu1.3).
wget is already the newest version (1.19.4-1ubuntu2.2).
0 upgraded, 0 newly installed, 0 to remove and 276 not upgraded.
Dependency list: /tmp/epi-download-requirements/.dependencies
Command used to download packages: apt-get download
Destination directory for packages: /var/www/html/epirepo/packages
OK
deb https://artifacts.elastic.co/packages/oss-6.x/apt stable main
OK
deb [arch=amd64] https://packages.elastic.co/curator/5/debian stable main
OK
deb https://packages.grafana.com/oss/deb stable main
OK
deb http://apt.kubernetes.io/ kubernetes-xenial main
OK
deb http://dl.bintray.com/rabbitmq-erlang/debian bionic erlang-21.x
deb https://dl.bintray.com/rabbitmq/debian bionic main
OK
deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
OK
deb https://artifacts.elastic.co/packages/oss-7.x/apt stable main
OK
deb https://d3g5vo6xdbdb9a.cloudfront.net/apt stable main
OK
deb https://dl.2ndquadrant.com/default/release/apt bionic-2ndquadrant main
Hit:1 http://azure.archive.ubuntu.com/ubuntu bionic InRelease
Hit:2 http://azure.archive.ubuntu.com/ubuntu bionic-updates InRelease
Hit:3 http://azure.archive.ubuntu.com/ubuntu bionic-backports InRelease
Hit:4 https://artifacts.elastic.co/packages/oss-6.x/apt stable InRelease
Hit:5 https://artifacts.elastic.co/packages/oss-7.x/apt stable InRelease
Hit:6 https://download.docker.com/linux/ubuntu bionic InRelease
Hit:7 https://packages.elastic.co/curator/5/debian stable InRelease
Hit:8 https://d3g5vo6xdbdb9a.cloudfront.net/apt stable InRelease
Ign:9 http://dl.bintray.com/rabbitmq-erlang/debian bionic InRelease
Hit:11 http://security.ubuntu.com/ubuntu bionic-security InRelease
Get:12 http://dl.bintray.com/rabbitmq-erlang/debian bionic Release [32.6 kB]
Ign:13 https://dl.bintray.com/rabbitmq/debian bionic InRelease
Hit:15 https://packages.grafana.com/oss/deb stable InRelease
Get:16 https://dl.bintray.com/rabbitmq/debian bionic Release [74.5 kB]
Hit:10 https://packages.cloud.google.com/apt kubernetes-xenial InRelease
Hit:17 https://dl.2ndquadrant.com/default/release/apt bionic-2ndquadrant InRelease
Fetched 107 kB in 1s (88.8 kB/s)
Reading package lists... Done
Building dependency tree
Reading state information... Done
276 packages can be upgraded. Run 'apt list --upgradable' to see them.
W: Skipping acquire of configured file 'erlang-21.x/i18n/Translation-en' as repository 'http://dl.bintray.com/rabbitmq-erlang/debian bionic InRelease' doesn't have the component 'erlang-21.x' (component misspelt in sources.list?)
W: Skipping acquire of configured file 'erlang-21.x/cnf/Commands-amd64' as repository 'http://dl.bintray.com/rabbitmq-erlang/debian bionic InRelease' doesn't have the component 'erlang-21.x' (component misspelt in sources.list?)

Packages to be downloaded:
     1	adduser
     2	apt
     3	apt-transport-https
     4	auditd
     5	bash-completion
     6	build-essential
     7	ca-certificates
     8	cifs-utils
     9	containerd.io
    10	cri-tools=1.13.0*
    11	curl
    12	debconf
    13	docker-ce-cli
    14	docker-ce-cli=5:18.09*
    15	docker-ce=5:18.09*
    16	dpkg-dev
    17	ebtables
    18	elasticsearch-curator=5.8.1*
    19	g++
    20	gawk
    21	gcc
    22	iptables
    23	libaudit1
    24	libauparse0
    25	libc6
    26	libc6-dev
    27	libcap-ng0
    28	libcurl4
    29	libkeyutils1
    30	libkrb5-3
    31	libpam0g
    32	libseccomp2
    33	libsystemd0
    34	libtalloc2
    35	libwbclient0
    36	lsb-base
    37	make
    38	mawk
    39	openssl
    40	passwd
    41	samba-common
    42	zlib1g
E: Version '5.8.1*' for 'elasticsearch-curator' was not found
root@de-stdbase-kubernetes-master-vm-0:~#
```

The existing version for Ubuntu is

```
oot@de-stdbase-kubernetes-master-vm-0:~# apt-cache madison elasticsearch-curator
elasticsearch-curator |      5.8.3 | https://packages.elastic.co/curator/5/debian stable/main amd64 Packages
elasticsearch-curator |    5.2.0-1 | http://azure.archive.ubuntu.com/ubuntu bionic/universe amd64 Packages
elasticsearch-curator |    5.2.0-1 | http://azure.archive.ubuntu.com/ubuntu bionic/universe Sources
root@de-stdbase-kubernetes-master-vm-0:~#
```

Thus we need to update the version.

This patch only for Ubuntu. I dont have time and access to test on other system
so I dont know. Also there is a deb in the file sections which is probably not
in use as well, see my code comment.