### PR TITLE
Virtual machine "kind" mismatch 

### DIFF
--- a/CHANGELOG-1.3.md
+++ b/CHANGELOG-1.3.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- [#1743](https://github.com/epiphany-platform/epiphany/issues/1743) - Virtual machine "kind" mismatch
+
 ### Updated
 
 ### Deprecated

--- a/core/src/epicli/data/any/defaults/infrastructure/machine.yml
+++ b/core/src/epicli/data/any/defaults/infrastructure/machine.yml
@@ -1,0 +1,7 @@
+kind: infrastructure/machine
+title: "Virtual Machine Infra"
+provider: any
+name: default
+specification:
+  ip: TO_BE_SET_BY_USER
+  hostname: TO_BE_SET_BY_USER

--- a/core/src/epicli/data/common/defaults/infrastructure/machine.yml
+++ b/core/src/epicli/data/common/defaults/infrastructure/machine.yml
@@ -1,7 +1,0 @@
-kind: infrastructure/virtual-machine
-title: "Virtual Machine Infra"
-provider: any
-name: default
-specification:
-  ip: TO_BE_SET
-  hostname: TO_BE_SET

--- a/core/src/epicli/data/common/defaults/infrastructure/machine.yml
+++ b/core/src/epicli/data/common/defaults/infrastructure/machine.yml
@@ -1,0 +1,7 @@
+kind: infrastructure/virtual-machine
+title: "Virtual Machine Infra"
+provider: any
+name: default
+specification:
+  ip: TO_BE_SET
+  hostname: TO_BE_SET


### PR DESCRIPTION
Moved the machine definition from common dir to any provider dir. Also corrected the kind mismatch for this default document.