### PR TITLE
Fix indentation in alertmanager configuration

### DIFF
--- a/core/src/epicli/data/common/defaults/configuration/prometheus.yml
+++ b/core/src/epicli/data/common/defaults/configuration/prometheus.yml
@@ -30,47 +30,47 @@ specification:
       postgresql: false
       prometheus: false
     # config: # Configuration for Alertmanager, it will be passed to Alertmanager service.
-      # Full list of configuration fields https://prometheus.io/docs/alerting/configuration/
-    # global:
-        # resolve_timeout: 5m
-        # smtp_from: "alert@test.com"
-        # smtp_smarthost: "smtp-url:smtp-port"
-        # smtp_auth_username: "your-smtp-user@domain.com"
-        # smtp_auth_password: "your-smtp-password"
-        # smtp_require_tls: True
-      # route:
-        # group_by: ['alertname']
-        # group_wait: 10s
-        # group_interval: 10s
-        # repeat_interval: 1h
-        # receiver: 'email' # Default receiver, change if another is set to default
-        # routes: # Example routes, names need to match 'name' field of receiver
-          # - match_re:
-          #     severity: critical
-          #   receiver: opsgenie
-          #   continue: true
-          # - match_re:
-          #     severity: critical
-          #   receiver: pagerduty
-          #   continue: true
-          # - match_re:
-          #      severity: info|warning|critical
-          #   receiver: slack
-          #   continue: true
-          # - match_re:
-          #      severity: warning|critical
-          #   receiver: email
-      # receivers: # example configuration for receivers # api_url: https://prometheus.io/docs/alerting/configuration/#receiver
-        # - name: 'email'
-        #   email_configs:
-        #     - to: "test@domain.com"
-        # - name: 'slack'
-        #   slack_configs:
-        #     - api_url: "your-slack-integration-url"
-        # - name: 'pagerduty'
-        #   pagerduty_configs:
-        #     - service_key: "your-pagerduty-service-key"
-        # - name: 'opsgenie'
-        #   opsgenie_config:
-        #     api_key: <secret> | default = global.opsgenie_api_key
-        #     api_url: <string> | default = global.opsgenie_api_url
+    #   # Full list of configuration fields https://prometheus.io/docs/alerting/configuration/
+    #   global:
+    #     resolve_timeout: 5m
+    #     smtp_from: "alert@test.com"
+    #     smtp_smarthost: "smtp-url:smtp-port"
+    #     smtp_auth_username: "your-smtp-user@domain.com"
+    #     smtp_auth_password: "your-smtp-password"
+    #     smtp_require_tls: True
+    #   route:
+    #     group_by: ['alertname']
+    #     group_wait: 10s
+    #     group_interval: 10s
+    #     repeat_interval: 1h
+    #     receiver: 'email' # Default receiver, change if another is set to default
+    #     routes: # Example routes, names need to match 'name' field of receiver
+    #       - match_re:
+    #           severity: critical
+    #         receiver: opsgenie
+    #         continue: true
+    #       - match_re:
+    #           severity: critical
+    #         receiver: pagerduty
+    #         continue: true
+    #       - match_re:
+    #           severity: info|warning|critical
+    #         receiver: slack
+    #         continue: true
+    #       - match_re:
+    #           severity: warning|critical
+    #         receiver: email
+    #   receivers: # example configuration for receivers # api_url: https://prometheus.io/docs/alerting/configuration/#receiver
+    #     - name: 'email'
+    #       email_configs:
+    #         - to: "test@domain.com"
+    #     - name: 'slack'
+    #       slack_configs:
+    #         - api_url: "your-slack-integration-url"
+    #     - name: 'pagerduty'
+    #       pagerduty_configs:
+    #         - service_key: "your-pagerduty-service-key"
+    #     - name: 'opsgenie'
+    #       opsgenie_config:
+    #         api_key: <secret> | default = global.opsgenie_api_key
+    #         api_url: <string> | default = global.opsgenie_api_url


### PR DESCRIPTION
'global' was on the same lvl as 'config' in the section commented out.