### PR TITLE
Upgrade Elasticsearch Curator to v5.8.3

### DIFF
--- a/CHANGELOG-0.9.md
+++ b/CHANGELOG-0.9.md
@@ -30,10 +30,11 @@
 - [#1770](https://github.com/epiphany-platform/epiphany/issues/1770) - Upgrade Filebeat to the latest version (7.9.2)
 - [#1848](https://github.com/epiphany-platform/epiphany/issues/1848) - Update Ansible to v2.8.17
 - [#1854](https://github.com/epiphany-platform/epiphany/issues/1854) - Upgrade RabbitMQ to the latest version (3.8.9)
-- [#1137](https://github.com/epiphany-platform/epiphany/issues/1137) - Upgrade Kafka to 2.6.0
+- [#1137](https://github.com/epiphany-platform/epiphany/issues/1137) - Upgrade Kafka to v2.6.0
 - [#1855](https://github.com/epiphany-platform/epiphany/issues/1855) - Upgrade Docker to v19.03.14
-- [#1853](https://github.com/epiphany-platform/epiphany/issues/1853) - Upgrade Zookeeper to 3.5.8
-- [#1860](https://github.com/epiphany-platform/epiphany/issues/1860) - Upgrade Grafana (7.3.5)
+- [#1853](https://github.com/epiphany-platform/epiphany/issues/1853) - Upgrade Zookeeper to v3.5.8
+- [#1860](https://github.com/epiphany-platform/epiphany/issues/1860) - Upgrade Grafana to v7.3.5
+- [#1955](https://github.com/epiphany-platform/epiphany/issues/1955) - Upgrade Elasticsearch Curator to v5.8.3
 
 ### Breaking changes
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 specification:
-  curator_version: "5.8.1" # used by upgrade playbook
+  curator_version: "5.8.3" # used by upgrade playbook
 
 elasticsearch_host_ip: "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
@@ -31,7 +31,7 @@ dejavu-sans-fonts # for grafana
 docker-ce-19.03.14
 docker-ce-cli-19.03.14
 ebtables
-elasticsearch-curator-5.8.1
+elasticsearch-curator-5.8.3
 elasticsearch-oss-6.8.5 # for elasticsearch role
 elasticsearch-oss-7.9.1 # for opendistroforelasticsearch & logging roles
 erlang-23.1.4 # must be compatible with rabbitmq version

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
@@ -30,7 +30,7 @@ dejavu-sans-fonts # for grafana
 docker-ce-19.03.14
 docker-ce-cli-19.03.14
 ebtables
-elasticsearch-curator-5.8.1
+elasticsearch-curator-5.8.3
 elasticsearch-oss-6.8.5 # for elasticsearch role
 elasticsearch-oss-7.9.1 # for opendistroforelasticsearch & logging roles
 erlang-23.1.4 # must be compatible with rabbitmq version

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
@@ -199,7 +199,6 @@ https://github.com/prometheus/alertmanager/releases/download/v0.17.0/alertmanage
 https://github.com/prometheus/haproxy_exporter/releases/download/v0.10.0/haproxy_exporter-0.10.0.linux-amd64.tar.gz
 https://github.com/prometheus/node_exporter/releases/download/v1.0.1/node_exporter-1.0.1.linux-amd64.tar.gz
 https://github.com/prometheus/prometheus/releases/download/v2.10.0/prometheus-2.10.0.linux-amd64.tar.gz
-https://packages.elastic.co/curator/5/debian9/pool/main/e/elasticsearch-curator/elasticsearch-curator_5.5.4_amd64.deb
 https://archive.apache.org/dist/ignite/2.7.6/apache-ignite-2.7.6-bin.zip
 https://releases.hashicorp.com/vault/1.4.0/vault_1.4.0_linux_amd64.zip
 https://get.helm.sh/helm-v3.2.0-linux-amd64.tar.gz

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
@@ -12,7 +12,7 @@ curl
 docker-ce 5:19.03.14
 docker-ce-cli 5:19.03.14
 ebtables
-elasticsearch-curator 5.8.1
+elasticsearch-curator 5.8.3
 elasticsearch-oss 6.8.5 # for elasticsearch role
 elasticsearch-oss 7.9.1 # for opendistroforelasticsearch & logging roles
 

--- a/core/src/epicli/data/common/defaults/configuration/elasticsearch-curator.yml
+++ b/core/src/epicli/data/common/defaults/configuration/elasticsearch-curator.yml
@@ -2,7 +2,7 @@ kind: configuration/elasticsearch-curator
 title: Elasticsearch Curator
 name: default
 specification:
-  curator_version: "5.8.1"
+  curator_version: "5.8.3"
   delete_indices_cron_jobs:
     - description: Delete indices older than N days
       cron:

--- a/docs/home/COMPONENTS.md
+++ b/docs/home/COMPONENTS.md
@@ -17,7 +17,7 @@ Note that versions are default versions and can be changed in certain cases thro
 | Docker CE                  | 19.03.14 | https://github.com/docker/docker-ce/                  | [Apache License](https://www.apache.org/licenses/LICENSE-1.0)     |
 | KeyCloak                   | 9.0.0    | https://github.com/keycloak/keycloak                  | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Elasticsearch OSS          | 7.9.1    | https://github.com/elastic/elasticsearch              | https://github.com/elastic/elasticsearch/blob/master/LICENSE.txt  |
-| Elasticsearch Curator OSS  | 5.8.1    | https://github.com/elastic/curator                    | https://github.com/elastic/curator/blob/master/LICENSE.txt        |
+| Elasticsearch Curator OSS  | 5.8.3    | https://github.com/elastic/curator                    | https://github.com/elastic/curator/blob/master/LICENSE.txt        |
 | Opendistro for Elasticsearch          | 1.10.1   | https://opendistro.github.io/for-elasticsearch/                  | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Opendistro for Elasticsearch Kibana   | 1.10.1   | https://opendistro.github.io/for-elasticsearch-docs/docs/kibana/ | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Filebeat                   | 7.9.2    | https://github.com/elastic/beats                      | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |


### PR DESCRIPTION
Related to issue #1955

- Elasticsearch Curator upgraded to v5.8.3 which is available on all supported os distributions CentOS/Ubuntu/Redhat
