### PR TITLE
Development improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,6 @@
         "davidanson.vscode-markdownlint",
         // Python
         "ms-python.python",
-        "littlefoxteam.vscode-python-test-adapter",
         // Ruby
         "rebornix.Ruby",
         "castwide.solargraph",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,6 +28,7 @@
         "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind",
     ],
     "settings": {
+        "python.envFile": "${workspaceFolder}/.devcontainer/python.env",
         "python.pythonPath": "/usr/local/bin/python",
     },
     "remoteUser": "vscode",

--- a/.devcontainer/python.env
+++ b/.devcontainer/python.env
@@ -1,0 +1,5 @@
+# https://code.visualstudio.com/docs/python/environments#_environment-variables
+
+# PYTHONPATH can contain multiple locations separated by os.pathsep: semicolon (;) on Windows and colon (:) on Linux/macOS.
+# Invalid paths are ignored. To verify use "python.analysis.logLevel": "Trace".
+PYTHONPATH="ansible/playbooks/roles/repository/files/download-requirements:${PYTHONPATH}"

--- a/.pylintrc
+++ b/.pylintrc
@@ -39,7 +39,7 @@ unsafe-load-any-extension=no
 extension-pkg-allow-list=
 
 # Minimum supported python version
-py-version = 3.6
+py-version = 3.10
 
 
 [MESSAGES CONTROL]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -12,7 +12,6 @@
         "davidanson.vscode-markdownlint",
         // Python
         "ms-python.python",
-        "littlefoxteam.vscode-python-test-adapter",
         // Ruby
         "rebornix.Ruby",
         "castwide.solargraph",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,10 +12,8 @@
         "--rcfile",
         "${workspaceFolder}/.pylintrc"
     ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.nosetestsEnabled": false,
     "python.testing.pytestEnabled": true,
-    "python.pythonPath": "/usr/local/bin/python",
+    "python.testing.unittestEnabled": false,
 
     // Ruby
     "ruby.format": false,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,35 +20,47 @@
       "group": "test",
     },
     {
-      "label": "Pylint junit",
+      "label": "Pylint epicli [junit]",
       "command": "pylint --rcfile .pylintrc ./cli ./tests --output ${workspaceFolder}/test_results/pylint_results.xml",
       "dependsOn": ["Ensure test_results directory"],
       "group": "test",
     },
     {
-      "label": "Pylint terminal",
+      "label": "Pylint epicli [terminal]",
       "command": "pylint --rcfile .pylintrc ./cli ./tests --output-format text",
       "group": "test",
     },
     {
-      "label": "Ansible-lint junit",
+      "label": "Pylint download-requirements",
+      "command": "pylint",
+      "args": [
+        "--rcfile", ".pylintrc",
+        "--output-format", "text",
+        "./ansible/playbooks/roles/repository/files/download-requirements/download-requirements.py",
+        "./ansible/playbooks/roles/repository/files/download-requirements/src",
+        "./ansible/playbooks/roles/repository/files/download-requirements/tests",
+      ],
+      "group": "test",
+    },
+    {
+      "label": "Ansible-lint [junit]",
       "command": "ansible-lint --nocolor -q -c .ansible-lint -p ${workspaceFolder}/ansible/playbooks/*.yml > ${workspaceFolder}/test_results/ansiblelint_results.txt ; ansible-lint-to-junit-xml ${workspaceFolder}/test_results/ansiblelint_results.txt > ${workspaceFolder}/test_results/ansiblelint_results.xml",
       "dependsOn": ["Ensure test_results directory"],
       "group": "test",
     },
     {
-      "label": "Ansible-lint terminal",
+      "label": "Ansible-lint [terminal]",
       "command": "ansible-lint -q -c .ansible-lint -p ${workspaceFolder}/ansible/playbooks/*.yml",
       "group": "test",
     },
     {
-      "label": "Rubocop junit",
+      "label": "Rubocop [junit]",
       "command": "rubocop -c .rubocop.yml --require rubocop/formatter/junit_formatter --format RuboCop::Formatter::JUnitFormatter --out test_results/rubocop_results.xml",
       "dependsOn": ["Ensure test_results directory"],
       "group": "test",
     },
     {
-      "label": "Rubocop terminal",
+      "label": "Rubocop [terminal]",
       "command": "rubocop -c .rubocop.yml",
       "group": "test",
     }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,56 +1,56 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558 for the documentation about the tasks.json format
