### PR TITLE
[BACKPORT to v0.6] Upgrade Elasticsearch Curator to v5.8.3

### DIFF
--- a/CHANGELOG-0.6.md
+++ b/CHANGELOG-0.6.md
@@ -10,6 +10,10 @@
 
 - [#1372](https://github.com/epiphany-platform/epiphany/issues/1372) - Epicli does not create PostgreSQL SET\_BY\_AUTOMATION values correctly
 
+### Updated
+
+- [#1966](https://github.com/epiphany-platform/epiphany/issues/1966) - Upgrade Elasticsearch Curator to v5.8.3
+
 ## [0.6.1] 2020-10-14
 
 ### Fixed

--- a/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/elasticsearch_curator/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 specification:
-  curator_version: "5.8.1" # used by upgrade playbook
+  curator_version: "5.8.3" # used by upgrade playbook
 
 elasticsearch_host_ip: "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
@@ -30,7 +30,7 @@ dejavu-sans-fonts # for grafana
 docker-ce-18.09.9
 docker-ce-cli-18.09.9
 ebtables
-elasticsearch-curator-5.8.1
+elasticsearch-curator-5.8.3
 elasticsearch-oss-6.8.5
 elasticsearch-oss-7.3.2 # Open Distro for Elasticsearch
 erlang-21.3.8.7

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
@@ -30,7 +30,7 @@ dejavu-sans-fonts # for grafana
 docker-ce-18.09.9
 docker-ce-cli-18.09.9
 ebtables
-elasticsearch-curator-5.8.1
+elasticsearch-curator-5.8.3
 elasticsearch-oss-6.8.5
 elasticsearch-oss-7.3.2 # Open Distro for Elasticsearch
 erlang-21.3.8.7

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
@@ -12,7 +12,7 @@ curl
 docker-ce 5:18.09
 docker-ce-cli 5:18.09
 ebtables
-elasticsearch-curator 5.8.1
+elasticsearch-curator 5.8.3
 elasticsearch-oss 6.8.5
 elasticsearch-oss 7.3.2
 erlang-nox
@@ -170,7 +170,6 @@ https://github.com/prometheus/alertmanager/releases/download/v0.17.0/alertmanage
 https://github.com/prometheus/haproxy_exporter/releases/download/v0.10.0/haproxy_exporter-0.10.0.linux-amd64.tar.gz
 https://github.com/prometheus/node_exporter/releases/download/v0.16.0/node_exporter-0.16.0.linux-amd64.tar.gz
 https://github.com/prometheus/prometheus/releases/download/v2.10.0/prometheus-2.10.0.linux-amd64.tar.gz
-https://packages.elastic.co/curator/5/debian9/pool/main/e/elasticsearch-curator/elasticsearch-curator_5.5.4_amd64.deb
 https://archive.apache.org/dist/ignite/2.7.6/apache-ignite-2.7.6-bin.zip
 
 [images]

--- a/core/src/epicli/data/common/defaults/configuration/elasticsearch-curator.yml
+++ b/core/src/epicli/data/common/defaults/configuration/elasticsearch-curator.yml
@@ -2,7 +2,7 @@ kind: configuration/elasticsearch-curator
 title: Elasticsearch Curator
 name: default
 specification:
-  curator_version: "5.8.1"
+  curator_version: "5.8.3"
   delete_indices_cron_jobs:
     - description: Delete indices older than N days
       cron:

--- a/docs/home/COMPONENTS.md
+++ b/docs/home/COMPONENTS.md
@@ -16,7 +16,7 @@ Note that versions are default versions and can be changed in certain cases thro
 | Docker-ce                 | 18.09   | https://github.com/docker/docker-ce/                  | [Apache License](https://www.apache.org/licenses/LICENSE-1.0)     |
 | KeyCloak                  | 9.0.0   | https://github.com/keycloak/keycloak                  | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Elasticsearch OSS         | 7.6.1   | https://github.com/elastic/elasticsearch              | https://github.com/elastic/elasticsearch/blob/master/LICENSE.txt  |
-| Elasticsearch Curator OSS | 5.8.1   | https://github.com/elastic/curator                    | https://github.com/elastic/curator/blob/master/LICENSE.txt        |
+| Elasticsearch Curator OSS | 5.8.3   | https://github.com/elastic/curator                    | https://github.com/elastic/curator/blob/master/LICENSE.txt        |
 | Kibana                    | 6.5.4   | https://github.com/elastic/kibana                     | https://github.com/elastic/kibana/blob/master/LICENSE.txt         |
 | Opendistro for Elasticsearch  | 1.3.0   | https://opendistro.github.io/for-elasticsearch/  | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)  |
 | Opendistro for Elasticsearch Kibana  | 1.3.0   | https://opendistro.github.io/for-elasticsearch-docs/docs/kibana/  | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)  |


### PR DESCRIPTION
PR related to issue #1966 

- Elasticsearch Curator upgraded to v5.8.3