### PR TITLE
[v1.0] Revert Keycloak upgrade

### DIFF
--- a/CHANGELOG-1.0.md
+++ b/CHANGELOG-1.0.md
@@ -4,7 +4,6 @@
 
 ### Updated
 
-- [#1797](https://github.com/epiphany-platform/epiphany/issues/1797) - Upgrade Keycloak to v14.0.0
 - [#2457](https://github.com/epiphany-platform/epiphany/issues/2457) - Upgrade Docker-CE to v20.10.8
 
 ## [1.0.1] 2021-07-16

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.txt
@@ -186,7 +186,7 @@ brainsam/pgbouncer:1.12
 istio/pilot:1.8.1
 istio/proxyv2:1.8.1
 istio/operator:1.8.1
-epiphanyplatform/keycloak:14.0.0
+jboss/keycloak:9.0.0
 rabbitmq:3.8.9
 # K8s upgrade
 ## v1.14.6

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.txt
@@ -182,7 +182,7 @@ brainsam/pgbouncer:1.12
 istio/pilot:1.8.1
 istio/proxyv2:1.8.1
 istio/operator:1.8.1
-epiphanyplatform/keycloak:14.0.0
+jboss/keycloak:9.0.0
 rabbitmq:3.8.9
 # K8s upgrade
 ## v1.14.6

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
@@ -238,7 +238,7 @@ brainsam/pgbouncer:1.12
 istio/pilot:1.8.1
 istio/proxyv2:1.8.1
 istio/operator:1.8.1
-epiphanyplatform/keycloak:14.0.0
+jboss/keycloak:9.0.0
 rabbitmq:3.8.9
 # K8s upgrade
 ## v1.14.6

--- a/core/src/epicli/data/common/defaults/configuration/applications.yml
+++ b/core/src/epicli/data/common/defaults/configuration/applications.yml
@@ -57,7 +57,7 @@ specification:
 
   - name: auth-service # requires PostgreSQL to be installed in cluster
     enabled: false
-    image_path: epiphanyplatform/keycloak:14.0.0
+    image_path: jboss/keycloak:9.0.0
     use_local_image_registry: true
     #image_pull_secret_name: regcred
     service:

--- a/core/src/epicli/data/common/defaults/configuration/image-registry.yml
+++ b/core/src/epicli/data/common/defaults/configuration/image-registry.yml
@@ -8,8 +8,8 @@ specification:
     file_name: registry-2.tar
   images_to_load:
     generic:
-      - name: "epiphanyplatform/keycloak:14.0.0"
-        file_name: keycloak-14.0.0.tar
+      - name: "jboss/keycloak:9.0.0"
+        file_name: keycloak-9.0.0.tar
       - name: "rabbitmq:3.8.9"
         file_name: rabbitmq-3.8.9.tar
       - name: "apacheignite/ignite:2.9.1"

--- a/docs/home/COMPONENTS.md
+++ b/docs/home/COMPONENTS.md
@@ -15,7 +15,7 @@ Note that versions are default versions and can be changed in certain cases thro
 | Zookeeper                  | 3.5.8    | https://github.com/apache/zookeeper                   | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | RabbitMQ                   | 3.8.9    | https://github.com/rabbitmq/rabbitmq-server           | [Mozilla Public License](https://www.mozilla.org/en-US/MPL/)      |
 | Docker CE                  | 20.10.8  | https://docs.docker.com/engine/release-notes/         | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
-| KeyCloak                   | 14.0.0   | https://github.com/keycloak/keycloak                  | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| KeyCloak                   | 9.0.0    | https://github.com/keycloak/keycloak                  | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Elasticsearch OSS          | 7.10.2   | https://github.com/elastic/elasticsearch              | https://github.com/elastic/elasticsearch/blob/master/LICENSE.txt  |
 | Elasticsearch Curator OSS  | 5.8.3    | https://github.com/elastic/curator                    | https://github.com/elastic/curator/blob/master/LICENSE.txt        |
 | Opendistro for Elasticsearch          | 1.13.x   | https://opendistro.github.io/for-elasticsearch/                  | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |


### PR DESCRIPTION
I think docs from the [PR](https://github.com/epiphany-platform/epiphany/pull/2447/files) and [this](https://github.com/epiphany-platform/epiphany/pull/2447/files#diff-9d0453ed86db5ffdaf5c65c8b33bc8f44e8d1fd74d372dcda6c895256108bb5fR18) can stay as is