-    "problemMatcher": [],
-    "type": "shell",
-    "version": "2.0.0",
-    "tasks": [
-      {
-        "label": "Ensure test_results directory",
-        "command": "mkdir -p ${workspaceFolder}/test_results",
-        "presentation": {
-          "echo": false,
-          "reveal": "silent",
-          "showReuseMessage": false,
-        }
-      },
-      {
-        "label": "Pytest",
-        "command": "pytest --junitxml=${workspaceFolder}/test_results/pytest_results.xml",
-        "dependsOn": ["Ensure test_results directory"],
-        "group": "test",
-      },
-      {
-        "label": "Pylint junit",
-        "command": "pylint --rcfile .pylintrc ./cli ./tests --output ${workspaceFolder}/test_results/pylint_results.xml",
-        "dependsOn": ["Ensure test_results directory"],
-        "group": "test",
-      },
-      {
-        "label": "Pylint terminal",
-        "command": "pylint --rcfile .pylintrc ./cli ./tests --output-format text",
-        "group": "test",
-      },
-      {
-        "label": "Ansible-lint junit",
-        "command": "ansible-lint --nocolor -q -c .ansible-lint -p ${workspaceFolder}/ansible/playbooks/*.yml > ${workspaceFolder}/test_results/ansiblelint_results.txt ; ansible-lint-to-junit-xml ${workspaceFolder}/test_results/ansiblelint_results.txt > ${workspaceFolder}/test_results/ansiblelint_results.xml",
-        "dependsOn": ["Ensure test_results directory"],
-        "group": "test",
-      },
-      {
-        "label": "Ansible-lint terminal",
-        "command": "ansible-lint -q -c .ansible-lint -p ${workspaceFolder}/ansible/playbooks/*.yml",
-        "group": "test",
-      },
-      {
-        "label": "Rubocop junit",
-        "command": "rubocop -c .rubocop.yml --require rubocop/formatter/junit_formatter --format RuboCop::Formatter::JUnitFormatter --out test_results/rubocop_results.xml",
-        "dependsOn": ["Ensure test_results directory"],
-        "group": "test",
-      },
-      {
-        "label": "Rubocop terminal",
-        "command": "rubocop -c .rubocop.yml",
-        "group": "test",
+  // See https://go.microsoft.com/fwlink/?LinkId=733558 for the documentation about the tasks.json format
+  "problemMatcher": [],
+  "type": "shell",
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Ensure test_results directory",
+      "command": "mkdir -p ${workspaceFolder}/test_results",
+      "presentation": {
+        "echo": false,
+        "reveal": "silent",
+        "showReuseMessage": false,
       }
-    ]
-  }
+    },
+    {
+      "label": "Pytest",
+      "command": "pytest --junitxml=${workspaceFolder}/test_results/pytest_results.xml",
+      "dependsOn": ["Ensure test_results directory"],
+      "group": "test",
+    },
+    {
+      "label": "Pylint junit",
+      "command": "pylint --rcfile .pylintrc ./cli ./tests --output ${workspaceFolder}/test_results/pylint_results.xml",
+      "dependsOn": ["Ensure test_results directory"],
+      "group": "test",
+    },
+    {
+      "label": "Pylint terminal",
+      "command": "pylint --rcfile .pylintrc ./cli ./tests --output-format text",
+      "group": "test",
+    },
+    {
+      "label": "Ansible-lint junit",
+      "command": "ansible-lint --nocolor -q -c .ansible-lint -p ${workspaceFolder}/ansible/playbooks/*.yml > ${workspaceFolder}/test_results/ansiblelint_results.txt ; ansible-lint-to-junit-xml ${workspaceFolder}/test_results/ansiblelint_results.txt > ${workspaceFolder}/test_results/ansiblelint_results.xml",
+      "dependsOn": ["Ensure test_results directory"],
+      "group": "test",
+    },
+    {
+      "label": "Ansible-lint terminal",
+      "command": "ansible-lint -q -c .ansible-lint -p ${workspaceFolder}/ansible/playbooks/*.yml",
+      "group": "test",
+    },
+    {
+      "label": "Rubocop junit",
+      "command": "rubocop -c .rubocop.yml --require rubocop/formatter/junit_formatter --format RuboCop::Formatter::JUnitFormatter --out test_results/rubocop_results.xml",
+      "dependsOn": ["Ensure test_results directory"],
+      "group": "test",
+    },
+    {
+      "label": "Rubocop terminal",
+      "command": "rubocop -c .rubocop.yml",
+      "group": "test",
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,42 +1,56 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
+    // See https://go.microsoft.com/fwlink/?LinkId=733558 for the documentation about the tasks.json format
+    "problemMatcher": [],
+    "type": "shell",
     "version": "2.0.0",
     "tasks": [
       {
+        "label": "Ensure test_results directory",
+        "command": "mkdir -p ${workspaceFolder}/test_results",
+        "presentation": {
+          "echo": false,
+          "reveal": "silent",
+          "showReuseMessage": false,
+        }
+      },
+      {
         "label": "Pytest",
-        "type": "shell",
-        "command": "mkdir -p test_results && pytest --junitxml=${workspaceFolder}/test_results/pytest_results.xml"
+        "command": "pytest --junitxml=${workspaceFolder}/test_results/pytest_results.xml",
+        "dependsOn": ["Ensure test_results directory"],
+        "group": "test",
       },
       {
         "label": "Pylint junit",
-        "type": "shell",
-        "command": "mkdir -p test_results && pylint --rcfile .pylintrc ./cli ./tests --output ${workspaceFolder}/test_results/pylint_results.xml"
+        "command": "pylint --rcfile .pylintrc ./cli ./tests --output ${workspaceFolder}/test_results/pylint_results.xml",
+        "dependsOn": ["Ensure test_results directory"],
+        "group": "test",
       },
       {
         "label": "Pylint terminal",
-        "type": "shell",
-        "command": "pylint --rcfile .pylintrc ./cli ./tests --output-format text"
+        "command": "pylint --rcfile .pylintrc ./cli ./tests --output-format text",
+        "group": "test",
       },
       {
         "label": "Ansible-lint junit",
-        "type": "shell",
-        "command": "mkdir -p test_results && ansible-lint --nocolor -q -c .ansible-lint -p ${workspaceFolder}/ansible/playbooks/*.yml > ${workspaceFolder}/test_results/ansiblelint_results.txt ; ansible-lint-to-junit-xml ${workspaceFolder}/test_results/ansiblelint_results.txt > ${workspaceFolder}/test_results/ansiblelint_results.xml"
+        "command": "ansible-lint --nocolor -q -c .ansible-lint -p ${workspaceFolder}/ansible/playbooks/*.yml > ${workspaceFolder}/test_results/ansiblelint_results.txt ; ansible-lint-to-junit-xml ${workspaceFolder}/test_results/ansiblelint_results.txt > ${workspaceFolder}/test_results/ansiblelint_results.xml",
+        "dependsOn": ["Ensure test_results directory"],
+        "group": "test",
       },
       {
         "label": "Ansible-lint terminal",
-        "type": "shell",
-        "command": "ansible-lint -q -c .ansible-lint -p ${workspaceFolder}/ansible/playbooks/*.yml"
+        "command": "ansible-lint -q -c .ansible-lint -p ${workspaceFolder}/ansible/playbooks/*.yml",
+        "group": "test",
       },
       {
         "label": "Rubocop junit",
-        "type": "shell",
-        "command": "mkdir -p test_results && rubocop -c .rubocop.yml --require rubocop/formatter/junit_formatter --format RuboCop::Formatter::JUnitFormatter --out test_results/rubocop_results.xml"
+        "command": "rubocop -c .rubocop.yml --require rubocop/formatter/junit_formatter --format RuboCop::Formatter::JUnitFormatter --out test_results/rubocop_results.xml",
+        "dependsOn": ["Ensure test_results directory"],
+        "group": "test",
       },
       {
         "label": "Rubocop terminal",
-        "type": "shell",
-        "command": "rubocop -c .rubocop.yml"
+        "command": "rubocop -c .rubocop.yml",
+        "group": "test",
       }
     ]
   }

