### PR TITLE
Fix/log path issue

### DIFF
--- a/CHANGELOG-1.2.md
+++ b/CHANGELOG-1.2.md
@@ -24,6 +24,7 @@
 - [#2449](https://github.com/epiphany-platform/epiphany/issues/2449) - [Grafana] Unable to add Grafana repository
 - [#2485](https://github.com/epiphany-platform/epiphany/issues/2485) - [Upgrade] Refactor upgrade role to not include "specification" at top level
 - [#2521](https://github.com/epiphany-platform/epiphany/issues/2521) - Fix 2 unit tests that are marked to be skipped during test execution
+- [#2542](https://github.com/epiphany-platform/epiphany/issues/2542) - Non critical error in epicli if no 'path' is provided
 
 ### Updated
 

--- a/core/src/epicli/.devcontainer/Dockerfile
+++ b/core/src/epicli/.devcontainer/Dockerfile
@@ -66,4 +66,4 @@ RUN : SETUP USER, CERTS AND OTHERS \
  && setcap 'cap_net_bind_service=+ep' /usr/bin/ssh \
  && /bin/bash /config-post.sh
 
-RUN echo alias epicli='"cd /workspaces/epiphany/core/src/epicli && PYTHONPATH=$(pwd) python3 cli/epicli.py"' >> /etc/bash.bashrc
+RUN echo alias epicli='"PYTHONPATH=/workspaces/epiphany/core/src/epicli && python3 -m cli.epicli"' >> /etc/bash.bashrc

--- a/core/src/epicli/.devcontainer/Dockerfile
+++ b/core/src/epicli/.devcontainer/Dockerfile
@@ -66,4 +66,4 @@ RUN : SETUP USER, CERTS AND OTHERS \
  && setcap 'cap_net_bind_service=+ep' /usr/bin/ssh \
  && /bin/bash /config-post.sh
 
-RUN echo alias epicli='"cd /workspaces/epiphany/core/src/epicli && PYTHONPATH=$(pwd) python3 cli/epicli.py"' >> /etc/bash.bashrc
+RUN echo alias epicli='"export PYTHONPATH=/workspaces/epiphany/core/src/epicli && python3 -m cli.epicli"' >> /etc/bash.bashrc

--- a/core/src/epicli/.devcontainer/Dockerfile
+++ b/core/src/epicli/.devcontainer/Dockerfile
@@ -66,4 +66,4 @@ RUN : SETUP USER, CERTS AND OTHERS \
  && setcap 'cap_net_bind_service=+ep' /usr/bin/ssh \
  && /bin/bash /config-post.sh
 
-RUN echo alias epicli='"PYTHONPATH=$(pwd) python3 cli/epicli.py"' >> /etc/bash.bashrc
+RUN echo alias epicli='"cd /workspaces/epiphany/core/src/epicli && PYTHONPATH=$(pwd) python3 cli/epicli.py"' >> /etc/bash.bashrc

--- a/core/src/epicli/.devcontainer/Dockerfile
+++ b/core/src/epicli/.devcontainer/Dockerfile
@@ -66,4 +66,4 @@ RUN : SETUP USER, CERTS AND OTHERS \
  && setcap 'cap_net_bind_service=+ep' /usr/bin/ssh \
  && /bin/bash /config-post.sh
 
-RUN echo alias epicli='"PYTHONPATH=/workspaces/epiphany/core/src/epicli && python3 -m cli.epicli"' >> /etc/bash.bashrc
+RUN echo alias epicli='"cd /workspaces/epiphany/core/src/epicli && PYTHONPATH=$(pwd) python3 cli/epicli.py"' >> /etc/bash.bashrc

--- a/core/src/epicli/.devcontainer/Dockerfile
+++ b/core/src/epicli/.devcontainer/Dockerfile
@@ -65,3 +65,5 @@ RUN : SETUP USER, CERTS AND OTHERS \
  && chmod ug=r,o= /etc/sudoers.d/$USERNAME \
  && setcap 'cap_net_bind_service=+ep' /usr/bin/ssh \
  && /bin/bash /config-post.sh
+
+RUN echo alias epicli='"PYTHONPATH=$(pwd) python3 cli/epicli.py"' >> /etc/bash.bashrc

--- a/core/src/epicli/cli/epicli.py
+++ b/core/src/epicli/cli/epicli.py
@@ -423,9 +423,10 @@ def ensure_vault_password_is_cleaned():
 
 
 def log_total_run_time():
-    logger = Log('run_time')
-    passed_time = format_time(time.time()-start_time)
-    logger.info(f'Total run time: {passed_time}')
+    if Config().output_dir is not None:
+        logger = Log('run_time')
+        passed_time = format_time(time.time()-start_time)
+        logger.info(f'Total run time: {passed_time}')
 
 
 def exit_handler():


### PR DESCRIPTION
- Fixed error in epicli if no 'path' is provided. Causes issue when running commands like: epicli --help
- Also added alias for epicli to .bashrc so you run epicli easily without debugger in the devcontainer