### PR TITLE
Fix for order of conditions in jmx_exporter upgrade task

### DIFF
--- a/ansible/playbooks/roles/jmx_exporter/tasks/upgrade/main.yml
+++ b/ansible/playbooks/roles/jmx_exporter/tasks/upgrade/main.yml
@@ -41,9 +41,7 @@
         msg: "Skipping upgrade: JMX Exporter in the same or newer version already installed!"
 
 - name: Upgrade | jmx-exporter
-  when: >
-    jmx_exporter_version.old is version( jmx_exporter_version.new, '<' ) or
-    lock_file_status.stat.exists
+  when: lock_file_status.stat.exists or jmx_exporter_version.old is version( jmx_exporter_version.new, '<' )
   block:
     - name: Create upgrade flag file
       file:


### PR DESCRIPTION
Fixes [BUG] Incorrect order of multiple conditions check in jmx_exporter upgrade task #2845

Signed-off-by: cicharka <arkadiusz.cichon@outlook.com>