--- a/ansible/playbooks/roles/repository/files/download-requirements/conftest.py
+++ b/ansible/playbooks/roles/repository/files/download-requirements/conftest.py
@@ -1,0 +1,3 @@
+# This file fixes import issues (like ModuleNotFoundError: No module named 'tests.mocks')
+# when discovering or running pytest by adding parent directory to sys.path.
+# See https://stackoverflow.com/a/50610630/10861750

--- a/ansible/playbooks/roles/repository/files/download-requirements/conftest.py
+++ b/ansible/playbooks/roles/repository/files/download-requirements/conftest.py
@@ -1,3 +1,3 @@
 # This file fixes import issues (like ModuleNotFoundError: No module named 'tests.mocks')
-# when discovering or running pytest by adding parent directory to sys.path.
+# when discovering or running tests by adding parent directory to sys.path.
 # See https://stackoverflow.com/a/50610630/10861750

--- a/ansible/playbooks/roles/repository/files/download-requirements/tests/command/test_yum.py
+++ b/ansible/playbooks/roles/repository/files/download-requirements/tests/command/test_yum.py
@@ -27,10 +27,10 @@ def test_interface_remove(mocker):
 def test_interface_is_repo_enabled(mocker):
     ''' Check argument construction for `yum repolist enabled` '''
     with CommandRunMock(mocker, Yum(1).is_repo_enabled, {'repo': 'some_repo'}) as call_args:
