### PR TITLE
Fix rsync and schema validation for backup/recovery

### DIFF
--- a/ansible/playbooks/roles/backup/tasks/common/download_via_rsync.yml
+++ b/ansible/playbooks/roles/backup/tasks/common/download_via_rsync.yml
@@ -75,14 +75,16 @@
         dest: "{{ backup_destination_dir }}"
         src: "{{ item }}"
         checksum: true
-        rsync_opts:
-          - --rsh={{ rsh }}
-      vars:
-        # this fixes / replaces incorrect path to the private key file that synchronize provides
-        # (setting private_key parameter has no effect whatsoever, looks like a bug tbh)
-        rsh: >-
-          /usr/bin/ssh -S none -i {{ private_key_file.path }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+        private_key: "{{ private_key_file.path }}"
       loop: "{{ artifacts }}"
+      #  Legacy code used in eariler version of Ansible
+      #   rsync_opts:
+      #     - --rsh={{ rsh }}
+      # vars:
+      #   # this fixes / replaces incorrect path to the private key file that synchronize provides
+      #   # (setting private_key parameter has no effect whatsoever, looks like a bug tbh)
+      #   rsh: >-
+      #     /usr/bin/ssh -S none -i {{ private_key_file.path }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 
     - name: Remove copied artifacts from source
       file:

--- a/ansible/playbooks/roles/backup/tasks/common/download_via_rsync.yml
+++ b/ansible/playbooks/roles/backup/tasks/common/download_via_rsync.yml
@@ -77,14 +77,6 @@
         checksum: true
         private_key: "{{ private_key_file.path }}"
       loop: "{{ artifacts }}"
-      #  Legacy code used in eariler version of Ansible
-      #   rsync_opts:
-      #     - --rsh={{ rsh }}
-      # vars:
-      #   # this fixes / replaces incorrect path to the private key file that synchronize provides
-      #   # (setting private_key parameter has no effect whatsoever, looks like a bug tbh)
-      #   rsh: >-
-      #     /usr/bin/ssh -S none -i {{ private_key_file.path }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 
     - name: Remove copied artifacts from source
       file:

--- a/ansible/playbooks/roles/recovery/tasks/common/upload_via_rsync.yml
+++ b/ansible/playbooks/roles/recovery/tasks/common/upload_via_rsync.yml
@@ -72,11 +72,3 @@
         checksum: true
         private_key: "{{ private_key_file.path }}"
       loop: "{{ artifacts }}"
-      #   Legacy code used in earlier version of Ansible
-      #   rsync_opts:
-      #     - --rsh={{ rsh }}
-      # vars:
-      #   # this fixes / replaces incorrect path to the private key file that synchronize provides
-      #   # (setting private_key parameter has no effect whatsoever, looks like a bug tbh)
-      #   rsh: >-
-      #     /usr/bin/ssh -S none -i {{ private_key_file.path }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/ansible/playbooks/roles/recovery/tasks/common/upload_via_rsync.yml
+++ b/ansible/playbooks/roles/recovery/tasks/common/upload_via_rsync.yml
@@ -70,12 +70,13 @@
         dest: "{{ recovery_dir }}/"
         src: "{{ item }}"
         checksum: true
-        rsync_opts:
-          - --rsh={{ rsh }}
-      vars:
-        # this fixes / replaces incorrect path to the private key file that synchronize provides
-        # (setting private_key parameter has no effect whatsoever, looks like a bug tbh)
-        rsh: >-
-          /usr/bin/ssh -S none -i {{ private_key_file.path }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-      loop: >-
-        {{ artifacts }}
+        private_key: "{{ private_key_file.path }}"
+      loop: "{{ artifacts }}"
+      #   Legacy code used in earlier version of Ansible
+      #   rsync_opts:
+      #     - --rsh={{ rsh }}
+      # vars:
+      #   # this fixes / replaces incorrect path to the private key file that synchronize provides
+      #   # (setting private_key parameter has no effect whatsoever, looks like a bug tbh)
+      #   rsh: >-
+      #     /usr/bin/ssh -S none -i {{ private_key_file.path }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/cli/src/commands/BackupRecoveryBase.py
+++ b/cli/src/commands/BackupRecoveryBase.py
@@ -10,7 +10,7 @@ from cli.src.helpers.build_io import (copy_file, copy_files_recursively,
 from cli.src.helpers.data_loader import load_schema_obj, load_yamls_file
 from cli.src.helpers.data_loader import types as data_types
 from cli.src.helpers.doc_list_helpers import (ExpectedSingleResultException,
-                                              select_single)
+                                              select_single, select_all)
 from cli.src.helpers.yaml_helpers import dump
 from cli.src.schema.DefaultMerger import DefaultMerger
 from cli.src.schema.SchemaValidator import SchemaValidator
@@ -48,8 +48,11 @@ class BackupRecoveryBase(Step):
         self.manifest_docs = load_manifest(self.build_directory)
         self.cluster_model = select_single(self.manifest_docs, lambda x: x.kind == 'epiphany-cluster')
 
-        # Load backup / recovery configuration documents
-        self.input_docs = load_yamls_file(self.file)
+        # Load only backup / recovery configuration documents
+        loaded_docs = load_yamls_file(self.file)
+        self.input_docs = select_all(loaded_docs, lambda x: x.kind == ('configuration/backup','configuration/recovery'))
+        if self.input_docs < 1:
+            raise Exception('No documents for backup or recovery in input file.')
 
         # Validate input documents
         with SchemaValidator(self.cluster_model.provider, self.input_docs) as schema_validator:

--- a/cli/src/commands/BackupRecoveryBase.py
+++ b/cli/src/commands/BackupRecoveryBase.py
@@ -50,8 +50,8 @@ class BackupRecoveryBase(Step):
 
         # Load only backup / recovery configuration documents
         loaded_docs = load_yamls_file(self.file)
-        self.input_docs = select_all(loaded_docs, lambda x: x.kind == ('configuration/backup','configuration/recovery'))
-        if self.input_docs < 1:
+        self.input_docs = select_all(loaded_docs, lambda x: x.kind in ['configuration/backup', 'configuration/recovery'])
+        if len(self.input_docs) < 1:
             raise Exception('No documents for backup or recovery in input file.')
 
         # Validate input documents

--- a/cli/src/schema/SchemaValidator.py
+++ b/cli/src/schema/SchemaValidator.py
@@ -47,11 +47,7 @@ class SchemaValidator(Step):
     def run_for_individual_documents(self):
         for doc in self.validation_docs:
             # Load document schema
-            if 'backup' in doc.kind or 'recovery' in doc.kind:
-                schema = load_schema_obj(types.VALIDATION, self.provider, doc.kind)
-            else:
-                schema = self.get_base_schema(doc.kind)
-                schema['properties']['specification'] = load_schema_obj(types.VALIDATION, self.provider, doc.kind)
+            schema = load_schema_obj(types.VALIDATION, self.provider, doc.kind)
 
             # Include "definitions"
             schema['definitions'] = self.definitions

--- a/cli/src/schema/SchemaValidator.py
+++ b/cli/src/schema/SchemaValidator.py
@@ -47,7 +47,11 @@ class SchemaValidator(Step):
     def run_for_individual_documents(self):
         for doc in self.validation_docs:
             # Load document schema
-            schema = load_schema_obj(types.VALIDATION, self.provider, doc.kind)
+            if 'backup' in doc.kind or 'recovery' in doc.kind:
+                schema = load_schema_obj(types.VALIDATION, self.provider, doc.kind)
+            else:
+                schema = self.get_base_schema(doc.kind)
+                schema['properties']['specification'] = load_schema_obj(types.VALIDATION, self.provider, doc.kind)
 
             # Include "definitions"
             schema['definitions'] = self.definitions

--- a/docs/changelogs/CHANGELOG-2.0.md
+++ b/docs/changelogs/CHANGELOG-2.0.md
@@ -23,8 +23,13 @@
 - [#2945](https://github.com/epiphany-platform/epiphany/issues/2945) - epicli apply sleeps 10 seconds after creating inventory
 - [#2968](https://github.com/epiphany-platform/epiphany/issues/2968) - `epicli init` should generate `specification.cloud.subscription_name` for minimal cluster config
 - [#2940](https://github.com/epiphany-platform/epiphany/issues/2940) - firewalld.service unit could not be found on host however ansible_facts sees it as defined
+<<<<<<< HEAD
 - [#2979](https://github.com/epiphany-platform/epiphany/issues/2979) - Restore the possibility of choosing the availability zone in AWS
 - [#2984](https://github.com/epiphany-platform/epiphany/issues/2984) - Validation blocks overwriting of destination_address_prefix in NSG rules, which is 0.0.0.0/0 by default
+=======
+- [#2942](https://github.com/epiphany-platform/epiphany/issues/2942) - rsync command fails trying to copy artifacts
+- [#2930](https://github.com/epiphany-platform/epiphany/issues/2930) - Backup/recovery commands fail when default configuration for backup attached to cluster-config.yml
+>>>>>>> 71b9c4f1 (* Changelog updated)
 
 ### Updated
 

--- a/docs/changelogs/CHANGELOG-2.0.md
+++ b/docs/changelogs/CHANGELOG-2.0.md
@@ -23,13 +23,10 @@
 - [#2945](https://github.com/epiphany-platform/epiphany/issues/2945) - epicli apply sleeps 10 seconds after creating inventory
 - [#2968](https://github.com/epiphany-platform/epiphany/issues/2968) - `epicli init` should generate `specification.cloud.subscription_name` for minimal cluster config
 - [#2940](https://github.com/epiphany-platform/epiphany/issues/2940) - firewalld.service unit could not be found on host however ansible_facts sees it as defined
-<<<<<<< HEAD
 - [#2979](https://github.com/epiphany-platform/epiphany/issues/2979) - Restore the possibility of choosing the availability zone in AWS
 - [#2984](https://github.com/epiphany-platform/epiphany/issues/2984) - Validation blocks overwriting of destination_address_prefix in NSG rules, which is 0.0.0.0/0 by default
-=======
 - [#2942](https://github.com/epiphany-platform/epiphany/issues/2942) - rsync command fails trying to copy artifacts
 - [#2930](https://github.com/epiphany-platform/epiphany/issues/2930) - Backup/recovery commands fail when default configuration for backup attached to cluster-config.yml
->>>>>>> 71b9c4f1 (* Changelog updated)
 
 ### Updated
 

--- a/docs/home/howto/BACKUP.md
+++ b/docs/home/howto/BACKUP.md
@@ -17,17 +17,18 @@ filesystem. See [How to store backup](#2-how-to-store-backup) chapter.
 
 ## 1. How to perform backup
 
-#### Backup configuration file and command
+### Backup configuration file and command
 
 Copy default configuration for backup from ``defaults/configuration/backup.yml`` into newly created backup.yml config
-file, and enable backup for chosen components by setting up ``enabled`` parameter to ``true``.
+file, supply correct provider and enable backup for chosen components by setting up ``enabled`` parameter to ``true``.
 
 This config may also be attached to cluster-config.yml
 
-```
+```yaml
 kind: configuration/backup
 title: Backup Config
 name: default
+provider: azure
 specification:
   components:
     load_balancer:
@@ -48,7 +49,7 @@ specification:
 
 Run ``epicli backup`` command:
 
-```
+```shell
 epicli backup -f backup.yml -b build_folder
 ```
 
@@ -80,15 +81,16 @@ machine's disk drive. This is not recommended.
 ### Recovery configuration file and command
 
 Copy existing default configuration from ``defaults/configuration/recovery.yml`` into newly created recovery.yml config
-file, and set ``enabled`` parameter for component to recovery. It's possible to choose snapshot name by passing date and
-time part of snapshot name. If snapshot name is not provided, the latest one will be restored.
+file, supply correct provider and set ``enabled`` parameter for component to recovery. It's possible to choose snapshot
+name by passing date and time part of snapshot name. If snapshot name is not provided, the latest one will be restored.
 
 This config may also be attached to cluster-config.yml
 
-```
+```yaml
 kind: configuration/recovery
 title: Recovery Config
 name: default
+provider: azure
 specification:
   components:
     load_balancer:
@@ -110,7 +112,9 @@ specification:
 
 Run ``epicli recovery`` command:
 
-``epicli recovery -f recovery.yml -b build_folder``
+```shell
+epicli recovery -f recovery.yml -b build_folder
+```
 
 If recovery config is attached to cluster-config.yml, use this file instead of ``recovery.yml``.
 

--- a/docs/home/howto/BACKUP.md
+++ b/docs/home/howto/BACKUP.md
@@ -22,8 +22,6 @@ filesystem. See [How to store backup](#2-how-to-store-backup) chapter.
 Copy default configuration for backup from ``defaults/configuration/backup.yml`` into newly created backup.yml config
 file, supply correct provider and enable backup for chosen components by setting up ``enabled`` parameter to ``true``.
 
-This config may also be attached to cluster-config.yml
-
 ```yaml
 kind: configuration/backup
 title: Backup Config
@@ -52,8 +50,6 @@ Run ``epicli backup`` command:
 ```shell
 epicli backup -f backup.yml -b build_folder
 ```
-
-If backup config is attached to cluster-config.yml, use this file instead of ``backup.yml``.
 
 ## 2. How to store backup
 
@@ -84,8 +80,6 @@ Copy existing default configuration from ``defaults/configuration/recovery.yml``
 file, supply correct provider and set ``enabled`` parameter for component to recovery. It's possible to choose snapshot
 name by passing date and time part of snapshot name. If snapshot name is not provided, the latest one will be restored.
 
-This config may also be attached to cluster-config.yml
-
 ```yaml
 kind: configuration/recovery
 title: Recovery Config
@@ -115,8 +109,6 @@ Run ``epicli recovery`` command:
 ```shell
 epicli recovery -f recovery.yml -b build_folder
 ```
-
-If recovery config is attached to cluster-config.yml, use this file instead of ``recovery.yml``.
 
 ## 4. How backup and recovery work
 


### PR DESCRIPTION
Bug #2942 rsync command fails trying to copy artifacts
* With new version of ansible we can use private_key option for
  synchronize module, therefore there's no need to use rsh

Bug #2930 Backup/recovery commands fail when default configuration for backup attached to cluster-config.yml
* extend run_for_individual_documents method so it can choose relevant
  schema for validated document
* Minor fixes for BACKUP.md documentation