### PR TITLE
[1.1] Fixed wal files removal

### DIFF
--- a/CHANGELOG-1.1.md
+++ b/CHANGELOG-1.1.md
@@ -13,6 +13,7 @@
 - [#1370](https://github.com/epiphany-platform/epiphany/issues/1370) - Epicli does not correctly generate vars for Postgres
 - [#2425](https://github.com/epiphany-platform/epiphany/issues/2425) - Feature-mapping - 'enabled: no' do nothing
 - [#1296](https://github.com/epiphany-platform/epiphany/issues/1296) - Epicli does not interpret alternative yaml boolean values as true booleans
+- [#2656](https://github.com/epiphany-platform/epiphany/issues/2656) - WAL files are not removed from $PGDATA/pg_wal directory
 
 ## [1.1.0] 2021-06-30
 

--- a/core/src/epicli/data/common/defaults/configuration/postgresql.yml
+++ b/core/src/epicli/data/common/defaults/configuration/postgresql.yml
@@ -46,7 +46,7 @@ specification:
                 value: 'on'
                 when: replication
               - name: archive_command
-                value: "'test ! -f /dbbackup/{{ inventory_hostname }}/backup/%f && gzip -c < %p > /dbbackup/{{ inventory_hostname }}/backup/%f'"
+                value: "'/bin/true'"
                 when: replication
       - name: REPLICATION
         subgroups:


### PR DESCRIPTION
Task #2656 

_Why the command changed but not removed:_ Changes to archive_mode require a full PostgreSQL server restart, while archive_command changes can be applied via a normal configuration reload. See https://repmgr.org/docs/repmgr.html#CONFIGURATION-POSTGRESQL. **The same changes are already in develop.**