### PR TITLE
[BUG] Grafana does not show metrics from kafka and haproxy exporters

### DIFF
--- a/CHANGELOG-1.1.md
+++ b/CHANGELOG-1.1.md
@@ -28,6 +28,7 @@
 - [#2262](https://github.com/epiphany-platform/epiphany/issues/2262) - [Ubuntu] elasticsearch-curator in version 5.8.3 is not available from APT repo
 - [#2233](https://github.com/epiphany-platform/epiphany/issues/2233) - Filebeat communication error in AKS
 - [#2291](https://github.com/epiphany-platform/epiphany/issues/2291) - PostgreSQL automated tests fail when run on a single machine
+- [#2215](https://github.com/epiphany-platform/epiphany/issues/2215) - Grafana does not show metrics from kafka and haproxy exporters
 
 ### Updated
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/haproxy_exporter/templates/prometheus-haproxy-exporter.service.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/haproxy_exporter/templates/prometheus-haproxy-exporter.service.j2
@@ -5,7 +5,7 @@ Description={{ specification.description }}
 [Service]
 User=haproxy_exporter
 Group=haproxy_exporter
-ExecStart=/opt/haproxy_exporter/haproxy_exporter "--haproxy.scrape-uri=http://{{ stats_credentials }}@{{ stats_bind_address }}{{ stats_uri }}"
+ExecStart=/opt/haproxy_exporter/haproxy_exporter "--haproxy.scrape-uri=http://{{ stats_credentials }}@{{ stats_bind_address }}{{ stats_uri }};csv"
 SyslogIdentifier=prometheus_haproxy_exporter
 Restart=always
 

--- a/docs/home/howto/MONITORING.md
+++ b/docs/home/howto/MONITORING.md
@@ -187,6 +187,8 @@ List of monitoring components - so called exporters:
 
 When dashboard creation or import succeeds you will see it on your dashboard list.
 
+`Note: Depends on the dashboards which rely on variouse variables, in order to visualize the data it is necessary to generate traffic to the components which are monitored`
+
 # Kibana
 
 Kibana is an free and open frontend application that sits on top of the Elastic Stack, providing search and data visualization capabilities for data indexed in Elasticsearch. For more informations about Kibana please refer to [the official website](https://www.elastic.co/what-is/kibana).

--- a/docs/home/howto/MONITORING.md
+++ b/docs/home/howto/MONITORING.md
@@ -187,8 +187,7 @@ List of monitoring components - so called exporters:
 
 When dashboard creation or import succeeds you will see it on your dashboard list.
 
-`Note: Depends on the dashboards which rely on variouse variables, in order to visualize the data it is necessary to generate traffic to the components which are monitored`
-
+`Note: For some dashboards, there is no data to visualize until there is traffic activity for the monitored component.
 # Kibana
 
 Kibana is an free and open frontend application that sits on top of the Elastic Stack, providing search and data visualization capabilities for data indexed in Elasticsearch. For more informations about Kibana please refer to [the official website](https://www.elastic.co/what-is/kibana).

--- a/docs/home/howto/MONITORING.md
+++ b/docs/home/howto/MONITORING.md
@@ -188,6 +188,7 @@ List of monitoring components - so called exporters:
 When dashboard creation or import succeeds you will see it on your dashboard list.
 
 `Note: For some dashboards, there is no data to visualize until there is traffic activity for the monitored component.
+
 # Kibana
 
 Kibana is an free and open frontend application that sits on top of the Elastic Stack, providing search and data visualization capabilities for data indexed in Elasticsearch. For more informations about Kibana please refer to [the official website](https://www.elastic.co/what-is/kibana).


### PR DESCRIPTION
PR related to task #2215

- In case of Kafka Exporter everything works fine, it is necessary to generate traffic (create topic, send message and pull message from the topic using consumers group" - added small note in documentation 
- In case of HAProxy it is necessary to generate traffic and I also added csv format to stats uri which exporter use 