### PR TITLE
Fix edge case in K8s total memory assertion

### DIFF
--- a/ansible/playbooks/roles/kubernetes_master/tasks/preflight/apply.yml
+++ b/ansible/playbooks/roles/kubernetes_master/tasks/preflight/apply.yml
@@ -1,10 +1,9 @@
 ---
 - name: Check if K8s node has enough memory
   assert:
-    that: ansible_memtotal_mb >= 2048
+    that: ansible_memtotal_mb >= 1700
     fail_msg: >-
-      At least 2 GB of RAM per machine is required.
-      Check documentation: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#before-you-begin.
+      At least 1700 MB of RAM per machine is required.
     quiet: true
 
 - name: Check if K8s node has enough CPUs


### PR DESCRIPTION
PR to allow 'apply' on 2 GB/GiB RAM machines and have the [exact](https://github.com/kubernetes/kubernetes/blob/13e97453f9024f347a40940f27630e62c4540fa5/cmd/kubeadm/app/constants/constants.go#L366) value as Kubeadm has.