### PR TITLE
Set ignite version to 2.9.1 in applications role

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
@@ -170,7 +170,7 @@ registry:2
 hashicorp/vault-k8s:0.7.0
 vault:1.6.1
 # applications
-apacheignite/ignite:2.5.0
+apacheignite/ignite:2.9.1
 bitnami/pgpool:4.1.1-debian-10-r29
 brainsam/pgbouncer:1.12
 # istio

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
@@ -167,7 +167,7 @@ registry:2
 hashicorp/vault-k8s:0.7.0
 vault:1.6.1
 # applications
-apacheignite/ignite:2.5.0
+apacheignite/ignite:2.9.1
 bitnami/pgpool:4.1.1-debian-10-r29
 brainsam/pgbouncer:1.12
 # istio

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
@@ -215,7 +215,7 @@ registry:2
 hashicorp/vault-k8s:0.7.0
 vault:1.6.1
 # applications
-apacheignite/ignite:2.5.0
+apacheignite/ignite:2.9.1
 bitnami/pgpool:4.1.1-debian-10-r29
 brainsam/pgbouncer:1.12
 # istio

--- a/core/src/epicli/data/common/defaults/configuration/applications.yml
+++ b/core/src/epicli/data/common/defaults/configuration/applications.yml
@@ -8,7 +8,7 @@ specification:
 
   - name: ignite-stateless
     enabled: false
-    image_path: "apacheignite/ignite:2.5.0" # it will be part of the image path: {{local_repository}}/{{image_path}}
+    image_path: "apacheignite/ignite:2.9.1" # it will be part of the image path: {{local_repository}}/{{image_path}}
     use_local_image_registry: true
     namespace: ignite
     service:

--- a/core/src/epicli/data/common/defaults/configuration/image-registry.yml
+++ b/core/src/epicli/data/common/defaults/configuration/image-registry.yml
@@ -12,8 +12,8 @@ specification:
         file_name: keycloak-9.0.0.tar
       - name: "rabbitmq:3.8.9"
         file_name: rabbitmq-3.8.9.tar
-      - name: "apacheignite/ignite:2.5.0"
-        file_name: ignite-2.5.0.tar
+      - name: "apacheignite/ignite:2.9.1"
+        file_name: ignite-2.9.1.tar
       - name: "kubernetesui/dashboard:v2.0.3"
         file_name: dashboard-v2.0.3.tar
       - name: "kubernetesui/metrics-scraper:v1.0.4"


### PR DESCRIPTION
This PR only changes the defaults. There is no automatic upgrade provided.