### PR TITLE
[2.0.1] Split available_roles and roles_mapping into separate yaml documents …

### DIFF
--- a/ansible/playbooks/repository.yml
+++ b/ansible/playbooks/repository.yml
@@ -1,5 +1,5 @@
 ---
-# This playbook is empty by purpose, just to enable repository role in configuration/feature-mapping
+# This playbook is empty by purpose, just to enable repository role in configuration/features
 # to populate defaults/configuration to Ansible vars
 - hosts: "!all"
   tasks: []

--- a/cli/src/ansible/AnsibleInventoryCreator.py
+++ b/cli/src/ansible/AnsibleInventoryCreator.py
@@ -43,12 +43,12 @@ class AnsibleInventoryCreator(Step):
         return self.group_duplicated(inventory)
 
     def get_roles_for_feature(self, component_key):
-        features_map = select_single(self.config_docs, lambda x: x.kind == 'configuration/feature-mapping')
-        return features_map.specification.roles_mapping[component_key]
+        features_map = select_single(self.config_docs, lambda x: x.kind == 'configuration/feature-mappings')
+        return features_map.specification[component_key]
 
     def get_available_roles(self):
-        features_map = select_single(self.config_docs, lambda x: x.kind == 'configuration/feature-mapping')
-        return features_map.specification.available_roles
+        features = select_single(self.config_docs, lambda x: x.kind == 'configuration/features')
+        return features.specification
 
     def get_enabled_roles(self):
         roles = self.get_available_roles()

--- a/cli/src/commands/Init.py
+++ b/cli/src/commands/Init.py
@@ -49,6 +49,9 @@ class Init(Step):
                 config_docs = config_appender.run()
 
             docs = [*config_docs, *infra_docs]
+        else:
+            with ConfigurationAppender(docs) as config_appender:
+                config_appender.add_feature_mappings()
 
         # set the provider and version for all docs
         for doc in docs:

--- a/cli/src/schema/ConfigurationAppender.py
+++ b/cli/src/schema/ConfigurationAppender.py
@@ -1,3 +1,5 @@
+from typing import Callable, Dict, List
+
 from cli.src.helpers.config_merger import merge_with_defaults
 from cli.src.helpers.data_loader import load_schema_obj, schema_types
 from cli.src.helpers.doc_list_helpers import select_first, select_single
@@ -6,45 +8,60 @@ from cli.version import VERSION
 
 
 class ConfigurationAppender(Step):
-    REQUIRED_DOCS = ['epiphany-cluster', 'configuration/feature-mapping', 'configuration/shared-config']
+    REQUIRED_DOCS = ['epiphany-cluster',
+                     'configuration/features',
+                     'configuration/feature-mappings',
+                     'configuration/shared-config']
 
     def __init__(self, input_docs):
         super().__init__(__name__)
-        self.cluster_model = select_single(input_docs, lambda x: x.kind == 'epiphany-cluster')
-        self.input_docs = input_docs
+        self.__cluster_model: Dict = select_single(input_docs, lambda x: x.kind == 'epiphany-cluster')
+        self.__input_docs: List[Dict] = input_docs
+
+    def __append_config(self, config_docs: List[Dict], document: Dict):
+        document['version'] = VERSION
+        config_docs.append(document)
+
+    def __add_doc(self, config_docs: List[Dict], document_kind: str):
+        doc = select_first(self.__input_docs, lambda x, kind=document_kind: x.kind == kind)
+        if doc is None:
+            doc = load_schema_obj(schema_types.DEFAULT, 'common', document_kind)
+            self.logger.info(f'Adding: {doc.kind}')
+
+        self.__append_config(config_docs, doc)
+
+    def __feature_selector(self, feature_key: str, config_selector: str) -> Callable:
+        return lambda x, key=feature_key, selector=config_selector: x.kind == f'configuration/{key}' and x.name == selector
+
+    def add_feature_mappings(self):
+        feature_mappings: List[Dict] = []
+        self.__add_doc(feature_mappings, 'configuration/feature-mappings')
+
+        if feature_mappings is not None:
+            self.__input_docs.append(feature_mappings[0])
 
     def run(self):
-        configuration_docs = []
-
-        def append_config(doc):
-            doc['version'] = VERSION
-            configuration_docs.append(doc)
+        configuration_docs: List[Dict] = []
 
         for document_kind in ConfigurationAppender.REQUIRED_DOCS:
-            doc = select_first(self.input_docs, lambda x: x.kind == document_kind)
-            if doc is None:
-                doc = load_schema_obj(schema_types.DEFAULT, 'common', document_kind)
-                self.logger.info("Adding: " + doc.kind)
-                append_config(doc)
-            else:
-                append_config(doc)
+            self.__add_doc(configuration_docs, document_kind)
 