-        assert call_args == ['yum', 'repolist', 'enabled']
+        assert call_args == ['yum', '-y', 'repolist', 'enabled']
 
 
 def test_interface_find_rhel_repo_id(mocker):
     ''' Check argument construction for `yum repolist all` '''
     with CommandRunMock(mocker, Yum(1).find_rhel_repo_id, {'patterns': ['pat1', 'pat2']}) as call_args:
-        assert call_args == ['yum', 'repolist', 'all']
+        assert call_args == ['yum', '-y', 'repolist', 'all']

--- a/cli/src/helpers/build_io.py
+++ b/cli/src/helpers/build_io.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from distutils import dir_util
+
 from pathlib import Path
 
 from ansible.inventory.manager import InventoryManager
@@ -147,7 +147,7 @@ def delete_directory(dir_path):
 
 
 def copy_files_recursively(src, dst):
-    dir_util.copy_tree(src, dst)
+    shutil.copytree(src, dst, dirs_exist_ok=True)
 
 
 def copy_file(src, dst):

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 addopts = --exitfirst -p no:warnings
 junit_family = xunit1
 testpaths = tests/unit/
+            ansible/playbooks/roles/repository/files/download-requirements/tests/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
-addopts = -x tests/ -p no:warnings
+addopts = --exitfirst -p no:warnings
 junit_family = xunit1
+testpaths = tests/unit/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,8 @@
+# This file should only contain common options (not CI pipeline or IDE specific)
 [pytest]
-addopts = --exitfirst -p no:warnings
-testpaths = tests/unit/
-            ansible/playbooks/roles/repository/files/download-requirements/tests/
+filterwarnings =
+    # packaging package is dependency of azure-cli
+    ignore:The distutils package is deprecated:DeprecationWarning:packaging.tags
+testpaths =
+    tests/unit/
+    ansible/playbooks/roles/repository/files/download-requirements/tests/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
 addopts = --exitfirst -p no:warnings
-junit_family = xunit1
 testpaths = tests/unit/
             ansible/playbooks/roles/repository/files/download-requirements/tests/


### PR DESCRIPTION
VSCode:
- Use VSCode native API and UI for running tests
- Remove obsolete VSCode settings
- Refactor tasks.json

pylint:
- Fix import issues for download-requirements
- Update py-version

pytest:
- Add download-requirements tests to pytest.ini
- Ignore only known warnings
- Do not use deprecated distutils package
- Use default junit_family
- Refactor pytest.ini
- Fix yum tests