### PR TITLE
ARM support for monitoring components

### DIFF
--- a/CHANGELOG-0.11.md
+++ b/CHANGELOG-0.11.md
@@ -10,10 +10,13 @@
 - [#2111](https://github.com/epiphany-platform/epiphany/issues/2111) - [ARM64] Add arm64 support to 'load_balancer' component
 - [#2112](https://github.com/epiphany-platform/epiphany/issues/2112) - [ARM64] Add arm64 support to 'postgresql' component
 - [#2113](https://github.com/epiphany-platform/epiphany/issues/2113) - [ARM64] Add arm64 support to 'applications' Ansible role to install 'Keycloak'
+- [#2117](https://github.com/epiphany-platform/epiphany/issues/2117) - [ARM64] Add arm64 support to 'monitoring' component
 
 ### Fixed
 
 ### Updated
+
+- [#2117](https://github.com/epiphany-platform/epiphany/issues/2117) - [AMD64/ARM64] Postgres exporter updated to version 0.9.0
 
 ### Breaking changes
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/haproxy_exporter/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/haproxy_exporter/defaults/main.yml
@@ -1,0 +1,4 @@
+haproxy_exporter:
+  file_name:
+    x86_64: "haproxy_exporter-0.10.0.linux-amd64.tar.gz"
+    aarch64: "haproxy_exporter-0.10.0.linux-arm64.tar.gz"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/haproxy_exporter/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/haproxy_exporter/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Set HAProxy Exporter file name to install
   set_fact:
-    exporter_file_name: "{{ specification.file_name }}"
+    exporter_file_name: "{{ haproxy_exporter.file_name[ansible_architecture] }}"
 
 - name: Download HAProxy Exporter binaries
   include_role:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kafka_exporter/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kafka_exporter/defaults/main.yml
@@ -1,3 +1,7 @@
 ---
 
 kafka_instances: "--kafka.server={{ groups['kafka']|join(':9092 --kafka.server=') }}:9092"
+kafka_exporter:
+  file_name:
+    x86_64: "kafka_exporter-1.2.0.linux-amd64.tar.gz"
+    aarch64: "kafka_exporter-1.2.0.linux-arm64.tar.gz"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/kafka_exporter/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/kafka_exporter/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Set Kafka Exporter file name to install
   set_fact:
-    exporter_file_name: "{{ specification.file_name }}"
+    exporter_file_name: "{{ kafka_exporter.file_name[ansible_architecture] }}"
 
 - name: Download Kafka Exporter binaries
   include_role:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/defaults/main.yml
@@ -4,6 +4,9 @@ exporter:
   service:
     description: "Service that runs Prometheus Node Exporter"
     name: prometheus-node-exporter
+    file_name:
+      x86_64: "node_exporter-1.0.1.linux-amd64.tar.gz"
+      aarch64: "node_exporter-1.0.1.linux-arm64.tar.gz"
 node_exporter_helm_chart_name: node-exporter
 # Use dedicated namespace for monitoring charts such as node exporter in case of k8s as cloud service.
 monitoring_chart_namespace: epi-monitoring

--- a/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/tasks/install-node-exporter-as-system-service.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/tasks/install-node-exporter-as-system-service.yml
@@ -16,7 +16,7 @@
 
 - name: Set Node Exporter file name to install
   set_fact:
-    exporter_file_name: "node_exporter-{{ exporter.version }}.linux-amd64.tar.gz"
+    exporter_file_name: "{{ exporter.service.file_name[ansible_architecture] }}"
 
 - name: Download Node Exporter binaries
   include_role:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/postgres_exporter/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/postgres_exporter/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 exporter:
-  version: "0.8.0"
+  version: "0.9.0"
+  file_name:
+    x86_64: "postgres_exporter-0.9.0.linux-amd64.tar.gz"
+    aarch64: "postgres_exporter-0.9.0.linux-arm64.tar.gz"
   service:
     description: "Service that runs Postgres Exporter"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/postgres_exporter/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/postgres_exporter/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Set Postgres Exporter file name to install
   set_fact:
-    exporter_file_name: "postgres_exporter_v{{ exporter.version }}_linux-amd64.tar.gz"
+    exporter_file_name: "{{ exporter.file_name[ansible_architecture] }}"
 
 - name: Download Postgres Exporter binaries
   include_role:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/prometheus/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/prometheus/defaults/main.yml
@@ -1,5 +1,13 @@
 ---
 prometheus_external_labels:
   environment: "{{ ansible_fqdn }}"
-prometheus_filename: "prometheus-2.10.0.linux-amd64.tar.gz"
-alertmanager_filename: "alertmanager-0.17.0.linux-amd64.tar.gz"
+
+prometheus:
+  file_name:
+    x86_64: "prometheus-2.10.0.linux-amd64.tar.gz"
+    aarch64: "prometheus-2.10.0.linux-arm64.tar.gz"
+
+alertmanager:
+  file_name:
+    x86_64: "alertmanager-0.17.0.linux-amd64.tar.gz"
+    aarch64: "alertmanager-0.17.0.linux-arm64.tar.gz"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/prometheus/tasks/install-alertmanager.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/prometheus/tasks/install-alertmanager.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set Alertmanager file name to install
   set_fact:
-    binary_file_name: "{{ alertmanager_filename }}"
+    binary_file_name: "{{ alertmanager.file_name[ansible_architecture] }}"
 
 - name: Download Alertmanager binaries
   include_role:

--- a/core/src/epicli/data/common/ansible/playbooks/roles/prometheus/tasks/install.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/prometheus/tasks/install.yml
@@ -35,7 +35,7 @@
 
 - name: Set Prometheus file name to install
   set_fact:
-    binary_file_name: "{{ prometheus_filename }}"
+    binary_file_name: "{{ prometheus.file_name[ansible_architecture] }}"
 
 - name: Package
   debug: msg="{{ binary_file_name }}"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.aarch64.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.aarch64.txt
@@ -43,7 +43,7 @@ firewalld
 fontconfig # for grafana
 fping
 gnutls # for cifs-utils
-#grafana-7.3.5
+grafana-7.3.5
 gssproxy # for nfs-utils
 htop
 iftop
@@ -140,7 +140,7 @@ https://archive.apache.org/dist/zookeeper/zookeeper-3.5.8/apache-zookeeper-3.5.8
 https://releases.hashicorp.com/vault/1.6.1/vault_1.6.1_linux_arm64.zip
 https://get.helm.sh/helm-v3.2.0-linux-arm64.tar.gz
 https://github.com/hashicorp/vault-helm/archive/v0.9.0.tar.gz
-#https://github.com/wrouesnel/postgres_exporter/releases/download/v0.8.0/postgres_exporter_v0.8.0_linux-amd64.tar.gz
+https://github.com/prometheus-community/postgres_exporter/releases/download/v0.9.0/postgres_exporter-0.9.0.linux-arm64.tar.gz
 https://charts.bitnami.com/bitnami/node-exporter-1.1.2.tgz
 https://helm.elastic.co/helm/filebeat/filebeat-7.9.2.tgz
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.x86_64.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.x86_64.txt
@@ -165,7 +165,7 @@ https://archive.apache.org/dist/ignite/2.9.1/apache-ignite-2.9.1-bin.zip
 https://releases.hashicorp.com/vault/1.6.1/vault_1.6.1_linux_amd64.zip
 https://get.helm.sh/helm-v3.2.0-linux-amd64.tar.gz
 https://github.com/hashicorp/vault-helm/archive/v0.9.0.tar.gz
-https://github.com/wrouesnel/postgres_exporter/releases/download/v0.8.0/postgres_exporter_v0.8.0_linux-amd64.tar.gz
+https://github.com/prometheus-community/postgres_exporter/releases/download/v0.9.0/postgres_exporter-0.9.0.linux-amd64.tar.gz
 https://charts.bitnami.com/bitnami/node-exporter-1.1.2.tgz
 https://helm.elastic.co/helm/filebeat/filebeat-7.9.2.tgz
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.x86_64.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.x86_64.txt
@@ -161,7 +161,7 @@ https://archive.apache.org/dist/ignite/2.9.1/apache-ignite-2.9.1-bin.zip
 https://releases.hashicorp.com/vault/1.6.1/vault_1.6.1_linux_amd64.zip
 https://get.helm.sh/helm-v3.2.0-linux-amd64.tar.gz
 https://github.com/hashicorp/vault-helm/archive/v0.9.0.tar.gz
-https://github.com/wrouesnel/postgres_exporter/releases/download/v0.8.0/postgres_exporter_v0.8.0_linux-amd64.tar.gz
+https://github.com/prometheus-community/postgres_exporter/releases/download/v0.9.0/postgres_exporter-0.9.0.linux-amd64.tar.gz
 https://charts.bitnami.com/bitnami/node-exporter-1.1.2.tgz
 https://helm.elastic.co/helm/filebeat/filebeat-7.9.2.tgz
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.x86_64.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.x86_64.txt
@@ -217,7 +217,7 @@ https://archive.apache.org/dist/ignite/2.9.1/apache-ignite-2.9.1-bin.zip
 https://releases.hashicorp.com/vault/1.6.1/vault_1.6.1_linux_amd64.zip
 https://get.helm.sh/helm-v3.2.0-linux-amd64.tar.gz
 https://github.com/hashicorp/vault-helm/archive/v0.9.0.tar.gz
-https://github.com/wrouesnel/postgres_exporter/releases/download/v0.8.0/postgres_exporter_v0.8.0_linux-amd64.tar.gz
+https://github.com/prometheus-community/postgres_exporter/releases/download/v0.9.0/postgres_exporter-0.9.0.linux-amd64.tar.gz
 https://charts.bitnami.com/bitnami/node-exporter-1.1.2.tgz
 https://helm.elastic.co/helm/filebeat/filebeat-7.9.2.tgz
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/upgrade/tasks/node-exporter.yml
@@ -57,7 +57,7 @@
 
 - name: Node Exporter as System Service | Set exporter_file_name fact
   set_fact:
-    exporter_file_name: "node_exporter-{{ exporter_defaults.exporter.version }}.linux-amd64.tar.gz"
+    exporter_file_name: "{{ exporter_defaults.exporter.service.file_name[ansible_architecture] }}"
 
 - name: Node Exporter as System Service | Collect version
   shell: >-

--- a/core/src/epicli/data/common/defaults/configuration/haproxy-exporter.yml
+++ b/core/src/epicli/data/common/defaults/configuration/haproxy-exporter.yml
@@ -2,8 +2,6 @@ kind: configuration/haproxy-exporter
 title: "HAProxy exporter"
 name: default
 specification:
-  version: 0.10.0 
-  file_name: "haproxy_exporter-0.10.0.linux-amd64.tar.gz"
   description: "Service that runs HAProxy Exporter"
 
   web_listen_port: "9101"

--- a/core/src/epicli/data/common/defaults/configuration/kafka-exporter.yml
+++ b/core/src/epicli/data/common/defaults/configuration/kafka-exporter.yml
@@ -3,9 +3,7 @@ title: "Kafka exporter"
 name: default
 specification:
   description: "Service that runs Kafka Exporter"
-  version: 1.2.0
-  file_name: "kafka_exporter-1.2.0.linux-amd64.tar.gz"
-  
+
   web_listen_port: "9308"
   config_flags:
     - "--web.listen-address=:9308" # Address to listen on for web interface and telemetry.

--- a/core/src/epicli/data/common/defaults/configuration/postgres-exporter.yml
+++ b/core/src/epicli/data/common/defaults/configuration/postgres-exporter.yml
@@ -6,7 +6,7 @@ specification:
   - --log.level=info
   - --extend.query-path=/opt/postgres_exporter/queries.yaml
   - --auto-discover-databases
-  # Please see optional flags: https://github.com/wrouesnel/postgres_exporter/tree/v0.8.0#flags
+  # Please see optional flags: https://github.com/prometheus-community/postgres_exporter/tree/v0.9.0#flags
   config_for_prometheus:
     exporter_listen_port: '9187'
     prometheus_config_dir: /etc/prometheus

--- a/docs/home/COMPONENTS.md
+++ b/docs/home/COMPONENTS.md
@@ -30,6 +30,7 @@ Note that versions are default versions and can be changed in certain cases thro
 | Kafka Exporter             | 1.2.0    | https://github.com/danielqsj/kafka_exporter           | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | HAProxy Exporter           | 0.10.0   | https://github.com/prometheus/haproxy_exporter        | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | JMX Exporter               | 0.12.0   | https://github.com/prometheus/jmx_exporter            | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| Postgres Exporter          | 0.9.0    | https://github.com/prometheus-community/postgres_exporter | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | PostgreSQL                 | 10       | https://www.postgresql.org/                           | https://opensource.org/licenses/postgresql                        |
 | HAProxy                    | 2.2.2    | https://www.haproxy.org/                              | [GNU General Public License 2.0](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html) |
 | PGAudit                    | 1.2.2    | https://github.com/pgaudit/pgaudit                    | [PostgreSQL license](http://www.postgresql.org/about/licence/)    |


### PR DESCRIPTION
PR related to task #2117 
- ARM support for monitoring components added 
- Postgres Exporter updated to v0.9.0 because v0.8.0 doesn't support ARM arch. 
- With the changes I created cluster with success and also checked Prometheus, Grafana, Node Exporters, Kafka, Zookeeper, JMX exporters, HAProxy and Postgres Exporter if they works. Everything looks fine. 