### PR TITLE
Remove `lower` filter from managed_disk_type parameter

### DIFF
--- a/terraform/azure/infrastructure/virtual-machine.j2
+++ b/terraform/azure/infrastructure/virtual-machine.j2
@@ -59,7 +59,7 @@ resource "azurerm_virtual_machine" "{{ specification.name }}" {
     create_option     = "{{ specification.storage_os_disk.create_option }}"
     disk_size_gb      = "{{ specification.storage_os_disk.disk_size_gb }}"
     {%- if specification.storage_os_disk.managed %}
-    managed_disk_type = "{{ specification.storage_os_disk.managed_disk_type | lower }}"
+    managed_disk_type = "{{ specification.storage_os_disk.managed_disk_type }}"
     {%- endif %}
   }
 


### PR DESCRIPTION
With current version of Terraform we don't need to use filter.