### PR TITLE
Added ansible-lint and rubocop to the devcontainer

### DIFF
--- a/CHANGELOG-1.2.md
+++ b/CHANGELOG-1.2.md
@@ -12,6 +12,7 @@
 - [#2346](https://github.com/epiphany-platform/epiphany/issues/2346) - Allow more than 2 PostgreSQL nodes installation with repmgr
 - [#2124](https://github.com/epiphany-platform/epiphany/issues/2124) - Added Internet connection test to download-requirements.sh
 - [#2531](https://github.com/epiphany-platform/epiphany/issues/2531) - Add Pylint configuration to epicli devcontainer
+- [#1892](https://github.com/epiphany-platform/epiphany/issues/1892) - Add ansible-lint to epicli devcontainer
 
 ### Fixed
 

--- a/CHANGELOG-1.2.md
+++ b/CHANGELOG-1.2.md
@@ -13,6 +13,7 @@
 - [#2124](https://github.com/epiphany-platform/epiphany/issues/2124) - Added Internet connection test to download-requirements.sh
 - [#2531](https://github.com/epiphany-platform/epiphany/issues/2531) - Add Pylint configuration to epicli devcontainer
 - [#1892](https://github.com/epiphany-platform/epiphany/issues/1892) - Add ansible-lint to epicli devcontainer
+- [#2558](https://github.com/epiphany-platform/epiphany/issues/2558) - Add rubocop to epicli devcontainer
 
 ### Fixed
 

--- a/core/src/epicli/.ansible-lint
+++ b/core/src/epicli/.ansible-lint
@@ -1,0 +1,14 @@
+---
+skip_list:
+  - yaml
+warn_list:
+  - command-instead-of-module  # Using command rather than module
+  - command-instead-of-shell   # Use shell only when shell functionality is required
+  - experimental               # all rules tagged as experimental
+  - metadata                   # all metadata tests
+  - no-changed-when            # Commands should not change things if nothing needs doing
+  - package-latest             # Package installs should not use latest
+  - risky-shell-pipe           # Shells that use pipes should set the pipefail option
+  - risky-file-permissions     # File permissions unset or incorrect
+  - role-name                  # Galaxy role name standards
+  - unnamed-task               # All tasks should be named

--- a/core/src/epicli/.devcontainer/Dockerfile
+++ b/core/src/epicli/.devcontainer/Dockerfile
@@ -46,7 +46,7 @@ RUN : INSTALL HELM BINARY \
 
 RUN : INSTALL GEM REQUIREMENTS \
  && gem install \
-    rake rspec_junit_formatter serverspec solargraph
+    rake rspec_junit_formatter serverspec solargraph rubocop rubocop-junit_formatter
 
 COPY requirements.txt /
 

--- a/core/src/epicli/.devcontainer/Dockerfile
+++ b/core/src/epicli/.devcontainer/Dockerfile
@@ -54,7 +54,7 @@ RUN : INSTALL PIP REQUIREMENTS \
  && pip install --disable-pip-version-check --no-cache-dir --default-timeout=100 \
     --requirement /requirements.txt \
  && pip install --disable-pip-version-check --no-cache-dir --default-timeout=100 \
-    poetry pylint pylint_junit pytest setuptools twine wheel
+    poetry pylint pylint_junit ansible-lint ansible-lint-to-junit-xml pytest setuptools twine wheel
 
 COPY cert/config-post.sh /
 

--- a/core/src/epicli/.rubocop.yml
+++ b/core/src/epicli/.rubocop.yml
@@ -1,0 +1,13 @@
+# The behavior of RuboCop can be controlled via the .rubocop.yml
+# configuration file. It makes it possible to enable/disable
+# certain cops (checks) and to alter their behavior if they accept
+# any parameters. The file can be placed either in your home
+# directory or in some project directory.
+#
+# RuboCop will start looking for the configuration file in the directory
+# where the inspected file is and continue its way up to the root directory.
+#
+# See https://docs.rubocop.org/rubocop/configuration
+AllCops:
+  Include:
+    - data/common/tests/**/*.rb

--- a/core/src/epicli/.vscode/extensions.json
+++ b/core/src/epicli/.vscode/extensions.json
@@ -11,6 +11,9 @@
         // Python
         "ms-python.python",
         "littlefoxteam.vscode-python-test-adapter",
+        // Ruby
+        "rebornix.Ruby",
+        "castwide.solargraph",
         // Shell
         "timonwong.shellcheck",
         // Terraform

--- a/core/src/epicli/.vscode/launch.json
+++ b/core/src/epicli/.vscode/launch.json
@@ -25,26 +25,6 @@
             // "args": ["test", "-b", "${workspaceFolder}/clusters/build/<DIR>", "-g", "<TEST_GROUP>"]
             // "args": ["upgrade", "-b", "${workspaceFolder}/clusters/build/<DIR>"]
             // "args": ["upgrade", "-b", "${workspaceFolder}/clusters/build/<DIR>","--upgrade-components","kafka,ignite"]
-        },
-        {
-            "name": "unit tests",
-            "type": "python",
-            "request": "launch",
-            "module": "pytest",
-            "cwd": "${workspaceFolder}",
-            "env": { "PYTHONPATH": "${workspaceFolder}" },
-            "console": "integratedTerminal",
-            "args": ["--junitxml=${workspaceFolder}/test_results/unit_test_results.xml"]
-        },
-        {
-            "name": "pylint",
-            "type": "python",
-            "request": "launch",
-            "module": "pylint",
-            "cwd": "${workspaceFolder}",
-            "env": { "PYTHONPATH": "${workspaceFolder}" },
-            "console": "integratedTerminal",
-            "args": ["--rcfile", ".pylintrc", "./cli", ">", "${workspaceFolder}/test_results/pylint_results.xml"]
         }
     ]
 }

--- a/core/src/epicli/.vscode/settings.json
+++ b/core/src/epicli/.vscode/settings.json
@@ -19,5 +19,8 @@
 
     // Ruby
     "ruby.format": false,
+    "ruby.lint": {
+        "rubocop": true
+    },
     "solargraph.formatting": true,
 }

--- a/core/src/epicli/.vscode/tasks.json
+++ b/core/src/epicli/.vscode/tasks.json
@@ -32,7 +32,7 @@
         "label": "Rubocop junit",
         "type": "shell",
         "command": "mkdir -p test_results && rubocop -c .rubocop.yml --require rubocop/formatter/junit_formatter --format RuboCop::Formatter::JUnitFormatter --out test_results/rubocop_results.xml"
-      }
+      },
       {
         "label": "Rubocop terminal",
         "type": "shell",

--- a/core/src/epicli/.vscode/tasks.json
+++ b/core/src/epicli/.vscode/tasks.json
@@ -1,0 +1,32 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "Pytest",
+        "type": "shell",
+        "command": "mkdir -p test_results && pytest --junitxml=${workspaceFolder}/test_results/pytest_results.xml"
+      },
+      {
+        "label": "Pylint junit",
+        "type": "shell",
+        "command": "mkdir -p test_results && pylint --rcfile .pylintrc ./cli ./tests --output ${workspaceFolder}/test_results/pylint_results.xml"
+      },
+      {
+        "label": "Pylint terminal",
+        "type": "shell",
+        "command": "pylint --rcfile .pylintrc ./cli ./tests --output-format text"
+      },
+      {
+        "label": "Ansible-lint junit",
+        "type": "shell",
+        "command": "mkdir -p test_results && ansible-lint --nocolor -q -c .ansible-lint -p ${workspaceFolder}/data/common/ansible/playbooks/*.yml > ${workspaceFolder}/test_results/ansiblelint_results.txt ; ansible-lint-to-junit-xml ${workspaceFolder}/test_results/ansiblelint_results.txt > ${workspaceFolder}/test_results/ansiblelint_results.xml"
+      },
+      {
+        "label": "Ansible-lint terminal",
+        "type": "shell",
+        "command": "ansible-lint -q -c .ansible-lint -p ${workspaceFolder}/data/common/ansible/playbooks/*.yml"
+      }
+    ]
+  }

