### PR TITLE
Dealing with slash in subscription name for terraform and MS quirkiness

### DIFF
--- a/core/src/epicli/cli/engine/terraform/TerraformRunner.py
+++ b/core/src/epicli/cli/engine/terraform/TerraformRunner.py
@@ -16,7 +16,7 @@ class TerraformRunner(Step):
         self.new_env = os.environ.copy()
         self.terraform.init(env=self.new_env)
         if self.cluster_model.provider == 'azure':
-            self.azure_login()        
+            self.azure_login()
 
     def __enter__(self):
         super().__enter__()
@@ -30,9 +30,9 @@ class TerraformRunner(Step):
 
     def delete(self):
         self.terraform.destroy(auto_approve=True, env=self.new_env)
-        
+
     def azure_login(self):
-        # From the 4 methods terraform provides to login to 
+        # From the 4 methods terraform provides to login to
         # Azure we support (https://www.terraform.io/docs/providers/azurerm/auth/azure_cli.html):
         # - Authenticating to Azure using the Azure CLI
         # - Authenticating to Azure using a Service Principal and a Client Secret
@@ -52,22 +52,29 @@ class TerraformRunner(Step):
                 # Create the service principal, for now we use the default subscription
                 self.logger.info('Creating service principal')
                 cluster_name = self.cluster_model.specification.name.lower()
-                cluster_prefix = self.cluster_model.specification.prefix.lower()               
+                cluster_prefix = self.cluster_model.specification.prefix.lower()
                 resource_group_name = resource_name(cluster_prefix, cluster_name, 'rg')
                 sp = apiproxy.create_sp(resource_group_name, subscription['id'])
                 sp['subscriptionId'] = subscription['id']
                 save_sp(sp, self.cluster_model.specification.name)
             else:
-                self.logger.info('Using service principal from file')
+                self.logger.info(f'Using service principal from file {sp_file}')
                 sp = load_yaml_file(sp_file)
 
             # Login as SP and get the default subscription.
             subscription = apiproxy.login_sp(sp)
 
             if 'subscriptionId' in sp:
-                # Set active subscription if sp contains it. 
+                # Set active subscription if sp contains it.
+                self.logger.info(f"subscriptionId from sp file: {sp['subscriptionId']}")
                 apiproxy.set_active_subscribtion(sp['subscriptionId'])
-                self.new_env['ARM_SUBSCRIPTION_ID'] = sp['subscriptionId']
+                arm_subscription_id = ""
+                if "/" in sp['subscriptionId']:
+                    self.logger.info(f"WARN Slash detected in the subscription name {sp['subscriptionId']}. Will parse the ID and use it instead")
+                    arm_subscription_id = [x['id'] for x in subscription if x['name'] == sp['subscriptionId']][0]
+                else:
+                    arm_subscription_id = sp['subscriptionId']
+                self.new_env['ARM_SUBSCRIPTION_ID'] = arm_subscription_id
             else:
                 # No subscriptionId in sp.yml so use the default one from Azure SP login.
                 self.new_env['ARM_SUBSCRIPTION_ID'] = subscription[0]['id']

--- a/core/src/epicli/cli/engine/terraform/TerraformRunner.py
+++ b/core/src/epicli/cli/engine/terraform/TerraformRunner.py
@@ -66,11 +66,11 @@ class TerraformRunner(Step):
 
             if 'subscriptionId' in sp:
                 # Set active subscription if sp contains it.
-                self.logger.info(f"subscriptionId from sp file: {sp['subscriptionId']}")
+                self.logger.debug(f"subscriptionId from sp file: {sp['subscriptionId']}")
                 apiproxy.set_active_subscribtion(sp['subscriptionId'])
                 arm_subscription_id = ""
                 if "/" in sp['subscriptionId']:
-                    self.logger.info(f"WARN Slash detected in the subscription name {sp['subscriptionId']}. Will parse the ID and use it instead")
+                    self.logger.debug(f"WARN Slash detected in the subscription name {sp['subscriptionId']}. Will parse the ID and use it instead")
                     arm_subscription_id = [x['id'] for x in subscription if x['name'] == sp['subscriptionId']][0]
                 else:
                     arm_subscription_id = sp['subscriptionId']

--- a/core/src/epicli/cli/engine/terraform/TerraformRunner.py
+++ b/core/src/epicli/cli/engine/terraform/TerraformRunner.py
@@ -68,12 +68,10 @@ class TerraformRunner(Step):
                 # Set active subscription if sp contains it.
                 self.logger.debug(f"subscriptionId from sp file: {sp['subscriptionId']}")
                 apiproxy.set_active_subscribtion(sp['subscriptionId'])
-                arm_subscription_id = ""
+                arm_subscription_id = sp['subscriptionId']
                 if "/" in sp['subscriptionId']:
                     self.logger.debug(f"WARN Slash detected in the subscription name {sp['subscriptionId']}. Will parse the ID and use it instead")
-                    arm_subscription_id = [x['id'] for x in subscription if x['name'] == sp['subscriptionId']][0]
-                else:
-                    arm_subscription_id = sp['subscriptionId']
+                    arm_subscription_id = next((_sub['id'] for _sub in subscription if _sub['name'] == sp['subscriptionId']), None)
                 self.new_env['ARM_SUBSCRIPTION_ID'] = arm_subscription_id
             else:
                 # No subscriptionId in sp.yml so use the default one from Azure SP login.


### PR DESCRIPTION
Azure allow / in the sub name however the API endpoint return wrongly even we
encode the / into %2F. Get
https://management.azure.com/subscriptions/CALM-WFM-Development-Dev%2FTest/providers?api-version=2016-02-01
into your browser and see, azure will return sub not found and the sub name is
the first part of the slash only.

However ID seems to work.

This changes put some more debugging and try to parse and use the ID if found a slash.