### PR TITLE
[1.0.3] Restart prometheus node exporter service

### DIFF
--- a/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/tasks/install-node-exporter-as-system-service.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/node_exporter/tasks/install-node-exporter-as-system-service.yml
@@ -60,6 +60,8 @@
     mode: u=rw,g=r,o=r
   vars:
     exporter_service_description: "{{ exporter.service.description }}"
+  notify:
+    - restart prometheus node exporter service
 
 - name: Configure systemd to use node_exporter service
   systemd:


### PR DESCRIPTION
Minor fix for #3111
Restart prometheus node exporter service when the service definition changes.
Scenario for which this fix is:
`apply` v1.0.2 -> `apply` v1.0.3
Without a restart, the service uses the old definition.