### PR TITLE
Downgrade kafka_exporter to v1.4.0

### DIFF
--- a/ansible/playbooks/roles/kafka/templates/kafka.service.j2
+++ b/ansible/playbooks/roles/kafka/templates/kafka.service.j2
@@ -1,7 +1,6 @@
 [Unit]
 Description=Kafka Daemon
 After=zookeeper.service
-Wants=kafka-exporter.service
 
 {% if specification.kafka_var.javax_net_debug is defined %}
 {%      set javax_debug = '-Djavax.net.debug=' ~ specification.kafka_var.javax_net_debug %}

--- a/ansible/playbooks/roles/kafka/templates/kafka.service.j2
+++ b/ansible/playbooks/roles/kafka/templates/kafka.service.j2
@@ -1,6 +1,7 @@
 [Unit]
 Description=Kafka Daemon
 After=zookeeper.service
+Wants=kafka-exporter.service
 
 {% if specification.kafka_var.javax_net_debug is defined %}
 {%      set javax_debug = '-Djavax.net.debug=' ~ specification.kafka_var.javax_net_debug %}

--- a/ansible/playbooks/roles/kafka_exporter/defaults/main.yml
+++ b/ansible/playbooks/roles/kafka_exporter/defaults/main.yml
@@ -2,7 +2,7 @@
 
 kafka_instances: "--kafka.server={{ groups['kafka']|join(':9092 --kafka.server=') }}:9092"
 kafka_exporter:
-  version: 1.4.2
+  version: 1.4.0
   file_name:
-    x86_64: "kafka_exporter-1.4.2.linux-amd64.tar.gz"
-    aarch64: "kafka_exporter-1.4.2.linux-arm64.tar.gz"
+    x86_64: "kafka_exporter-1.4.0.linux-amd64.tar.gz"
+    aarch64: "kafka_exporter-1.4.0.linux-arm64.tar.gz"

--- a/ansible/playbooks/roles/kafka_exporter/templates/kafka-exporter.service.j2
+++ b/ansible/playbooks/roles/kafka_exporter/templates/kafka-exporter.service.j2
@@ -1,6 +1,8 @@
 #jinja2: trim_blocks:False
 [Unit]
 Description={{ specification.description }}
+After=kafka.service
+PartOf=kafka.service
 
 [Service]
 User=kafka_exporter

--- a/ansible/playbooks/roles/kafka_exporter/templates/kafka-exporter.service.j2
+++ b/ansible/playbooks/roles/kafka_exporter/templates/kafka-exporter.service.j2
@@ -2,7 +2,6 @@
 [Unit]
 Description={{ specification.description }}
 After=kafka.service
-PartOf=kafka.service
 
 [Service]
 User=kafka_exporter

--- a/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.aarch64.txt
+++ b/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.aarch64.txt
@@ -152,7 +152,7 @@ https://packages.erlang-solutions.com/erlang/rpm/centos/7/aarch64/esl-erlang_23.
 https://dl.grafana.com/oss/release/grafana-7.3.5-1.aarch64.rpm
 # --- Exporters ---
 https://github.com/prometheus/haproxy_exporter/releases/download/v0.10.0/haproxy_exporter-0.10.0.linux-arm64.tar.gz
-https://github.com/danielqsj/kafka_exporter/releases/download/v1.4.2/kafka_exporter-1.4.2.linux-arm64.tar.gz
+https://github.com/danielqsj/kafka_exporter/releases/download/v1.4.0/kafka_exporter-1.4.0.linux-arm64.tar.gz
 https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.16.1/jmx_prometheus_javaagent-0.16.1.jar
 https://github.com/prometheus/node_exporter/releases/download/v1.0.1/node_exporter-1.0.1.linux-arm64.tar.gz
 https://github.com/prometheus-community/postgres_exporter/releases/download/v0.9.0/postgres_exporter-0.9.0.linux-arm64.tar.gz

