### PR TITLE
Fixed rabbitmq upgrade after recent changes

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/rabbitmq.yml
@@ -95,7 +95,7 @@
 
             - rabbitmq-server={{ versions.debian.rabbitmq }}
           RedHat:
-            - erlang-{{ versions.redhat.erlang }}
+            - "{{ repository_url }}/files/{{ versions.redhat.erlang_filename }}"
             - rabbitmq-server-{{ versions.redhat.rabbitmq }}
 
     - name: RabbitMQ | Start master


### PR DESCRIPTION
Fix for #2155 issue that was introduced by PR #2151. @przemyslavic could you test Ubuntu/Redhat upgrade before merge?

There is no changelog update as it's a fix related to a recent changes that were not released.