### PR TITLE
[2.0.1] Filebeat: update template for new version

### DIFF
--- a/ansible/playbooks/roles/filebeat/templates/custom-chart-values.yml.j2
+++ b/ansible/playbooks/roles/filebeat/templates/custom-chart-values.yml.j2
@@ -64,10 +64,10 @@ filebeatConfig:
 
       processors:
         - add_kubernetes_metadata:
-          in_cluster: true
-          matchers:
-          - logs_path:
-              logs_path: "/var/log/containers/"
+            in_cluster: true
+            matchers:
+            - logs_path:
+                logs_path: "/var/log/containers/"
 {% endif %}
 
 {# -------------------------- Filebeat modules -------------------------- #}


### PR DESCRIPTION
After bumping up filebeat version (PR: #3086) installation of it with
k8s_as_cloud_service flag is broken.
This change needs to be merged after #3086.