--- a/core/src/epicli/.vscode/tasks.json
+++ b/core/src/epicli/.vscode/tasks.json
@@ -27,6 +27,16 @@
         "label": "Ansible-lint terminal",
         "type": "shell",
         "command": "ansible-lint -q -c .ansible-lint -p ${workspaceFolder}/data/common/ansible/playbooks/*.yml"
+      },
+      {
+        "label": "Rubocop junit",
+        "type": "shell",
+        "command": "mkdir -p test_results && rubocop -c .rubocop.yml --require rubocop/formatter/junit_formatter --format RuboCop::Formatter::JUnitFormatter --out test_results/rubocop_results.xml"
+      }
+      {
+        "label": "Rubocop terminal",
+        "type": "shell",
+        "command": "rubocop -c .rubocop.yml"
       }
     ]
   }


### PR DESCRIPTION
- Added ansible-lint to the devcontainer
- Added rubocop to the devcontainer
- Added ansible-lint task to devcontainer to produce junit output
- Added rubocop task to devcontainer to produce junit output
- Moved running of Pytest and Pylint to tasks instead of debug configuration

**Notes:**  
- Running ansible-lint is pretty slow, running over all playbooks takes about half an hour. I checked and this seems to be a known issue which is being worked on by the creators. Thi is the reason it does not play will with showing results in the problems tab of VSCode for open  source files and only work when running it as a task.
- Rubocop works fine as tasks or from the problems tab:
![image](https://user-images.githubusercontent.com/11056665/132495301-9a93a527-329d-48f6-abab-681a895398cb.png)

**Task running:**
To run tasks to **ctrl+shift+p** and search for run tasks

![image](https://user-images.githubusercontent.com/11056665/132363575-a9eaaabb-caff-47b1-bcf2-8d2b2c8638b5.png)

Select that option and then select the task you want to run:

![image](https://user-images.githubusercontent.com/11056665/132363703-cfe4530e-1ddd-408f-9136-02c6277d92ed.png)