### PR TITLE
[BUG] Allow traffic from loadbalancer to kubernetes subnet

### DIFF
--- a/CHANGELOG-0.10.md
+++ b/CHANGELOG-0.10.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - [#1881](https://github.com/epiphany-platform/epiphany/issues/1881) - epicli: wrong informations in help messages
+- [#1959](https://github.com/epiphany-platform/epiphany/issues/1959) - Network traffic not allowed from load balancer's subnet to Kubernetes's subnet in AWS
 
 ### Updated
 

--- a/core/src/epicli/data/aws/defaults/infrastructure/virtual-machine.yml
+++ b/core/src/epicli/data/aws/defaults/infrastructure/virtual-machine.yml
@@ -253,7 +253,7 @@ specification:
        destination_port_range: "0"
        source_address_prefix: "0.0.0.0/0"
        destination_address_prefix: "0.0.0.0/0"
-     - name: load-balacner-subnet-traffic
+     - name: load-balancer-subnet-traffic
        description: Allow load-balancer subnet traffic
        direction: Inbound
        protocol: ALL
@@ -313,7 +313,7 @@ specification:
        destination_port_range: "0"
        source_address_prefix: "0.0.0.0/0"
        destination_address_prefix: "0.0.0.0/0"
-     - name: load-balacner-subnet-traffic
+     - name: load-balancer-subnet-traffic
        description: Allow load-balancer subnet traffic
        direction: Inbound
        protocol: ALL

--- a/core/src/epicli/data/aws/defaults/infrastructure/virtual-machine.yml
+++ b/core/src/epicli/data/aws/defaults/infrastructure/virtual-machine.yml
@@ -253,6 +253,13 @@ specification:
        destination_port_range: "0"
        source_address_prefix: "0.0.0.0/0"
        destination_address_prefix: "0.0.0.0/0"
+     - name: load-balacner-subnet-traffic
+       description: Allow load-balancer subnet traffic
+       direction: Inbound
+       protocol: ALL
+       destination_port_range: "0"
+       source_address_prefix: "10.1.7.0/24"
+       destination_address_prefix: "0.0.0.0/0"
 ---
 kind: infrastructure/virtual-machine
 title: "Virtual Machine Infra"
@@ -305,6 +312,13 @@ specification:
        protocol: "all"
        destination_port_range: "0"
        source_address_prefix: "0.0.0.0/0"
+       destination_address_prefix: "0.0.0.0/0"
+     - name: load-balacner-subnet-traffic
+       description: Allow load-balancer subnet traffic
+       direction: Inbound
+       protocol: ALL
+       destination_port_range: "0"
+       source_address_prefix: "10.1.7.0/24"
        destination_address_prefix: "0.0.0.0/0"
 ---
 kind: infrastructure/virtual-machine


### PR DESCRIPTION
PR related to BUG reported in #1959 

- Problem exist only on AWS. On Azure, there is by default rules which allow all traffic in vnet.
- Additional rule added and tested using connection from Loadbalancer instance (HAProxy) to application in kubernetes cluster.