-        for component_key, component_value in self.cluster_model.specification.components.items():
+        for component_key, component_value in self.__cluster_model.specification.components.items():
             if component_value.count < 1:
                 continue
 
-            features_map = select_first(configuration_docs, lambda x: x.kind == 'configuration/feature-mapping')
+            feature_mappings = select_first(configuration_docs, lambda x: x.kind == 'configuration/feature-mappings')
             config_selector = component_value.configuration
-            for feature_key in features_map.specification.roles_mapping[component_key]:
-                config = select_first(self.input_docs, lambda x: x.kind == 'configuration/' + feature_key and x.name == config_selector)
-                if config is not None:
-                    append_config(config)
-                if config is None:
-                    config = select_first(configuration_docs, lambda
-                        x: x.kind == 'configuration/' + feature_key and x.name == config_selector)
-                if config is None:
-                    config = merge_with_defaults('common', 'configuration/' + feature_key, config_selector, self.input_docs)
-                    self.logger.info("Adding: " + config.kind)
-                    append_config(config)
+            for feature_key in feature_mappings.specification.mappings[component_key]:
+                first_input_docs_config = select_first(self.__input_docs, self.__feature_selector(feature_key, config_selector))
+                if first_input_docs_config is not None:
+                    self.__append_config(configuration_docs, first_input_docs_config)
+                else:
+                    first_config = select_first(configuration_docs, self.__feature_selector(feature_key, config_selector))
+
+                    if first_config is None:
+                        merged_config = merge_with_defaults('common', f'configuration/{feature_key}', config_selector, self.__input_docs)
+                        self.logger.info(f'Adding: {merged_config.kind}')
+                        self.__append_config(configuration_docs, merged_config)
 
         return configuration_docs