--- a/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.x86_64.txt
+++ b/ansible/playbooks/roles/repository/files/download-requirements/centos-7/requirements.x86_64.txt
@@ -153,7 +153,7 @@ https://github.com/rabbitmq/erlang-rpm/releases/download/v23.1.5/erlang-23.1.5-1
 https://dl.grafana.com/oss/release/grafana-7.3.5-1.x86_64.rpm
 # --- Exporters ---
 https://github.com/prometheus/haproxy_exporter/releases/download/v0.10.0/haproxy_exporter-0.10.0.linux-amd64.tar.gz
-https://github.com/danielqsj/kafka_exporter/releases/download/v1.4.2/kafka_exporter-1.4.2.linux-amd64.tar.gz
+https://github.com/danielqsj/kafka_exporter/releases/download/v1.4.0/kafka_exporter-1.4.0.linux-amd64.tar.gz
 https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.16.1/jmx_prometheus_javaagent-0.16.1.jar
 https://github.com/prometheus/node_exporter/releases/download/v1.0.1/node_exporter-1.0.1.linux-amd64.tar.gz
 https://github.com/prometheus-community/postgres_exporter/releases/download/v0.9.0/postgres_exporter-0.9.0.linux-amd64.tar.gz

--- a/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.x86_64.txt
+++ b/ansible/playbooks/roles/repository/files/download-requirements/redhat-7/requirements.x86_64.txt
@@ -149,7 +149,7 @@ https://github.com/rabbitmq/erlang-rpm/releases/download/v23.1.5/erlang-23.1.5-1
 https://dl.grafana.com/oss/release/grafana-7.3.5-1.x86_64.rpm
 # --- Exporters ---
 https://github.com/prometheus/haproxy_exporter/releases/download/v0.10.0/haproxy_exporter-0.10.0.linux-amd64.tar.gz
-https://github.com/danielqsj/kafka_exporter/releases/download/v1.4.2/kafka_exporter-1.4.2.linux-amd64.tar.gz
+https://github.com/danielqsj/kafka_exporter/releases/download/v1.4.0/kafka_exporter-1.4.0.linux-amd64.tar.gz
 https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.16.1/jmx_prometheus_javaagent-0.16.1.jar
 https://github.com/prometheus/node_exporter/releases/download/v1.0.1/node_exporter-1.0.1.linux-amd64.tar.gz
 https://github.com/prometheus-community/postgres_exporter/releases/download/v0.9.0/postgres_exporter-0.9.0.linux-amd64.tar.gz

--- a/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.x86_64.txt
+++ b/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.x86_64.txt
@@ -212,7 +212,7 @@ https://packages.elastic.co/curator/5/debian9/pool/main/e/elasticsearch-curator/
 https://dl.grafana.com/oss/release/grafana_7.3.5_amd64.deb
 # --- Exporters ---
 https://github.com/prometheus/haproxy_exporter/releases/download/v0.10.0/haproxy_exporter-0.10.0.linux-amd64.tar.gz
-https://github.com/danielqsj/kafka_exporter/releases/download/v1.4.2/kafka_exporter-1.4.2.linux-amd64.tar.gz
+https://github.com/danielqsj/kafka_exporter/releases/download/v1.4.0/kafka_exporter-1.4.0.linux-amd64.tar.gz
 https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.16.1/jmx_prometheus_javaagent-0.16.1.jar
 https://github.com/prometheus/node_exporter/releases/download/v1.0.1/node_exporter-1.0.1.linux-amd64.tar.gz
 https://github.com/prometheus-community/postgres_exporter/releases/download/v0.9.0/postgres_exporter-0.9.0.linux-amd64.tar.gz

--- a/docs/changelogs/CHANGELOG-1.3.md
+++ b/docs/changelogs/CHANGELOG-1.3.md
@@ -59,3 +59,5 @@
 - PgBouncer available only as Kubernetes service
 
 ### Known issues
