### PR TITLE
Define additional disks with defined sizes to VMs for Azure

### DIFF
--- a/docs/changelogs/CHANGELOG-2.0.md
+++ b/docs/changelogs/CHANGELOG-2.0.md
@@ -5,6 +5,7 @@
 ### Added
 
 - [#2701](https://github.com/epiphany-platform/epiphany/issues/2701) - Epicli prepare - generate files in separate directory
+- [#2888](https://github.com/epiphany-platform/epiphany/issues/2888) - Define additional disks with defined sizes to VMs for Azure
 
 ### Fixed
 

--- a/schema/azure/defaults/infrastructure/virtual-machine.yml
+++ b/schema/azure/defaults/infrastructure/virtual-machine.yml
@@ -11,7 +11,7 @@ specification:
   network_interface_name: SET_BY_AUTOMATION
   availability_set_name: SET_BY_AUTOMATION  # Please don't change this default value, keep it "SET_BY_AUTOMATION"
   use_network_security_groups: SET_BY_AUTOMATION
-  security_group_association_name: SET_BY_AUTOMATION  
+  security_group_association_name: SET_BY_AUTOMATION
   tags: []
   os_type: linux
   size: Standard_DS1_v2
@@ -28,6 +28,12 @@ specification:
     create_option: FromImage
     disk_size_gb: 32
     managed_disk_type: Premium_LRS
+  additional_disks: []
+    # - storage_account_type: Premium_LRS
+    #   create_option: Empty
+    #   disk_size_gb: 32
+    #   device_name: "/dev/sdb"
+    #   mountpoint: /var/pvs
   network_interface:
     enable_accelerated_networking: false
     private_ip:

--- a/schema/azure/defaults/infrastructure/virtual-machine.yml
+++ b/schema/azure/defaults/infrastructure/virtual-machine.yml
@@ -30,10 +30,7 @@ specification:
     managed_disk_type: Premium_LRS
   additional_disks: []
     # - storage_account_type: Premium_LRS
-    #   create_option: Empty
     #   disk_size_gb: 32
-    #   device_name: "/dev/sdb"
-    #   mountpoint: /var/pvs
   network_interface:
     enable_accelerated_networking: false
     private_ip:

--- a/terraform/azure/infrastructure/virtual-machine.j2
+++ b/terraform/azure/infrastructure/virtual-machine.j2
@@ -86,8 +86,8 @@ resource "azurerm_virtual_machine" "{{ specification.name }}" {
 
 {%- if specification.additional_disks is defined %}
   {%- for disk in specification.additional_disks %}
-resource "azurerm_managed_disk" "{{ specification.name }}-data-disk-{{ loop.index }}" {
-  name                 = "{{ specification.name }}-data-disk-{{ loop.index }}"
+resource "azurerm_managed_disk" "{{ specification.name }}-data-disk-{{ loop.index0 }}" {
+  name                 = "{{ specification.name }}-data-disk-{{ loop.index0 }}"
   location             = azurerm_resource_group.rg.location
   resource_group_name  = azurerm_resource_group.rg.name
   storage_account_type = "{{ disk.storage_account_type }}"
@@ -95,8 +95,8 @@ resource "azurerm_managed_disk" "{{ specification.name }}-data-disk-{{ loop.inde
   disk_size_gb         = "{{ disk.disk_size_gb }}"
 }
 
-resource "azurerm_virtual_machine_data_disk_attachment" "{{ specification.name }}-disk-attachment-{{ loop.index }}" {
-  managed_disk_id    = azurerm_managed_disk.{{ specification.name }}-data-disk-{{ loop.index }}.id
+resource "azurerm_virtual_machine_data_disk_attachment" "{{ specification.name }}-disk-attachment-{{ loop.index0 }}" {
+  managed_disk_id    = azurerm_managed_disk.{{ specification.name }}-data-disk-{{ loop.index0 }}.id
   virtual_machine_id = azurerm_virtual_machine.{{ specification.name }}.id
   lun                = "{{ loop.index * 10 }}"
   caching            = "ReadWrite"

--- a/terraform/azure/infrastructure/virtual-machine.j2
+++ b/terraform/azure/infrastructure/virtual-machine.j2
@@ -85,3 +85,24 @@ resource "azurerm_virtual_machine" "{{ specification.name }}" {
   #TODO:
   # storage_data_disk
 }
+
+{%- if specification.additional_disks is defined %}
+  {%- for disk in specification.additional_disks %}
+resource "azurerm_managed_disk" "{{ specification.name }}-data-disk-{{ loop.index }}" {
+  name                 = "{{ specification.name }}-pvs-disk-{{ loop.index }}"
+  location             = azurerm_resource_group.rg.location
+  resource_group_name  = azurerm_resource_group.rg.name
+  storage_account_type = "{{ disk.storage_account_type }}"
+  create_option        = "{{ disk.create_option }}"
+  disk_size_gb         = "{{ disk.disk_size_gb }}"
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "{{ specification.name }}-disk-attachment-{{ loop.index }}" {
+  managed_disk_id    = azurerm_managed_disk.{{ specification.name }}-data-disk-{{ loop.index }}.id
+  virtual_machine_id = azurerm_virtual_machine.{{ specification.name }}.id
+  lun                = "{{ loop.index * 10 }}"
+  caching            = "ReadWrite"
+}
+
+  {%- endfor %}
+{%- endif %}

--- a/terraform/azure/infrastructure/virtual-machine.j2
+++ b/terraform/azure/infrastructure/virtual-machine.j2
@@ -82,18 +82,16 @@ resource "azurerm_virtual_machine" "{{ specification.name }}" {
   depends_on = [azurerm_network_interface_security_group_association.{{ specification.security_group_association_name }}]
   {%- endif %}
 
-  #TODO:
-  # storage_data_disk
 }
 
 {%- if specification.additional_disks is defined %}
   {%- for disk in specification.additional_disks %}
 resource "azurerm_managed_disk" "{{ specification.name }}-data-disk-{{ loop.index }}" {
-  name                 = "{{ specification.name }}-pvs-disk-{{ loop.index }}"
+  name                 = "{{ specification.name }}-data-disk-{{ loop.index }}"
   location             = azurerm_resource_group.rg.location
   resource_group_name  = azurerm_resource_group.rg.name
   storage_account_type = "{{ disk.storage_account_type }}"
-  create_option        = "{{ disk.create_option }}"
+  create_option        = "Empty"
   disk_size_gb         = "{{ disk.disk_size_gb }}"
 }
 
@@ -103,6 +101,5 @@ resource "azurerm_virtual_machine_data_disk_attachment" "{{ specification.name }
   lun                = "{{ loop.index * 10 }}"
   caching            = "ReadWrite"
 }
-
   {%- endfor %}
 {%- endif %}

--- a/terraform/azure/infrastructure/virtual-machine.j2
+++ b/terraform/azure/infrastructure/virtual-machine.j2
@@ -98,7 +98,7 @@ resource "azurerm_managed_disk" "{{ specification.name }}-data-disk-{{ loop.inde
 resource "azurerm_virtual_machine_data_disk_attachment" "{{ specification.name }}-disk-attachment-{{ loop.index0 }}" {
   managed_disk_id    = azurerm_managed_disk.{{ specification.name }}-data-disk-{{ loop.index0 }}.id
   virtual_machine_id = azurerm_virtual_machine.{{ specification.name }}.id
-  lun                = "{{ loop.index * 10 }}"
+  lun                = "{{ loop.index0 }}"
   caching            = "ReadWrite"
 }
   {%- endfor %}


### PR DESCRIPTION
Generic way to add and attach additional disks for VMs.
Additional resource is not placed under azurerm_virtual_machine resource but as separate resource because:
* it gives opportunity to simplify configuration file (and it also unifies how it is done on AWS)
* it can be later enhanced to attach already existing disks (not possible if storage disks are attached under azurerm_virtual_machine )