### PR TITLE
Default configuration of Kibana dashboards and indexes (#126)

### DIFF
--- a/CHANGELOG-1.2.md
+++ b/CHANGELOG-1.2.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- [#126](https://github.com/epiphany-platform/epiphany/issues/126) - Added default Kibana dashboards
 - [#2127](https://github.com/epiphany-platform/epiphany/issues/2127) - Allow to specify configuration to be used in upgrade mode
 - [#2397](https://github.com/epiphany-platform/epiphany/issues/2397) - Restart CoreDNS pods conditionally
 

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
@@ -179,12 +179,20 @@ setup.template.settings:
 # These settings control loading the sample dashboards to the Kibana index. Loading
 # the dashboards is disabled by default and can be enabled either by setting the
 # options here or by using the `setup` command.
-setup.dashboards.enabled: true
+{% if specification.kibana.dashboards.enable == 'auto' %}
+    {% if groups.kibana is defined %}
+        setup.dashboards.enabled: true
+    {% else %}
+        setup.dashboards.enabled: false
+    {% endif %}
+{% else %}
+    setup.dashboards.enabled: "{{ specification.kibana.dashboards.enable }}"
+{% endif %}
 
 # The Elasticsearch index name.
 # This setting overwrites the index name defined in the dashboards and index pattern.
 # Example: "testbeat-*"
-setup.dashboards.index: "filebeat-*"
+setup.dashboards.index: "{{ specification.kibana.dashboards.index }}"
 
 # The URL from where to download the dashboards archive. By default this URL
 # has a value which is computed based on the Beat name and version. For released

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
@@ -180,7 +180,6 @@ setup.template.settings:
 # the dashboards is disabled by default and can be enabled either by setting the
 # options here or by using the `setup` command.
 {% set dashboards_enabled = is_upgrade_run | ternary(specification.kibana.dashboards.enabled | default(False), specification.kibana.dashboards.enabled) %}
-
 {% if dashboards_enabled == 'auto' %}
   {% if groups.kibana is defined and groups.kibana | length > 0 %}
 setup.dashboards.enabled: true
@@ -188,7 +187,7 @@ setup.dashboards.enabled: true
 setup.dashboards.enabled: false
   {% endif %}
 {% else %}
-setup.dashboards.enabled: "{{ dashboards_enabled }}"
+setup.dashboards.enabled: "{{ dashboards_enabled | lower }}"
 {% endif %}
 
 # The Elasticsearch index name.

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
@@ -179,20 +179,23 @@ setup.template.settings:
 # These settings control loading the sample dashboards to the Kibana index. Loading
 # the dashboards is disabled by default and can be enabled either by setting the
 # options here or by using the `setup` command.
-{% if specification.kibana.dashboards.enable == 'auto' %}
-    {% if groups.kibana is defined %}
-        setup.dashboards.enabled: true
-    {% else %}
-        setup.dashboards.enabled: false
-    {% endif %}
+{% set dashboards_enabled = is_upgrade_run | ternary(specification.kibana.dashboards.enabled | default(False), specification.kibana.dashboards.enabled) %}
+
+{% if dashboards_enabled == 'auto' %}
+  {% if groups.kibana is defined and groups.kibana | length > 0 %}
+setup.dashboards.enabled: true
+  {% else %}
+setup.dashboards.enabled: false
+  {% endif %}
 {% else %}
-    setup.dashboards.enabled: "{{ specification.kibana.dashboards.enable }}"
+setup.dashboards.enabled: "{{ dashboards_enabled }}"
 {% endif %}
 
 # The Elasticsearch index name.
 # This setting overwrites the index name defined in the dashboards and index pattern.
 # Example: "testbeat-*"
-setup.dashboards.index: "{{ specification.kibana.dashboards.index }}"
+{% set dashboards_index  = is_upgrade_run | ternary(specification.kibana.dashboards.index | default('filebeat-*'), specification.kibana.dashboards.index) %}
+setup.dashboards.index: "{{ dashboards_index }}"
 
 # The URL from where to download the dashboards archive. By default this URL
 # has a value which is computed based on the Beat name and version. For released

--- a/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
@@ -179,7 +179,12 @@ setup.template.settings:
 # These settings control loading the sample dashboards to the Kibana index. Loading
 # the dashboards is disabled by default and can be enabled either by setting the
 # options here or by using the `setup` command.
-setup.dashboards.enabled: false
+setup.dashboards.enabled: true
+
+# The Elasticsearch index name.
+# This setting overwrites the index name defined in the dashboards and index pattern.
+# Example: "testbeat-*"
+setup.dashboards.index: "filebeat-*"
 
 # The URL from where to download the dashboards archive. By default this URL
 # has a value which is computed based on the Beat name and version. For released

--- a/core/src/epicli/data/common/defaults/configuration/filebeat.yml
+++ b/core/src/epicli/data/common/defaults/configuration/filebeat.yml
@@ -5,7 +5,7 @@ specification:
   kibana:
     dashboards:
       index: 'filebeat-*'
-      enable: 'auto'
+      enabled: 'auto'
   disable_helm_chart: false
   postgresql_input:
     multiline:

--- a/core/src/epicli/data/common/defaults/configuration/filebeat.yml
+++ b/core/src/epicli/data/common/defaults/configuration/filebeat.yml
@@ -2,6 +2,10 @@ kind: configuration/filebeat
 title: Filebeat
 name: default
 specification:
+  kibana:
+    dashboards:
+      index: 'filebeat-*'
+      enable: 'auto'
   disable_helm_chart: false
   postgresql_input:
     multiline:

--- a/core/src/epicli/data/common/defaults/configuration/filebeat.yml
+++ b/core/src/epicli/data/common/defaults/configuration/filebeat.yml
@@ -4,8 +4,8 @@ name: default
 specification:
   kibana:
     dashboards:
-      index: 'filebeat-*'
-      enabled: 'auto'
+      index: filebeat-*
+      enabled: auto
   disable_helm_chart: false
   postgresql_input:
     multiline:

--- a/docs/home/howto/LOGGING.md
+++ b/docs/home/howto/LOGGING.md
@@ -302,3 +302,19 @@ specification:
   cloud:
     k8s_as_cloud_service: true
 ```
+
+## How to use default Kibana dashboards
+
+Default Filebeat configuration sets this option to 'auto'. In this case if Kibana service exists it will be enabled - false otherwise.
+Other possible values are True and False.
+
+Default configuration:
+```
+specification:
+  kibana:
+    dashboards:
+      enabled: 'auto'
+      index: 'filebeat-*'
+```
+
+Setting this option to True and not providing Kibana will result in a Filebeat crash.

--- a/docs/home/howto/LOGGING.md
+++ b/docs/home/howto/LOGGING.md
@@ -305,16 +305,17 @@ specification:
 
 ## How to use default Kibana dashboards
 
-Default Filebeat configuration sets this option to 'auto'. In this case if Kibana service exists it will be enabled - false otherwise.
-Other possible values are True and False.
+It is possible to configure `setup.dashboards.enabled` and `setup.dashboards.index` Filebeat settings using `specification.kibana.dashboards` key in `configuration/filebeat` doc.
+When `specification.kibana.dashboards.enabled` is set to `auto`, the corresponding setting in Filebeat configuration file will be set to `true` only if Kibana is configured to be present on the host.
+Other possible values are `true` and `false`.
 
 Default configuration:
 ```
 specification:
   kibana:
     dashboards:
-      enabled: 'auto'
-      index: 'filebeat-*'
+      enabled: auto
+      index: filebeat-*
 ```
 
-Setting this option to True and not providing Kibana will result in a Filebeat crash.
+Note: Setting `specification.kibana.dashboards.enabled` to `true` not providing Kibana will result in a Filebeat crash.


### PR DESCRIPTION
* Dashboards enabled by default

* Default index set to "filebeat-*"