+
+- Kafka exporter for Prometheus: Performance issue on large clusters. We use verion 1.4.0 since 1.4.1 and 1.4.2 contain critical bug (see https://github.com/danielqsj/kafka_exporter/issues/273). For release notes, see https://github.com/danielqsj/kafka_exporter/releases.

--- a/docs/changelogs/CHANGELOG-1.3.md
+++ b/docs/changelogs/CHANGELOG-1.3.md
@@ -45,7 +45,7 @@
 - [#2180](https://github.com/epiphany-platform/epiphany/issues/2180) - [documentation] Missing clear information about supported CNI plugins
 - [#2755](https://github.com/epiphany-platform/epiphany/issues/2755) - Upgrade Python dependencies to the latest
 - [#2700](https://github.com/epiphany-platform/epiphany/issues/2700) - Upgrade Prometheus to 2.31.1 and AlertManager to 0.23.0
-- [#2748](https://github.com/epiphany-platform/epiphany/issues/2748) - Upgrade Kafka exporter to the version 1.4.2
+- [#2748](https://github.com/epiphany-platform/epiphany/issues/2748) - Upgrade Kafka exporter to the version 1.4.0
 - [#2750](https://github.com/epiphany-platform/epiphany/issues/2750) - Upgrade JMX exporter to the newest version
 
 ### Removed

--- a/docs/changelogs/CHANGELOG-1.3.md
+++ b/docs/changelogs/CHANGELOG-1.3.md
@@ -60,4 +60,4 @@
 
 ### Known issues
 
-- Kafka exporter for Prometheus: Performance issue on large clusters. We use verion 1.4.0 since 1.4.1 and 1.4.2 contain critical bug (see https://github.com/danielqsj/kafka_exporter/issues/273). For release notes, see https://github.com/danielqsj/kafka_exporter/releases.
+- Kafka exporter for Prometheus: Performance issue on large clusters. We use version 1.4.0 since 1.4.1 and 1.4.2 contain critical bug (see https://github.com/danielqsj/kafka_exporter/issues/273). For release notes, see https://github.com/danielqsj/kafka_exporter/releases.

--- a/docs/home/COMPONENTS.md
+++ b/docs/home/COMPONENTS.md
@@ -29,7 +29,7 @@ Note that versions are default versions and can be changed in certain cases thro
 | Grafana                    | 7.3.5    | https://github.com/grafana/grafana                    | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Node Exporter              | 1.0.1    | https://github.com/prometheus/node_exporter           | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Bitnami Node Exporter Helm Chart      | 1.1.2    | https://github.com/bitnami/charts          | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
-| Kafka Exporter             | 1.4.2    | https://github.com/danielqsj/kafka_exporter           | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| Kafka Exporter             | 1.4.0    | https://github.com/danielqsj/kafka_exporter           | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | HAProxy Exporter           | 0.10.0   | https://github.com/prometheus/haproxy_exporter        | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | JMX Exporter               | 0.16.1   | https://github.com/prometheus/jmx_exporter            | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | Postgres Exporter          | 0.9.0    | https://github.com/prometheus-community/postgres_exporter | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |

--- a/schema/common/defaults/configuration/kafka-exporter.yml
+++ b/schema/common/defaults/configuration/kafka-exporter.yml
@@ -8,10 +8,10 @@ specification:
   config_flags:
     - "--web.listen-address=:9308" # Address to listen on for web interface and telemetry.
     - '--web.telemetry-path=/metrics' # Path under which to expose metrics.
-    - '--verbosity=0'
     - '--topic.filter=.*' # Regex that determines which topics to collect.
     - '--group.filter=.*' # Regex that determines which consumer groups to collect.
     #- '--tls.insecure-skip-tls-verify' # If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+    #- '--log.enable-sarama' # Turn on Sarama logging
     - '--kafka.version=2.6.0'
     #- '--sasl.enabled' # Connect using SASL/PLAIN.
     #- '--sasl.handshake' # Only set this to false if using a non-Kafka SASL proxy


### PR DESCRIPTION
Related issue: #2748
Related PR: #2772

We use version 1.4.0 since 1.4.1 and 1.4.2 contain critical bug (see https://github.com/danielqsj/kafka_exporter/issues/273).