### PR TITLE
Add state flag file in K8s upgrades (#2702)

### DIFF
--- a/ansible/playbooks/roles/upgrade/defaults/main.yml
+++ b/ansible/playbooks/roles/upgrade/defaults/main.yml
@@ -19,3 +19,6 @@ opendistro_for_elasticsearch:
       filename: demo2epiphany-certs-migration-root-CAs.pem
 
   upgrade_state_file_path: /etc/elasticsearch/epicli-upgrade-started.state
+
+kubernetes:
+  upgrade_flag_path: /tmp/kubernetes-upgrade-in-progress{{ ver }}.flag

--- a/ansible/playbooks/roles/upgrade/defaults/main.yml
+++ b/ansible/playbooks/roles/upgrade/defaults/main.yml
@@ -21,4 +21,5 @@ opendistro_for_elasticsearch:
   upgrade_state_file_path: /etc/elasticsearch/epicli-upgrade-started.state
 
 kubernetes:
-  upgrade_state_file_path: /var/lib/epiphany/upgrade/state/kubernetes-{{ ver }}.uncompleted
+  upgrade_master_state_file_path: /var/lib/epiphany/upgrade/state/kubernetes-master-{{ ver }}.uncompleted
+  upgrade_node_state_file_path: /var/lib/epiphany/upgrade/state/kubernetes-node-{{ ver }}.uncompleted

--- a/ansible/playbooks/roles/upgrade/defaults/main.yml
+++ b/ansible/playbooks/roles/upgrade/defaults/main.yml
@@ -21,5 +21,4 @@ opendistro_for_elasticsearch:
   upgrade_state_file_path: /etc/elasticsearch/epicli-upgrade-started.state
 
 kubernetes:
-  upgrade_master_state_file_path: /var/lib/epiphany/upgrade/state/kubernetes-master-{{ ver }}.uncompleted
-  upgrade_node_state_file_path: /var/lib/epiphany/upgrade/state/kubernetes-node-{{ ver }}.uncompleted
+  upgrade_state_file_path: /var/lib/epiphany/upgrade/state/kubernetes-{{ ver }}.uncompleted

--- a/ansible/playbooks/roles/upgrade/defaults/main.yml
+++ b/ansible/playbooks/roles/upgrade/defaults/main.yml
@@ -21,4 +21,4 @@ opendistro_for_elasticsearch:
   upgrade_state_file_path: /etc/elasticsearch/epicli-upgrade-started.state
 
 kubernetes:
-  upgrade_flag_path: /tmp/kubernetes-upgrade-in-progress{{ ver }}.flag
+  upgrade_state_file_path: /var/lib/epiphany/upgrade/state/kubernetes-{{ ver }}.uncompleted

--- a/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
+++ b/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
@@ -1,6 +1,8 @@
 ---
 - name: Wait for kube-apiserver and get cluster version
-  delegate_to: "{{ groups.kubernetes_master[0] }}"
+  delegate_to: >-
+    {{ inventory_hostname if inventory_hostname in groups.kubernetes_master else
+      groups.kubernetes_master[0] }}
   block:
     - name: k8s | Include wait-for-kube-apiserver.yml
       import_tasks: kubernetes/utils/wait-for-kube-apiserver.yml

--- a/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
+++ b/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
@@ -12,10 +12,10 @@
   import_tasks: kubernetes/get-kubelet-version.yml # sets kubelet_version
   delegate_to: "{{ groups.kubernetes_master[0] }}"
 
-- name: Check for upgrade flag file
+- name: Check for upgrade state file
   stat:
     path: "{{ kubernetes.upgrade_state_file_path }}"
-  register: lock_file_status
+  register: upgrade_state_file_status
 
 - name: Upgrade masters then nodes
   vars:
@@ -24,13 +24,14 @@
   block:
     - name: Upgrade masters
       when: >
-        lock_file_status.stat.exists or
+        upgrade_state_file_status.stat.exists or
         cluster_version is version('v' + version, '<')
       block:
-        - name: Create upgrade flag file
-          file:
-            path: "{{ kubernetes.upgrade_state_file_path }}"
-            state: touch
+        - name: Create upgrade state file
+          copy:
+            dest: "{{ kubernetes.upgrade_state_file_path }}"
+            content: Upgrade started
+            mode: u=rw,g=r,o=
 
         - name: k8s | Upgrade first master to v{{ version }}
           include_tasks: kubernetes/upgrade-master0.yml
@@ -42,20 +43,21 @@
           when:
             - inventory_hostname in groups.kubernetes_master[1:]
 
-        - name: Remove k8s upgrade flag file
+        - name: Remove k8s upgrade state file
           file:
             path: "{{ kubernetes.upgrade_state_file_path }}"
             state: absent
 
     - name: Upgrade nodes
       when: >
-        lock_file_status.stat.exists or
+        upgrade_state_file_status.stat.exists or
         kubelet_version is version('v' + version, '<')
       block:
-        - name: Create upgrade flag file
-          file:
-            path: "{{ kubernetes.upgrade_state_file_path }}"
-            state: touch
+        - name: Create upgrade state file
+          copy:
+            dest: "{{ kubernetes.upgrade_state_file_path }}"
+            content: Upgrade started
+            mode: u=rw,g=r,o=
 
         - name: k8s | Upgrade node to v{{ version }}
           include_tasks: kubernetes/upgrade-node.yml
@@ -63,7 +65,7 @@
             - groups.kubernetes_node is defined
             - inventory_hostname in groups.kubernetes_node
 
-        - name: Remove k8s upgrade flag file
+        - name: Remove k8s upgrade state file
           file:
             path: "{{ kubernetes.upgrade_state_file_path }}"
             state: absent

--- a/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
+++ b/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
@@ -1,4 +1,14 @@
 ---
+# During HA control plane upgrade server address in kubeconfig is switched to local for
+#   * compatibility between client and server versions
+#   * identifying correct server version
+
+- name: k8s/master | Switch apiserver address to local
+  include_tasks: kubernetes/utils/set-local-apiserver.yml # sets kubectl_context_cluster
+  when:
+    - groups.kubernetes_master | length > 1
+    - inventory_hostname in groups.kubernetes_master
+
 - name: Wait for kube-apiserver and get cluster version
   delegate_to: >-
     {{ inventory_hostname if inventory_hostname in groups.kubernetes_master else
@@ -14,10 +24,15 @@
   import_tasks: kubernetes/get-kubelet-version.yml # sets kubelet_version
   delegate_to: "{{ groups.kubernetes_master[0] }}"
 
-- name: Check for upgrade state file
+- name: Check upgrade state file for master
   stat:
-    path: "{{ kubernetes.upgrade_state_file_path }}"
-  register: upgrade_state_file_status
+    path: "{{ kubernetes.upgrade_master_state_file_path }}"
+  register: upgrade_master_state_file_status
+
+- name: Check upgrade state file for node
+  stat:
+    path: "{{ kubernetes.upgrade_node_state_file_path }}"
+  register: upgrade_node_state_file_status
 
 - name: Upgrade masters then nodes
   vars:
@@ -26,12 +41,12 @@
   block:
     - name: Upgrade masters
       when: >
-        upgrade_state_file_status.stat.exists or
+        upgrade_master_state_file_status.stat.exists or
         cluster_version is version('v' + version, '<')
       block:
-        - name: Create upgrade state file
+        - name: Create k8s upgrade state file for masters
           copy:
-            dest: "{{ kubernetes.upgrade_state_file_path }}"
+            dest: "{{ kubernetes.upgrade_master_state_file_path }}"
             content: Upgrade started
             mode: u=rw,g=r,o=
 
@@ -45,19 +60,19 @@
           when:
             - inventory_hostname in groups.kubernetes_master[1:]
 
-        - name: Remove k8s upgrade state file
+        - name: Remove k8s upgrade state file for masters
           file:
-            path: "{{ kubernetes.upgrade_state_file_path }}"
+            path: "{{ kubernetes.upgrade_master_state_file_path }}"
             state: absent
 
     - name: Upgrade nodes
       when: >
-        upgrade_state_file_status.stat.exists or
+        upgrade_node_state_file_status.stat.exists or
         kubelet_version is version('v' + version, '<')
       block:
-        - name: Create upgrade state file
+        - name: Create k8s upgrade state file for nodes
           copy:
-            dest: "{{ kubernetes.upgrade_state_file_path }}"
+            dest: "{{ kubernetes.upgrade_node_state_file_path }}"
             content: Upgrade started
             mode: u=rw,g=r,o=
 
@@ -67,10 +82,19 @@
             - groups.kubernetes_node is defined
             - inventory_hostname in groups.kubernetes_node
 
-        - name: Remove k8s upgrade state file
+        - name: Remove k8s upgrade state file for nodes
           file:
-            path: "{{ kubernetes.upgrade_state_file_path }}"
+            path: "{{ kubernetes.upgrade_node_state_file_path }}"
             state: absent
+
+
+- name: k8s/master | Switch apiserver address to HAProxy
+  command: |-
+    kubectl config set-cluster {{ kubectl_context_cluster.stdout }} --server=https://localhost:3446
+  when:
+    - groups.kubernetes_master | length > 1
+    - inventory_hostname in groups.kubernetes_master
+  changed_when: true
 
 - name: k8s | Upgrade internal haproxy load-balancer
   import_tasks: kubernetes/upgrade-haproxy.yml

--- a/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
+++ b/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
@@ -18,21 +18,30 @@
       import_tasks: kubernetes/utils/wait-for-kube-apiserver.yml
 
     - name: k8s | Include get-cluster-version.yml
-      import_tasks: kubernetes/get-cluster-version.yml # sets cluster_version
+      import_tasks: kubernetes/get-cluster-version.yml
+
+    - name: k8s | Set cluster version facts
+      set_fact:
+        initial_cluster_version: "{{ _cluster_version }}"
+        cluster_version: "{{ _cluster_version }}"
+      vars:
+        _cluster_version: "{{ (kubectl_cluster_version.stdout | from_yaml).serverVersion.gitVersion }}"
 
 - name: k8s | Include get-kubelet-version.yml
-  import_tasks: kubernetes/get-kubelet-version.yml # sets kubelet_version
+  import_tasks: kubernetes/get-kubelet-version.yml
   delegate_to: "{{ groups.kubernetes_master[0] }}"
 
-- name: Check upgrade state file for master
-  stat:
-    path: "{{ kubernetes.upgrade_master_state_file_path }}"
-  register: upgrade_master_state_file_status
+- name: k8s | Set kubelet version as fact
+  set_fact:
+    initial_kubelet_version: "{{ kubelet_version.stdout }}"
 
-- name: Check upgrade state file for node
+- name: Check if upgrade state file exists
   stat:
-    path: "{{ kubernetes.upgrade_node_state_file_path }}"
-  register: upgrade_node_state_file_status
+    path: "{{ kubernetes.upgrade_state_file_path }}"
+    get_attributes: false
+    get_checksum: false
+    get_mime: false
+  register: k8s_upgrade_state_file_status
 
 - name: Upgrade masters then nodes
   vars:
@@ -40,13 +49,14 @@
     cni_version: "{{ cni_ver }}"
   block:
     - name: Upgrade masters
-      when: >
-        upgrade_master_state_file_status.stat.exists or
-        cluster_version is version('v' + version, '<')
+      when:
+        - inventory_hostname in groups.kubernetes_master
+        - k8s_upgrade_state_file_status.stat.exists
+          or initial_cluster_version is version('v' + version, '<')
       block:
-        - name: Create k8s upgrade state file for masters
+        - name: Create K8s upgrade state file on master node
           copy:
-            dest: "{{ kubernetes.upgrade_master_state_file_path }}"
+            dest: "{{ kubernetes.upgrade_state_file_path }}"
             content: Upgrade started
             mode: u=rw,g=r,o=
 
@@ -60,33 +70,31 @@
           when:
             - inventory_hostname in groups.kubernetes_master[1:]
 
-        - name: Remove k8s upgrade state file for masters
+        - name: Remove K8s upgrade state file on master node
           file:
-            path: "{{ kubernetes.upgrade_master_state_file_path }}"
+            path: "{{ kubernetes.upgrade_state_file_path }}"
             state: absent
 
     - name: Upgrade nodes
-      when: >
-        upgrade_node_state_file_status.stat.exists or
-        kubelet_version is version('v' + version, '<')
+      when:
+        - groups.kubernetes_node is defined
+        - inventory_hostname in groups.kubernetes_node
+        - k8s_upgrade_state_file_status.stat.exists
+          or initial_kubelet_version is version('v' + version, '<')
       block:
-        - name: Create k8s upgrade state file for nodes
+        - name: Create K8s upgrade state file on node
           copy:
-            dest: "{{ kubernetes.upgrade_node_state_file_path }}"
+            dest: "{{ kubernetes.upgrade_state_file_path }}"
             content: Upgrade started
             mode: u=rw,g=r,o=
 
         - name: k8s | Upgrade node to v{{ version }}
           include_tasks: kubernetes/upgrade-node.yml
-          when:
-            - groups.kubernetes_node is defined
-            - inventory_hostname in groups.kubernetes_node
 
-        - name: Remove k8s upgrade state file for nodes
+        - name: Remove K8s upgrade state file on node
           file:
-            path: "{{ kubernetes.upgrade_node_state_file_path }}"
+            path: "{{ kubernetes.upgrade_state_file_path }}"
             state: absent
-
 
 - name: k8s/master | Switch apiserver address to HAProxy
   command: |-

--- a/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
+++ b/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
@@ -14,7 +14,7 @@
 
 - name: Check for upgrade flag file
   stat:
-    path: "{{ kubernetes.upgrade_flag_path }}"
+    path: "{{ kubernetes.upgrade_state_file_path }}"
   register: lock_file_status
 
 - name: Upgrade masters then nodes
@@ -22,13 +22,16 @@
     version: "{{ ver }}"
     cni_version: "{{ cni_ver }}"
   block:
-    - name: Create upgrade flag file
-      file:
-        path: "{{ kubernetes.upgrade_flag_path }}"
-        state: touch
-
     - name: Upgrade masters
+      when: >
+        lock_file_status.stat.exists or
+        cluster_version is version('v' + version, '<')
       block:
+        - name: Create upgrade flag file
+          file:
+            path: "{{ kubernetes.upgrade_state_file_path }}"
+            state: touch
+
         - name: k8s | Upgrade first master to v{{ version }}
           include_tasks: kubernetes/upgrade-master0.yml
           when:
@@ -39,22 +42,31 @@
           when:
             - inventory_hostname in groups.kubernetes_master[1:]
 
+        - name: Remove k8s upgrade flag file
+          file:
+            path: "{{ kubernetes.upgrade_state_file_path }}"
+            state: absent
+
     - name: Upgrade nodes
+      when: >
+        lock_file_status.stat.exists or
+        kubelet_version is version('v' + version, '<')
       block:
+        - name: Create upgrade flag file
+          file:
+            path: "{{ kubernetes.upgrade_state_file_path }}"
+            state: touch
+
         - name: k8s | Upgrade node to v{{ version }}
           include_tasks: kubernetes/upgrade-node.yml
           when:
             - groups.kubernetes_node is defined
             - inventory_hostname in groups.kubernetes_node
 
-    - name: Remove k8s upgrade flag file
-      file:
-        path: "{{ kubernetes.upgrade_flag_path }}"
-        state: absent
-  when: >
-    lock_file_status.stat.exists or
-    cluster_version is version('v' + version, '<') or
-    kubelet_version is version('v' + version, '<')
+        - name: Remove k8s upgrade flag file
+          file:
+            path: "{{ kubernetes.upgrade_state_file_path }}"
+            state: absent
 
 - name: k8s | Upgrade internal haproxy load-balancer
   import_tasks: kubernetes/upgrade-haproxy.yml

--- a/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
+++ b/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
@@ -1,22 +1,24 @@
 ---
+- name: k8s | Wait for kube-apiserver
+  delegate_to: >-
+    {{ inventory_hostname if inventory_hostname in groups.kubernetes_master else
+      groups.kubernetes_master[0] }}
+  import_tasks: kubernetes/utils/wait-for-kube-apiserver.yml
+
 # During HA control plane upgrade server address in kubeconfig is switched to local for
 #   * compatibility between client and server versions
 #   * identifying correct server version
-
 - name: k8s/master | Switch apiserver address to local
   include_tasks: kubernetes/utils/set-local-apiserver.yml # sets kubectl_context_cluster
   when:
     - groups.kubernetes_master | length > 1
     - inventory_hostname in groups.kubernetes_master
 
-- name: Wait for kube-apiserver and get cluster version
+- name: Get cluster version and set version facts
   delegate_to: >-
     {{ inventory_hostname if inventory_hostname in groups.kubernetes_master else
       groups.kubernetes_master[0] }}
   block:
-    - name: k8s | Include wait-for-kube-apiserver.yml
-      import_tasks: kubernetes/utils/wait-for-kube-apiserver.yml
-
     - name: k8s | Include get-cluster-version.yml
       import_tasks: kubernetes/get-cluster-version.yml
 

--- a/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
+++ b/ansible/playbooks/roles/upgrade/tasks/kubernetes.yml
@@ -12,13 +12,22 @@
   import_tasks: kubernetes/get-kubelet-version.yml # sets kubelet_version
   delegate_to: "{{ groups.kubernetes_master[0] }}"
 
+- name: Check for upgrade flag file
+  stat:
+    path: "{{ kubernetes.upgrade_flag_path }}"
+  register: lock_file_status
+
 - name: Upgrade masters then nodes
   vars:
     version: "{{ ver }}"
     cni_version: "{{ cni_ver }}"
   block:
+    - name: Create upgrade flag file
+      file:
+        path: "{{ kubernetes.upgrade_flag_path }}"
+        state: touch
+
     - name: Upgrade masters
-      when: cluster_version is version('v' + version, '<=')
       block:
         - name: k8s | Upgrade first master to v{{ version }}
           include_tasks: kubernetes/upgrade-master0.yml
@@ -31,7 +40,6 @@
             - inventory_hostname in groups.kubernetes_master[1:]
 
     - name: Upgrade nodes
-      when: kubelet_version is version('v' + version, '<=')
       block:
         - name: k8s | Upgrade node to v{{ version }}
           include_tasks: kubernetes/upgrade-node.yml
@@ -39,7 +47,14 @@
             - groups.kubernetes_node is defined
             - inventory_hostname in groups.kubernetes_node
 
+    - name: Remove k8s upgrade flag file
+      file:
+        path: "{{ kubernetes.upgrade_flag_path }}"
+        state: absent
+  when: >
+    lock_file_status.stat.exists or
+    cluster_version is version('v' + version, '<') or
+    kubelet_version is version('v' + version, '<')
+
 - name: k8s | Upgrade internal haproxy load-balancer
   import_tasks: kubernetes/upgrade-haproxy.yml
-
-# TODO: Create a flag file that the upgrade completed to not run it again for the same version next time

--- a/ansible/playbooks/roles/upgrade/tasks/kubernetes/get-cluster-version.yml
+++ b/ansible/playbooks/roles/upgrade/tasks/kubernetes/get-cluster-version.yml
@@ -6,12 +6,3 @@
   retries: 60
   delay: 5
   changed_when: false
-
-- name: Set cluster version as fact
-  set_fact:
-    cluster_version: >-
-      {{ (kubectl_cluster_version.stdout | from_yaml).serverVersion.gitVersion }}
-    cluster_version_major: >-
-      {{ (kubectl_cluster_version.stdout | from_yaml).serverVersion.major }}
-    cluster_version_minor: >-
-      {{ (kubectl_cluster_version.stdout | from_yaml).serverVersion.minor }}

--- a/ansible/playbooks/roles/upgrade/tasks/kubernetes/get-kubelet-version.yml
+++ b/ansible/playbooks/roles/upgrade/tasks/kubernetes/get-kubelet-version.yml
@@ -4,7 +4,3 @@
     kubectl get node {{ inventory_hostname }} -o jsonpath='{.status.nodeInfo.kubeletVersion}'
   register: kubelet_version
   changed_when: false
-
-- name: Set kubelet version as fact
-  set_fact:
-    kubelet_version: "{{ kubelet_version.stdout }}"

--- a/ansible/playbooks/roles/upgrade/tasks/kubernetes/patch-kubelet-cm.yml
+++ b/ansible/playbooks/roles/upgrade/tasks/kubernetes/patch-kubelet-cm.yml
@@ -1,6 +1,6 @@
 ---
-- name: k8s/kubelet-cm | Include get-cluster-version.yml
-  include_tasks: get-cluster-version.yml # sets cluster_version
+- name: k8s/kubelet-cm | Include set-cluster-version.yml
+  include_tasks: set-cluster-version.yml # sets cluster_version
 
 - name: k8s/kubelet-cm | Get kubelet config from ConfigMap
   command: |-

--- a/ansible/playbooks/roles/upgrade/tasks/kubernetes/set-cluster-version.yml
+++ b/ansible/playbooks/roles/upgrade/tasks/kubernetes/set-cluster-version.yml
@@ -1,0 +1,12 @@
+---
+- name: k8s | Include get-cluster-version.yml
+  include_tasks: kubernetes/get-cluster-version.yml
+
+- name: Set cluster version as fact
+  set_fact:
+    cluster_version: >-
+      {{ (kubectl_cluster_version.stdout | from_yaml).serverVersion.gitVersion }}
+    cluster_version_major: >-
+      {{ (kubectl_cluster_version.stdout | from_yaml).serverVersion.major }}
+    cluster_version_minor: >-
+      {{ (kubectl_cluster_version.stdout | from_yaml).serverVersion.minor }}

--- a/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master0.yml
+++ b/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-master0.yml
@@ -1,13 +1,4 @@
 ---
-# During HA control plane upgrade server address in kubeconfig is switched to local for
-#   * compatibility between client and server versions
-#   * identifying correct server version
-
-- name: k8s/master0 | Switch apiserver address to local
-  include_tasks: utils/set-local-apiserver.yml # sets kubectl_context_cluster
-  when:
-    - groups.kubernetes_master | length > 1
-
 - name: k8s/master0 | Wait for cluster's readiness
   include_tasks: utils/wait.yml
 
@@ -107,10 +98,3 @@
 
 - name: k8s/master0 | Verify component versions and node status
   include_tasks: kubernetes/verify-upgrade.yml
-
-- name: k8s/master0 | Switch apiserver address to HAProxy
-  command: |-
-    kubectl config set-cluster {{ kubectl_context_cluster.stdout }} --server=https://localhost:3446
-  when:
-    - groups.kubernetes_master | length > 1
-  changed_when: true

--- a/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-masterN.yml
+++ b/ansible/playbooks/roles/upgrade/tasks/kubernetes/upgrade-masterN.yml
@@ -1,7 +1,4 @@
 ---
-- name: k8s/masterN | Switch apiserver address to local
-  include_tasks: utils/set-local-apiserver.yml # sets kubectl_context_cluster
-
 - name: k8s/masterN | Drain master in preparation for maintenance
   include_tasks: utils/drain.yml
 
@@ -55,8 +52,3 @@
 
 - name: k8s/masterN | Verify component versions and node status
   include_tasks: kubernetes/verify-upgrade.yml
-
-- name: k8s/masterN | Switch apiserver address to HAProxy
-  command: |-
-    kubectl config set-cluster {{ kubectl_context_cluster.stdout }} --server=https://localhost:3446
-  changed_when: true

--- a/ansible/playbooks/roles/upgrade/tasks/kubernetes/verify-upgrade.yml
+++ b/ansible/playbooks/roles/upgrade/tasks/kubernetes/verify-upgrade.yml
@@ -6,8 +6,8 @@
     - name: k8s/verify | Include wait-for-kube-apiserver.yml
       include_tasks: utils/wait-for-kube-apiserver.yml
 
-    - name: k8s/verify | Include get-cluster-version.yml
-      include_tasks: get-cluster-version.yml  # sets cluster_version
+    - name: k8s/verify | Include set-cluster-version.yml
+      include_tasks: set-cluster-version.yml
 
     - name: k8s/verify | Verify cluster version
       assert:

--- a/docs/changelogs/CHANGELOG-1.3.md
+++ b/docs/changelogs/CHANGELOG-1.3.md
@@ -21,6 +21,7 @@
 - [#2814](https://github.com/epiphany-platform/epiphany/issues/2814) - Add description how to enable TLS in Kibana
 - [#1076](https://github.com/epiphany-platform/epiphany/issues/2595) - Document connection protocols and ciphers
 - [#2665](https://github.com/epiphany-platform/epiphany/issues/2665) - Add Kubernetes prereqs to epicli preflight checks
+- [#2702](https://github.com/epiphany-platform/epiphany/issues/2702) - Use state flag file in K8s upgrades
 
 ### Fixed
 


### PR DESCRIPTION
* it is based on solution under upgrade/tasks/kafka.yml
* added usage of update flag for masters and nodes - having single
  flag file for both was introducing malfunction (incomplete master
  upgrade flag was removed by tasks in nodes block)
* 'Switch apiserver address to local' task is now executed before the
  upgrade procedure in order to correctly fetch versions of particular
  masters - without it procedure for some masters could be skipped,
  because fetched version didn't match host it tried to upgrade
* separate _get_ and _set_ cluster version tasks
* introduce _initial_cluster_version_ used to evaluate need of
  an upgrade

Tested on cluster (Ubuntu machines) containing:
1. three k8s masters and three k8s nodes (HA) (upgrade from v1.0.1 to v1.3.0)