### PR TITLE
Set `/bin/bash` executable for k8s promote to HA task

### DIFF
--- a/ansible/playbooks/roles/kubernetes_promote/tasks/update-master.yml
+++ b/ansible/playbooks/roles/kubernetes_promote/tasks/update-master.yml
@@ -47,6 +47,8 @@
         | kubectl apply \
           --namespace kube-system \
           -f-
+      args:
+        executable: /bin/bash
       vars:
         server: https://localhost:3446
 


### PR DESCRIPTION
Fix for #3096.
The bug was introduced in #3018  
https://github.com/rafzei/epiphany/blob/4e9092a43baf141200cda5a05bb8c9f589425c3d/ansible/playbooks/roles/kubernetes_promote/tasks/update-master.yml#L42 so no updating the changelog.
