### PR TITLE
Replace bintray repository

### DIFF
--- a/CHANGELOG-0.10.md
+++ b/CHANGELOG-0.10.md
@@ -25,6 +25,7 @@
 - [#2115](https://github.com/epiphany-platform/epiphany/issues/2115) - Epicli hangs on importing GPG keys for kubernetes repository on RHEL
 - [#2121](https://github.com/epiphany-platform/epiphany/issues/2121) - [RedHat/CentOS] Erlang package versions specified in requirements are missing in external repository
 - [#2068](https://github.com/epiphany-platform/epiphany/issues/2068) - Preflight role requires sudoer user
+- [#2136](https://github.com/epiphany-platform/epiphany/issues/2136) - Replace Bintray repository
 
 ### Updated
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/defaults/main.yml
@@ -8,5 +8,5 @@ versions:
     erlang: 1:23.1.*
     rabbitmq: 3.8.9*
   redhat:
-    erlang: 23.1.*
+    erlang_filename: "erlang-23.1.5-1.el7.x86_64.rpm"
     rabbitmq: 3.8.9

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/defaults/main.yml
@@ -10,4 +10,3 @@ versions:
   redhat:
     erlang_filename: erlang-23.1.5-1.el7.x86_64.rpm
     rabbitmq: 3.8.9
-repository_url: test

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/defaults/main.yml
@@ -8,5 +8,6 @@ versions:
     erlang: 1:23.1.*
     rabbitmq: 3.8.9*
   redhat:
-    erlang_filename: "erlang-23.1.5-1.el7.x86_64.rpm"
+    erlang_filename: erlang-23.1.5-1.el7.x86_64.rpm
     rabbitmq: 3.8.9
+repository_url: test

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/install-packages-redhat.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/tasks/install-packages-redhat.yml
@@ -3,7 +3,7 @@
   yum:
     name:
       - logrotate
-      - erlang-{{ versions.redhat.erlang }}
+      - "{{ repository_url }}/files/{{ versions.redhat.erlang_filename }}"
       - rabbitmq-server-{{ versions.redhat.rabbitmq }}
     update_cache: true
     state: present

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/download-requirements.sh
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/download-requirements.sh
@@ -699,25 +699,14 @@ gpgkey=https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
 EOF
 )
 
-RABBITMQ_ERLANG_REPO_CONF=$(cat <<'EOF'
-[rabbitmq-erlang]
-name=rabbitmq-erlang
-baseurl=https://dl.bintray.com/rabbitmq-erlang/rpm/erlang/23/el/7
-gpgcheck=1
-gpgkey=https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
-repo_gpgcheck=1
-enabled=1
-deltarpm_percentage=0
-EOF
-)
-
 RABBITMQ_SERVER_REPO_CONF=$(cat <<'EOF'
-[bintray-rabbitmq-server]
-name=bintray-rabbitmq-rpm
-baseurl=https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/v3.8.x/el/7/
+[rabbitmq-server]
+name=rabbitmq-rpm
+baseurl=https://packagecloud.io/rabbitmq/rabbitmq-server/el/7/$basearch
 gpgcheck=1
-gpgkey=https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+gpgkey=https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey
 repo_gpgcheck=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 enabled=1
 EOF
 )
@@ -737,7 +726,6 @@ add_repo_as_file 'grafana' "$GRAFANA_REPO_CONF"
 add_repo_as_file 'kubernetes' "$KUBERNETES_REPO_CONF"
 add_repo_as_file 'opendistroforelasticsearch' "$OPENDISTRO_REPO_CONF"
 add_repo_as_file 'postgresql-10' "$POSTGRESQL_REPO_CONF"
-add_repo_as_file 'rabbitmq-erlang' "$RABBITMQ_ERLANG_REPO_CONF"
 add_repo_as_file 'bintray-rabbitmq-rpm' "$RABBITMQ_SERVER_REPO_CONF"
 add_repo_from_script 'https://dl.2ndquadrant.com/default/release/get/10/rpm'
 disable_repo '2ndquadrant-dl-default-release-pg10-debug'

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
@@ -37,7 +37,6 @@ docker-ce-cli-19.03.14
 ebtables
 elasticsearch-curator-5.8.3
 elasticsearch-oss-7.10.2 # for opendistroforelasticsearch & logging roles
-erlang-23.1.5 # must be compatible with rabbitmq version
 ethtool
 filebeat-7.9.2
 firewalld
@@ -149,6 +148,7 @@ kubernetes-cni-0.7.5-0
 kubernetes-cni-0.8.6-0
 
 [files]
+https://github.com/rabbitmq/erlang-rpm/releases/download/v23.1.5/erlang-23.1.5-1.el7.x86_64.rpm
 https://github.com/prometheus/haproxy_exporter/releases/download/v0.10.0/haproxy_exporter-0.10.0.linux-amd64.tar.gz
 https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.14.0/jmx_prometheus_javaagent-0.14.0.jar
 https://archive.apache.org/dist/kafka/2.6.0/kafka_2.12-2.6.0.tgz

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
@@ -148,7 +148,7 @@ kubernetes-cni-0.7.5-0
 kubernetes-cni-0.8.6-0
 
 [files]
-# Github repository for erlang rpm is used since packagecloud repository is limited to a certain number of packages and erlang package from erlang-solution repository is much more complex and bigger
+# Github repository for erlang rpm is used since packagecloud repository is limited to a certain number of versions and erlang package from erlang-solutions repository is much more complex and bigger
 https://github.com/rabbitmq/erlang-rpm/releases/download/v23.1.5/erlang-23.1.5-1.el7.x86_64.rpm
 https://github.com/prometheus/haproxy_exporter/releases/download/v0.10.0/haproxy_exporter-0.10.0.linux-amd64.tar.gz
 https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.14.0/jmx_prometheus_javaagent-0.14.0.jar

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
@@ -148,6 +148,7 @@ kubernetes-cni-0.7.5-0
 kubernetes-cni-0.8.6-0
 
 [files]
+# Github repository for erlang rpm is used since packagecloud repository is limited to a certain number of packages and erlang package from erlang-solution repository is much more complex and bigger
 https://github.com/rabbitmq/erlang-rpm/releases/download/v23.1.5/erlang-23.1.5-1.el7.x86_64.rpm
 https://github.com/prometheus/haproxy_exporter/releases/download/v0.10.0/haproxy_exporter-0.10.0.linux-amd64.tar.gz
 https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.14.0/jmx_prometheus_javaagent-0.14.0.jar

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/download-requirements.sh
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/download-requirements.sh
@@ -729,25 +729,14 @@ gpgkey=https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
 EOF
 )
 
-RABBITMQ_ERLANG_REPO_CONF=$(cat <<'EOF'
-[rabbitmq-erlang]
-name=rabbitmq-erlang
-baseurl=https://dl.bintray.com/rabbitmq-erlang/rpm/erlang/23/el/7
-gpgcheck=1
-gpgkey=https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
-repo_gpgcheck=1
-enabled=1
-deltarpm_percentage=0
-EOF
-)
-
 RABBITMQ_SERVER_REPO_CONF=$(cat <<'EOF'
-[bintray-rabbitmq-server]
-name=bintray-rabbitmq-rpm
-baseurl=https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/v3.8.x/el/7/
+[rabbitmq-server]
+name=rabbitmq-rpm
+baseurl=https://packagecloud.io/rabbitmq/rabbitmq-server/el/7/$basearch
 gpgcheck=1
-gpgkey=https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+gpgkey=https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey
 repo_gpgcheck=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 enabled=1
 EOF
 )
@@ -767,7 +756,6 @@ add_repo_as_file 'grafana' "$GRAFANA_REPO_CONF"
 add_repo_as_file 'kubernetes' "$KUBERNETES_REPO_CONF"
 add_repo_as_file 'opendistroforelasticsearch' "$OPENDISTRO_REPO_CONF"
 add_repo_as_file 'postgresql-10' "$POSTGRESQL_REPO_CONF"
-add_repo_as_file 'rabbitmq-erlang' "$RABBITMQ_ERLANG_REPO_CONF"
 add_repo_as_file 'bintray-rabbitmq-rpm' "$RABBITMQ_SERVER_REPO_CONF"
 add_repo_from_script 'https://dl.2ndquadrant.com/default/release/get/10/rpm'
 disable_repo '2ndquadrant-dl-default-release-pg10-debug'

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
@@ -144,6 +144,7 @@ kubernetes-cni-0.7.5-0
 kubernetes-cni-0.8.6-0
 
 [files]
+# Github repository for erlang rpm is used since packagecloud repository is limited to a certain number of packages and erlang package from erlang-solution repository is much more complex and bigger
 https://github.com/rabbitmq/erlang-rpm/releases/download/v23.1.5/erlang-23.1.5-1.el7.x86_64.rpm
 https://github.com/prometheus/haproxy_exporter/releases/download/v0.10.0/haproxy_exporter-0.10.0.linux-amd64.tar.gz
 https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.14.0/jmx_prometheus_javaagent-0.14.0.jar

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
@@ -35,7 +35,6 @@ docker-ce-cli-19.03.14
 ebtables
 elasticsearch-curator-5.8.3
 elasticsearch-oss-7.10.2 # for opendistroforelasticsearch & logging roles
-erlang-23.1.5 # must be compatible with rabbitmq version
 ethtool
 filebeat-7.9.2
 firewalld
@@ -145,6 +144,7 @@ kubernetes-cni-0.7.5-0
 kubernetes-cni-0.8.6-0
 
 [files]
+https://github.com/rabbitmq/erlang-rpm/releases/download/v23.1.5/erlang-23.1.5-1.el7.x86_64.rpm
 https://github.com/prometheus/haproxy_exporter/releases/download/v0.10.0/haproxy_exporter-0.10.0.linux-amd64.tar.gz
 https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.14.0/jmx_prometheus_javaagent-0.14.0.jar
 https://archive.apache.org/dist/kafka/2.6.0/kafka_2.12-2.6.0.tgz

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
@@ -144,7 +144,7 @@ kubernetes-cni-0.7.5-0
 kubernetes-cni-0.8.6-0
 
 [files]
-# Github repository for erlang rpm is used since packagecloud repository is limited to a certain number of packages and erlang package from erlang-solution repository is much more complex and bigger
+# Github repository for erlang rpm is used since packagecloud repository is limited to a certain number of versions and erlang package from erlang-solutions repository is much more complex and bigger
 https://github.com/rabbitmq/erlang-rpm/releases/download/v23.1.5/erlang-23.1.5-1.el7.x86_64.rpm
 https://github.com/prometheus/haproxy_exporter/releases/download/v0.10.0/haproxy_exporter-0.10.0.linux-amd64.tar.gz
 https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.14.0/jmx_prometheus_javaagent-0.14.0.jar

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/add-repositories.sh
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/add-repositories.sh
@@ -12,9 +12,11 @@ echo "deb https://packages.grafana.com/oss/deb stable main" | tee /etc/apt/sourc
 wget -qO - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
 
-wget -qO - https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc | apt-key add -
-echo "deb http://dl.bintray.com/rabbitmq-erlang/debian bionic erlang-23.x" | tee /etc/apt/sources.list.d/erlang-23.x.list
-echo "deb https://dl.bintray.com/rabbitmq/debian bionic main" | tee /etc/apt/sources.list.d/rabbitmq.list
+wget -qO - https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | apt-key add -
+echo "deb https://packages.erlang-solutions.com/ubuntu bionic contrib" | tee /etc/apt/sources.list.d/erlang-23.x.list
+
+wget -qO - https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey | apt-key add -
+echo "deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu bionic main" | tee /etc/apt/sources.list.d/rabbitmq.list
 
 wget -qO -  https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" | tee /etc/apt/sources.list.d/docker-ce.list


### PR DESCRIPTION
PR related to task #2136 

- PackageCloud repository used for rabbitmq since it is recommend by official rabbitmq documentation and looks very solid (they archive packages for 5 years)
- Erlang-solution repository used for erlang for Ubuntu/Debian distribution - there is no better replacement, rabbitmq doesn't release erlang packages for Ubuntu/Debian distribution on rabbitmq github repository
- RabbitMQ github repository used for erlang package for RedHat/Centos distribution. Well suited to RabbitMQ