### PR TITLE
Upgraded logstash to v7.12.0

### DIFF
--- a/CHANGELOG-0.11.md
+++ b/CHANGELOG-0.11.md
@@ -22,6 +22,7 @@
 ### Updated
 
 - [#2117](https://github.com/epiphany-platform/epiphany/issues/2117) - [AMD64/ARM64] Postgres exporter updated to version 0.9.0
+- [#2116](https://github.com/epiphany-platform/epiphany/issues/2116) - Logstash updated to version 7.12.0
 
 ### Breaking changes
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/logstash/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/logstash/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 versions:
-  RedHat: "7.8.1"
-  Debian: "1:7.8.1*"
+  RedHat: "7.12.0"
+  Debian: "1:7.12.0*"

--- a/core/src/epicli/data/common/ansible/playbooks/roles/logstash/tasks/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/logstash/tasks/main.yml
@@ -5,13 +5,10 @@
     state: present
   vars:
     _packages:
-      # Bundled with ElasticSearch OpenJDK 15 doesn't work correctly with Logstash
-      # as there are startup options that are deprecated in OpenJDK 15 such as UseConcMarkSweepGC
+      # Logstash is installed with bundled JDK
       Debian:
-        - openjdk-8-jre-headless
         - logstash-oss={{ versions[ansible_os_family] }}
       RedHat:
-        - java-1.8.0-openjdk-headless
         - logstash-oss-{{ versions[ansible_os_family] }}
   module_defaults:
     yum: { lock_timeout: "{{ yum_lock_timeout }}" }

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.aarch64.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.aarch64.txt
@@ -58,7 +58,7 @@ libxcb # for grafana
 libXcursor # for grafana
 libXt # for grafana
 logrotate
-logstash-oss-7.8.1
+logstash-oss-7.12.0
 net-tools
 nfs-utils
 nmap-ncat

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.x86_64.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.x86_64.txt
@@ -59,7 +59,7 @@ libxcb # for grafana
 libXcursor # for grafana
 libXt # for grafana
 logrotate
-logstash-oss-7.8.1
+logstash-oss-7.12.0
 net-tools
 nfs-utils
 nmap-ncat

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.x86_64.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.x86_64.txt
@@ -57,7 +57,7 @@ libxcb # for grafana
 libXcursor # for grafana
 libXt # for grafana
 logrotate
-logstash-oss-7.8.1
+logstash-oss-7.12.0
 net-tools
 nfs-utils
 nmap-ncat

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.x86_64.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.x86_64.txt
@@ -52,7 +52,7 @@ iftop
 jq
 libfontconfig1
 logrotate
-logstash-oss 1:7.8.1
+logstash-oss 1:7.12.0
 netcat
 net-tools
 nfs-common

--- a/docs/home/COMPONENTS.md
+++ b/docs/home/COMPONENTS.md
@@ -16,13 +16,13 @@ Note that versions are default versions and can be changed in certain cases thro
 | RabbitMQ                   | 3.8.9    | https://github.com/rabbitmq/rabbitmq-server           | [Mozilla Public License](https://www.mozilla.org/en-US/MPL/)      |
 | Docker CE                  | 19.03.14 | https://github.com/docker/docker-ce/                  | [Apache License](https://www.apache.org/licenses/LICENSE-1.0)     |
 | KeyCloak                   | 9.0.0    | https://github.com/keycloak/keycloak                  | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
-| Elasticsearch OSS          | 7.10.2    | https://github.com/elastic/elasticsearch              | https://github.com/elastic/elasticsearch/blob/master/LICENSE.txt  |
+| Elasticsearch OSS          | 7.10.2   | https://github.com/elastic/elasticsearch              | https://github.com/elastic/elasticsearch/blob/master/LICENSE.txt  |
 | Elasticsearch Curator OSS  | 5.8.3    | https://github.com/elastic/curator                    | https://github.com/elastic/curator/blob/master/LICENSE.txt        |
 | Opendistro for Elasticsearch          | 1.13.x   | https://opendistro.github.io/for-elasticsearch/                  | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Opendistro for Elasticsearch Kibana   | 1.13.1   | https://opendistro.github.io/for-elasticsearch-docs/docs/kibana/ | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Filebeat                   | 7.9.2    | https://github.com/elastic/beats                      | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Filebeat Helm Chart        | 7.9.2    | https://github.com/elastic/helm-charts                | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
-| Logstash OSS               | 7.8.1    | https://github.com/elastic/logstash                   | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| Logstash OSS               | 7.12.0   | https://github.com/elastic/logstash                   | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Prometheus                 | 2.10.0   | https://github.com/prometheus/prometheus              | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Grafana                    | 7.3.5    | https://github.com/grafana/grafana                    | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Node Exporter              | 1.0.1    | https://github.com/prometheus/node_exporter           | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |

--- a/docs/home/howto/LOGGING.md
+++ b/docs/home/howto/LOGGING.md
@@ -1,7 +1,8 @@
 # Centralized logging setup
 
 For centralized logging Epiphany uses [OpenDistro for Elasticsearch](https://opendistro.github.io/for-elasticsearch/).
-In order to enable centralized logging, be sure that `count` property for `logging` feature is greater than 0 in your configuration manifest.
+In order to enable centralized logging, be sure that `count` property for `logging` feature is greater than 0 in your
+configuration manifest.
 
 ```yaml
 kind: epiphany-cluster
@@ -22,21 +23,25 @@ specification:
 ## Default feature mapping for logging
 
 ```yaml
-    ...
-    logging:
-      - logging
-      - kibana
-      - node-exporter
-      - filebeat
-      - firewall
-    ...
+...
+logging:
+  - logging
+  - kibana
+  - node-exporter
+  - filebeat
+  - firewall
+...
 ```
->Optional feature (role) available for logging: **logstash**
->more details here: [link](https://github.com/epiphany-platform/epiphany/blob/develop/docs/home/howto/LOGGING.md#how-to-export-elasticsearch-data-to-csv-format)
 
-The `logging` role replaced `elasticsearch` role. This change was done to enable Elasticsearch usage also for data storage - not only for logs as it was till 0.5.0.
+> Optional feature (role) available for logging: **logstash**
+> more details here: [link](https://github.com/epiphany-platform/epiphany/blob/develop/docs/home/howto/LOGGING.md#how-to-export-elasticsearch-data-to-csv-format)
 
-Default configuration of `logging` and `opendistro_for_elasticsearch` roles is identical (./DATABASES.md#how-to-start-working-with-opendistro-for-elasticsearch). To modify configuration of centralized logging adjust and use the following defaults in your manifest:
+The `logging` role replaced `elasticsearch` role. This change was done to enable Elasticsearch usage also for data
+storage - not only for logs as it was till 0.5.0.
+
+Default configuration of `logging` and `opendistro_for_elasticsearch` roles is identical (
+./DATABASES.md#how-to-start-working-with-opendistro-for-elasticsearch). To modify configuration of centralized logging
+adjust and use the following defaults in your manifest:
 
 ```yaml
 kind: configuration/logging
@@ -50,18 +55,24 @@ specification:
     repo: /var/lib/elasticsearch-snapshots
     logs: /var/log/elasticsearch
 ```
+
 ## How to manage Opendistro for Elasticsearch data
 
-Elasticsearch stores data using JSON documents, and an Index is a collection of documents. As in every database it's crutial to correctly maintain data in this one. It's almost impossible to deliver database configuration which will fit to every type of project and data stored in. Epiphany deploys preconfigured Opendistro Elasticsearch, but this configuration may not meet user requirements. Before going to production configuration shoud be tailor to the project needs. All configuration tips and tricks are available in [official documentation](https://opendistro.github.io/for-elasticsearch-docs/).
+Elasticsearch stores data using JSON documents, and an Index is a collection of documents. As in every database, it's
+crucial to correctly maintain data in this one. It's almost impossible to deliver database configuration which will fit
+to every type of project and data stored in. Epiphany deploys preconfigured Opendistro Elasticsearch, but this
+configuration may not meet user requirements. Before going to production, configuration should be tailored to the
+project needs. All configuration tips and tricks are available
+in [official documentation](https://opendistro.github.io/for-elasticsearch-docs/).
 
 The main and most important decisions to take before you deploy cluster are:
 
 1) How many Nodes are needed
 2) How big machines and/or storage data disks need to be used
 
-These parameters are defined in yaml file and it's important to create a big enough cluster.
+These parameters are defined in yaml file, and it's important to create a big enough cluster.
 
-```
+```yaml
 specification:
   components:
     logging:
@@ -74,26 +85,40 @@ specification:
   size: Standard_DS2_v2    #  Choose machine size
 ```
 
-If it's required to have Elasticsearch which works in cluster formation configuration, except setting up more than one machine in yaml config file please acquaint dedicated support [article](https://opendistro.github.io/for-elasticsearch-docs/docs/elasticsearch/cluster/) and adjust Elasticseach configuration file.
+If it's required to have Elasticsearch which works in cluster formation configuration, except setting up more than one
+machine in yaml config file please acquaint dedicated
+support [article](https://opendistro.github.io/for-elasticsearch-docs/docs/elasticsearch/cluster/) and adjust
+Elasticsearch configuration file.
 
-At this moment Opendistro for Elasticsearch does not support plugin similar to [ILM](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html), log rotation is possible only by configuration created in Index State Management.
+At this moment Opendistro for Elasticsearch does not support plugin similar
+to [ILM](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html), log rotation
+is possible only by configuration created in Index State Management.
 
-`ISM - Index State Management` - is a plugin that provides users and administrative panel to monitor the indices and apply policies at different index stages. ISM lets users automate periodic, administrative operations by triggering them besed on index age, size, or number of documents. Using the ISM plugin, can define policies that automatically handle index rollovers or deletions. ISM is installed with Opendistro by default - user does not have to enable this.
-Official documentation is available in [Opendistro for Elasticsearch website](https://opendistro.github.io/for-elasticsearch-docs/docs/im/ism/).
+`ISM - Index State Management` - is a plugin that provides users and administrative panel to monitor the indices and
+apply policies at different index stages. ISM lets users automate periodic, administrative operations by triggering them
+based on index age, size, or number of documents. Using the ISM plugin, can define policies that automatically handle
+index rollovers or deletions. ISM is installed with Opendistro by default - user does not have to enable this. Official
+documentation is available
+in [Opendistro for Elasticsearch website](https://opendistro.github.io/for-elasticsearch-docs/docs/im/ism/).
 
-To reduce the consumption of disk resources, every index you created should use well designed [policy](https://opendistro.github.io/for-elasticsearch-docs/docs/im/ism/policies/).
+To reduce the consumption of disk resources, every index you created should use
+well-designed [policy](https://opendistro.github.io/for-elasticsearch-docs/docs/im/ism/policies/).
 
 Among others these two index actions might save machine from filling up disk space:
 
-[`Index Rollover`](https://opendistro.github.io/for-elasticsearch-docs/docs/im/ism/policies/#rollover) - rolls an alias to a new index. Set up correctly max index size / age or minimum number of documents to keep index size in requirements framework.
+[`Index Rollover`](https://opendistro.github.io/for-elasticsearch-docs/docs/im/ism/policies/#rollover) - rolls an alias
+to a new index. Set up correctly max index size / age or minimum number of documents to keep index size in requirements
+framework.
 
-[`Index Deletion`](https://opendistro.github.io/for-elasticsearch-docs/docs/im/ism/policies/#delete) - deletes indexes managed by policy
+[`Index Deletion`](https://opendistro.github.io/for-elasticsearch-docs/docs/im/ism/policies/#delete) - deletes indexes
+managed by policy
 
-Combining these actions, adapting them to data amount and specification users are able to create policy which will maintain data in cluster  for example: to secure node from fullfilling disk space.
+Combining these actions, adapting them to data amount and specification users are able to create policy which will
+maintain data in cluster for example: to secure node from fulfilling disk space.
 
-There is example of policy below. Be aware that this is only example, and it needs to be adjust to environment needs.
+There is example of policy below. Be aware that this is only example, and it needs to be adjusted to environment needs.
 
-```
+```json
 {
     "policy": {
         "policy_id": "epi_policy",
@@ -158,13 +183,21 @@ There is example of policy below. Be aware that this is only example, and it nee
     }
 }
 ```
-Example above shows configuration with rollover daily or when index achieve 1GB size. Indexes older than 14 days will be deleted. States and condionals could be cobined. Please see [policies](https://opendistro.github.io/for-elasticsearch-docs/docs/im/ism/policies/) documentation for more details.
+
+Example above shows configuration with rollover daily or when index achieve 1 GB size. Indexes older than 14 days will
+be deleted. States and conditionals could be combined. Please
+see [policies](https://opendistro.github.io/for-elasticsearch-docs/docs/im/ism/policies/) documentation for more
+details.
 
 `Apply Policy`
 
 To apply policy use similar API request as presented below:
+
 ```
 PUT _template/template_01
+```
+
+```json
 {
   "index_patterns": ["filebeat*"],
   "settings": {
@@ -173,46 +206,75 @@ PUT _template/template_01
   }
 }
 ```
-After applying this policy every new index created under this one will apply to it. There is also possibility to apply policy to already existing policies by assigning them to policy in Index Management Kibana panel.
+
+After applying this policy, every new index created under this one will apply to it. There is also possibility to apply
+policy to already existing policies by assigning them to policy in Index Management Kibana panel.
 
 ## How to export Elasticsearch data to csv format
 
-Since v0.8 Epiphany provide posibility to export data from Elasticsearch to CSV using Logstash *(logstash-oss v7.8.1*) along with *logstash-input-elasticsearch (v4.6.2)* and *logstash-output-csv (v3.0.8)* plugin.
+Since v0.8 Epiphany provides possibility to export data from Elasticsearch to CSV using Logstash *(logstash-oss)* along
+with *logstash-input-elasticsearch* and *logstash-output-csv* plugins.
 
-To install Logstash in your cluster add **logstash** to feature mapping for *logging, opendistro_for_elasticsearch* or *elasticsearch* group.
+To install Logstash in your cluster add **logstash** to feature mapping for *logging, opendistro_for_elasticsearch* or *
+elasticsearch* group.
 
-Epiphany provides a basic configuration file `(logstash-export.conf.template)` as template for your data export.
-This file has to be modified according to your Elasticsearch configuration and data you want to export.
+---
+**NOTE**
 
-`Note: Exporting data is not automated. It has to be invoked manually. Logstash daemon is disabled by default after installation.`
+To check plugin versions following command can be used
+
+```shell
+/usr/share/logstash/bin/logstash-plugin list --verbose
+```
+
+---
+
+Epiphany provides a basic configuration file `(logstash-export.conf.template)` as template for your data export. This
+file has to be modified according to your Elasticsearch configuration and data you want to export.
+
+---
+**NOTE**
+
+Exporting data is not automated. It has to be invoked manually. Logstash daemon is disabled by default after
+installation.
+
+---
 
 Run Logstash to export data:  
 `/usr/share/logstash/bin/logstash -f /etc/logstash/logstash-export.conf`
 
-More details about configuration of input plugin:  
-https://www.elastic.co/guide/en/logstash/current/plugins-inputs-elasticsearch.html
+More details about configuration
+of [input](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-elasticsearch.html)
+and [output](https://www.elastic.co/guide/en/logstash/current/plugins-outputs-csv.html) plugins.
 
-More details about configuration of output plugin:  
-https://www.elastic.co/guide/en/logstash/current/plugins-outputs-csv.html
+---
+**NOTE**
 
-Note: Currently input plugin doesn't officialy support skipping certificate validation for secure connection to Elasticsearch.
+At the moment input plugin doesn't officially support skipping certificate validation for secure connection to
+Elasticsearch. For non-production environment you can easily disable it by adding new line:
 
-For non-production environment you can easly disable it by adding new line:  
-`ssl_options[:verify] = false` right after other ssl_options definitions in file:  
-`/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-elasticsearch-4.6.2/lib/logstash/inputs/elasticsearch.rb`
+`ssl_options[:verify] = false` right after other ssl_options definitions in file:
+
+`/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-elasticsearch-*/lib/logstash/inputs/elasticsearch.rb`
+
+---
 
 ## How to add multiline support for Filebeat logs
 
-In order to properly handle multilines in files harvested by Filebeat you have to provide `multiline` definition in the configuration manifest. Using the following code you will be able to specify which lines are part of a single event.
+In order to properly handle multilines in files harvested by Filebeat you have to provide `multiline` definition in the
+configuration manifest. Using the following code you will be able to specify which lines are part of a single event.
 
-By default postgresql block is provided, you can use it as example:  
+By default, postgresql block is provided, you can use it as example:
+
 ```yaml
-  postgresql_input:
-    multiline:
-      pattern: >-
-        '^\d{4}-\d{2}-\d{2} '
-      negate: true
-      match: after
+postgresql_input:
+  multiline:
+    pattern: >-
+      '^\d{4}-\d{2}-\d{2} '
+    negate: true
+    match: after
 ```
-Currently supported inputs: `common_input`,`postgresql_input`,`container_input`  
-More details about multiline options you can find in the [official documentation](https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html)
+
+Supported inputs: `common_input`,`postgresql_input`,`container_input`
+More details about multiline options you can find in
+the [official documentation](https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html)


### PR DESCRIPTION
Task #2116. This change is done as there is a bug for ARM in previous Logstash version we had. New version brings bundled JDK, so it's not necessary to install it additionally.