--- a/docs/changelogs/CHANGELOG-2.0.md
+++ b/docs/changelogs/CHANGELOG-2.0.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- [#3097](https://github.com/epiphany-platform/epiphany/issues/3097) - Split available_roles and roles_mapping into separate yaml documents
+
+### Breaking changes
+
+- Schema `configuration/feature-mapping` changed. The document was splitted into two separate docs `configuration/features` and `configuration/feature-mappings`.
+
 ## [2.0.0] 2022-05-09
 
 ### Added
@@ -58,7 +64,7 @@
 - [#2803](https://github.com/epiphany-platform/epiphany/issues/2803) - Refactor: rename 'kafka_var' setting
 - [#2995](https://github.com/epiphany-platform/epiphany/issues/2995) - Update expired RHUI client certificate before installing any RHEL packages
 - [#3049](https://github.com/epiphany-platform/epiphany/issues/3049) - HAProxy upgrade fails on re-run trying to remove haproxy_exporter
-- [#3006](https://github.com/epiphany-platform/epiphany/issues/3006) - install 'containerd.io=1.4.12-*' failed, when upgrade from v1.3.0 to 2.0.0dev
+- [#3006](https://github.com/epiphany-platform/epiphany/issues/3006) - install `containerd.io=1.4.12-*` failed, when upgrade from v1.3.0 to 2.0.0dev
 - [#3065](https://github.com/epiphany-platform/epiphany/issues/3065) - Flag `delete_os_disk_on_termination` has no effect when removing cluster
 
 ### Updated

--- a/docs/home/howto/CLUSTER.md
+++ b/docs/home/howto/CLUSTER.md
@@ -57,10 +57,9 @@ Disable:
 2. Prepend `kubernetes_master` mapping (or any other mapping if you don't deploy Kubernetes) with:
 
     ```yaml
-    kind: configuration/feature-mapping
+    kind: configuration/feature-mappings
     specification:
-    ...
-      roles_mapping:
+      mappings:
       ...
         kubernetes_master:
           - repository
@@ -290,12 +289,12 @@ specification:
     kubernetes_node:
       count: 2
 ---
-kind: configuration/feature-mapping
-title: "Feature mapping to roles"
+kind: configuration/feature-mappings
+title: "Feature mapping to components"
 provider: <provider>
 name: default
 specification:
-  roles_mapping:
+  mappings:
     kubernetes_master:
       - repository
       - image-registry
@@ -671,40 +670,44 @@ specification:
 
 Epiphany gives you the ability to define custom components. This allows you to define a custom set of roles for a component you want to use in your cluster. It can be useful when you for example want to maximize usage of the available machines you have at your disposal.
 
-The first thing you will need to do is define it in the `configuration/feature-mapping` configuration. To get this configuration you can run `epicli init ... --full` command. In the `available_roles` roles section you can see all the available roles that Epiphany provides. The `roles_mapping` is where all the Epiphany components are defined and were you need to add your custom components.
+The first thing you will need to do is define it in the `configuration/features` and the `configuration/feature-mappings` configurations. To get these configurations you can run `epicli init ... --full` command. In the `configuration/features` doc you can see all the available features that Epiphany provides. The `configuration/feature-mappings` doc is where all the Epiphany components are defined and where you can add your custom components.
 
-Below are parts of an example `configuration/feature-mapping` were we define a new `single_machine_new` component. We want to use Kafka instead of RabbitMQ and don`t need applications and postgres since we don't want a Keycloak deployment:
+Below are parts of an example `configuration/features` and `configuration/feature-mappings` docs where we define a new `single_machine_new` component. We want to use Kafka instead of RabbitMQ and don't need applications and postgres since we don't want a Keycloak deployment:
 
 ```yaml
-kind: configuration/feature-mapping
-title: Feature mapping to roles
+kind: configuration/features
+title: "Features to be enabled/disabled"
 name: default
 specification:
-  available_roles: # All entries here represent the available roles within Epiphany
-  - name: repository
-    enabled: yes
-  - name: firewall
-    enabled: yes
-  - name: image-registry
-  ...
-  roles_mapping: # All entries here represent the default components provided with Epiphany
-  ...
+  features:  # All entries here represent the available features within Epiphany
+    - name: repository
+      enabled: yes
+    - name: firewall
+      enabled: yes
+    - name: image-registry
+    ...
+---
+kind: configuration/feature-mappings
+title: "Feature mapping to components"
+name: default
+specification:
+  mappings: # All entries here represent the default components provided with Epiphany
     single_machine:
-    - repository
-    - image-registry
-    - kubernetes-master
-    - applications
-    - rabbitmq
-    - postgresql
-    - firewall
+      - repository
+      - image-registry
+      - kubernetes-master
+      - applications
+      - rabbitmq
+      - postgresql
+      - firewall
     # Below is the new single_machine_new definition
     single_machine_new:
-    - repository
-    - image-registry
-    - kubernetes-master
-    - kafka
-    - firewall
-  ...
+      - repository
+      - image-registry
+      - kubernetes-master
+      - kafka
+      - firewall
+    ...
 ```
 
 Once defined the new `single_machine_new` can be used inside the `epiphany-cluster` configuration:

--- a/docs/home/howto/DATABASES.md
+++ b/docs/home/howto/DATABASES.md
@@ -491,11 +491,11 @@ By default, Kibana is deployed only for `logging` component. If you want to depl
 for `opendistro_for_elasticsearch` you have to modify feature mapping. Use below configuration in your manifest.
 
 ```yaml
-kind: configuration/feature-mapping
-title: "Feature mapping to roles"
+kind: configuration/feature-mappings
+title: "Feature mapping to components"
 name: default
 specification:
-  roles_mapping:
+  mappings:
     opendistro_for_elasticsearch:
       - opendistro-for-elasticsearch
       - node-exporter

--- a/docs/home/howto/KUBERNETES.md
+++ b/docs/home/howto/KUBERNETES.md
@@ -143,15 +143,15 @@ specification:
       count: 2
 ```
 
-2. Enable `applications` in feature-mapping in initial configuration manifest.
+2. Enable `applications` in `configuration/features` in initial configuration manifest.
 
 ```yaml
 ---
-kind: configuration/feature-mapping
-title: Feature mapping to roles
+kind: configuration/features
+title: "Features to be enabled/disabled"
 name: default
 specification:
-  available_roles:
+  features:
     - name: applications
       enabled: true
 ```

--- a/docs/home/howto/MODULES.md
+++ b/docs/home/howto/MODULES.md
@@ -108,12 +108,12 @@ AWS:
       rabbitmq:
         count: 0
   ---
-  kind: configuration/feature-mapping
-  title: Feature mapping to roles
+  kind: configuration/feature-mappings
+  title: "Feature mapping to components"
   name: your-cluster-name # <----- make unified with other places and build directory name
   provider: any
   specification:
-    roles_mapping:
+    mappings:
       repository:
         - repository
         - image-registry

--- a/docs/home/howto/UPGRADE.md
+++ b/docs/home/howto/UPGRADE.md
@@ -206,12 +206,12 @@ specification:
   prefix: 'prefix'
 title: Epiphany cluster Config
 ---
-kind: configuration/feature-mapping
-title: Feature mapping to roles
+kind: configuration/feature-mappings
+title: "Feature mapping to components"
 provider: azure
 name: default
 specification:
-  roles_mapping:
+  mappings:
     kubernetes_master:
       - kubernetes-master
       - helm

--- a/schema/common/defaults/configuration/feature-mappings.yml
+++ b/schema/common/defaults/configuration/feature-mappings.yml
@@ -1,58 +1,9 @@
-kind: configuration/feature-mapping
-title: "Feature mapping to roles"
+---
+kind: configuration/feature-mappings
+title: "Feature mapping to components"
 name: default
 specification:
-  available_roles:
-    - name: repository
-      enabled: true
-    - name: firewall
-      enabled: true
-    - name: image-registry
-      enabled: true
-    - name: kubernetes-master
-      enabled: true
-    - name: kubernetes-node
-      enabled: true
-    - name: helm
-      enabled: true
-    - name: logging
-      enabled: true
-    - name: opendistro-for-elasticsearch
-      enabled: true
-    - name: elasticsearch-curator
-      enabled: true
-    - name: kibana
-      enabled: true
-    - name: filebeat
-      enabled: true
-    - name: prometheus
-      enabled: true
-    - name: grafana
-      enabled: true
-    - name: node-exporter
-      enabled: true
-    - name: jmx-exporter
-      enabled: true
-    - name: zookeeper
-      enabled: true
-    - name: kafka
-      enabled: true
-    - name: rabbitmq
-      enabled: true
-    - name: kafka-exporter
-      enabled: true
-    - name: postgresql
-      enabled: true
-    - name: postgres-exporter
-      enabled: true
-    - name: haproxy
-      enabled: true
-    - name: applications
-      enabled: true
-    - name: rook
-      enabled: true
-
-  roles_mapping:
+  mappings:
     kafka:
       - zookeeper
       - jmx-exporter

--- a/schema/common/defaults/configuration/features.yml
+++ b/schema/common/defaults/configuration/features.yml
@@ -1,0 +1,54 @@
+---
+kind: configuration/features
+title: "Features to be enabled/disabled"
+name: default
+specification:
+  features:
+    - name: repository
+      enabled: true
+    - name: firewall
+      enabled: true
+    - name: image-registry
+      enabled: true
+    - name: kubernetes-master
+      enabled: true
+    - name: kubernetes-node
+      enabled: true
+    - name: helm
+      enabled: true
+    - name: logging
+      enabled: true
+    - name: opendistro-for-elasticsearch
+      enabled: true
+    - name: elasticsearch-curator
+      enabled: true
+    - name: kibana
+      enabled: true
+    - name: filebeat
+      enabled: true
+    - name: prometheus
+      enabled: true
+    - name: grafana
+      enabled: true
+    - name: node-exporter
+      enabled: true
+    - name: jmx-exporter
+      enabled: true
+    - name: zookeeper
+      enabled: true
+    - name: kafka
+      enabled: true
+    - name: rabbitmq
+      enabled: true
+    - name: kafka-exporter
+      enabled: true
+    - name: postgresql
+      enabled: true
+    - name: postgres-exporter
+      enabled: true
+    - name: haproxy
+      enabled: true
+    - name: applications
+      enabled: true
+    - name: rook
+      enabled: true

--- a/schema/common/validation/configuration/feature-mappings.yml
+++ b/schema/common/validation/configuration/feature-mappings.yml
@@ -1,18 +1,10 @@
+---
 "$id": "#/specification"
-title: "Feature-mapping specification schema"
-description: "Feature-mapping specification schema"
+title: "Feature-mappings specification schema"
+description: "Feature-mappings specification schema"
 type: object
 properties:
-  available_roles:
-    type: array
-    items:
-      type: object
-      properties:
-        name:
-          type: string
-        enabled:
-          type: boolean
-  roles_mapping:
+  mappings:
     type: object
     properties:
       kafka:

--- a/schema/common/validation/configuration/features.yml
+++ b/schema/common/validation/configuration/features.yml
@@ -1,0 +1,15 @@
+---
+"$id": "#/specification"
+title: "Features to be enabled/disabled schema"
+description: "Features to be enabled/disabled schema"
+type: object
+properties:
+  features:
+    type: array
+    items:
+      type: object
+      properties:
+        name:
+          type: string
+        enabled:
+          type: boolean

--- a/schema/common/validation/epiphany-cluster.yml
+++ b/schema/common/validation/epiphany-cluster.yml
@@ -137,9 +137,9 @@ properties:
           properties:
             kubernetes_master:
               properties:
-                count: { type: integer, enum: [0] }
+                count: {type: integer, enum: [0]}
         then:
           properties:
             kubernetes_node:
               properties:
-                count: { type: integer, enum: [0] }
+                count: {type: integer, enum: [0]}


### PR DESCRIPTION
…(#3097)

* available_roles splitted into roles-mapping and roles-enabled
  documents

* roles-mapping added to the Init by default