### PR TITLE
Support 'epicli upgrade' for RHEL/AlmaLinux 8

### DIFF
--- a/ansible/playbooks/roles/preflight/tasks/main.yml
+++ b/ansible/playbooks/roles/preflight/tasks/main.yml
@@ -1,7 +1,4 @@
 ---
-- include_tasks: upgrade-pre-common.yml
-  when: is_upgrade_run
-
 - include_tasks: common/main.yml
 
 - include_tasks: apply.yml

--- a/ansible/playbooks/roles/preflight/tasks/upgrade-pre-common.yml
+++ b/ansible/playbooks/roles/preflight/tasks/upgrade-pre-common.yml
@@ -1,7 +1,0 @@
-# In version 2.0.0 we switched from RHEL 7 to 8 but only 'epicli apply' is supported so far.
-- name: Check whether OS family is supported
-  assert:
-    that: ansible_os_family != 'RedHat'
-    fail_msg: >-
-      In this version 'epicli upgrade' is supported only for Ubuntu
-    success_msg: OS family check passed

--- a/ansible/playbooks/roles/repository/files/download-requirements/requirements/x86_64/redhat/packages.yml
+++ b/ansible/playbooks/roles/repository/files/download-requirements/requirements/x86_64/redhat/packages.yml
@@ -69,6 +69,7 @@ packages:
     - 'nss'  # for java-1.8.0-openjdk-headless
     - 'nss-softokn'  # for nss
     # Open Distro for Elasticsearch plugins are installed individually to not download them twice in different versions (as dependencies of opendistroforelasticsearch package)
+    - 'ntsysv'  # for python36
     - 'opendistro-alerting-1.13.1.*'
     - 'opendistro-index-management-1.13.1.*'
     - 'opendistro-job-scheduler-1.13.0.*'

--- a/ansible/playbooks/roles/repository/files/download-requirements/src/command/dnf.py
+++ b/ansible/playbooks/roles/repository/files/download-requirements/src/command/dnf.py
@@ -12,16 +12,19 @@ class Dnf(Command):
     def __init__(self, retries: int):
         super().__init__('dnf', retries)
 
-    def update(self, enablerepo: str = None,
-                     package: str = None,
+    def update(self, package: str = None,
                      disablerepo: str = None,
+                     enablerepo: str = None,
+                     releasever: str = None,
                      assume_yes: bool = True):
+
         """
         Interface for `dnf update`
 
-        :param enablerepo:
         :param package:
         :param disablerepo:
+        :param enablerepo:
+        :param releasever:
         :param assume_yes: if set to True, -y flag will be used
         """
         update_parameters: List[str] = ['update']
@@ -37,6 +40,9 @@ class Dnf(Command):
 
         if enablerepo is not None:
             update_parameters.append(f'--enablerepo={enablerepo}')
+
+        if releasever is not None:
+            update_parameters.append(f'--releasever={releasever}')
 
         proc = self.run(update_parameters)
 

--- a/ansible/playbooks/roles/repository/files/download-requirements/src/command/dnf_config_manager.py
+++ b/ansible/playbooks/roles/repository/files/download-requirements/src/command/dnf_config_manager.py
@@ -1,4 +1,5 @@
 from src.command.command import Command
+from src.error import DnfVariableNotfound
 
 
 class DnfConfigManager(Command):
@@ -17,3 +18,19 @@ class DnfConfigManager(Command):
 
     def enable_repo(self, repo: str):
         self.run(['config-manager', '--set-enabled', repo])
+
+    def get_variable(self, name: str) -> str:
+        process = self.run(['config-manager', '--dump-variables'])
+        variables = [x for x in process.stdout.splitlines() if '=' in x]
+        value = None
+
+        for var in variables:
+            chunks = var.split('=', maxsplit=1)
+            if name == chunks[0].strip():
+                value = chunks[1].strip()
+                break
+
+        if not value:
+            raise DnfVariableNotfound(f'Variable not found: {name}')
+
+        return value

--- a/ansible/playbooks/roles/repository/files/download-requirements/src/error.py
+++ b/ansible/playbooks/roles/repository/files/download-requirements/src/error.py
@@ -17,6 +17,12 @@ class CriticalError(DownloadRequirementsError):
     """
 
 
+class DnfVariableNotfound(CriticalError):
+    """
+    Raised when DNF variable was not found.
+    """
+
+
 class PackageNotfound(CriticalError):
     """
     Raised when there was no package found by the query tool.

--- a/ansible/playbooks/roles/repository/files/download-requirements/src/mode/red_hat_family_mode.py
+++ b/ansible/playbooks/roles/repository/files/download-requirements/src/mode/red_hat_family_mode.py
@@ -51,7 +51,8 @@ class RedHatFamilyMode(BaseMode):
     def _install_base_packages(self):
 
         # Bug in RHEL 8.4 https://bugzilla.redhat.com/show_bug.cgi?id=2004853
-        self._tools.dnf.update(package='libmodulemd')
+        releasever = '8' if self._tools.dnf_config_manager.get_variable('releasever') == '8.4' else None
+        self._tools.dnf.update(package='libmodulemd', releasever=releasever)
 
         # some packages are from EPEL repo
         # make sure that we reinstall it before proceeding

--- a/ansible/playbooks/upgrade.yml
+++ b/ansible/playbooks/upgrade.yml
@@ -316,9 +316,7 @@
     - include_role:
         name: postgresql
         tasks_from: upgrade/nodes/common/ensure-ansible-requirements
-      when:
-        - ansible_os_family == 'Debian'
-        - "'postgresql' in upgrade_components or upgrade_components|length == 0"
+      when: "'postgresql' in upgrade_components or upgrade_components|length == 0"
 
     # step 2: upgrade repmgr
     - include_role:

--- a/ci/ansible/playbooks/os/rhel/upgrade-release.yml
+++ b/ci/ansible/playbooks/os/rhel/upgrade-release.yml
@@ -610,3 +610,9 @@
           command: subscription-manager release --unset
           register: result
           failed_when: result.rc > 1 # May return code 1 even when correctly subscribed if system purpose is not defined
+
+    # download-requirements.py fails if releasever = 8.4 (2ndQuadrant repo)
+    - name: Remove releasever DNF variable
+      file:
+        path: /etc/dnf/vars/releasever  # file created by upgrade
+        state: absent

--- a/ci/ansible/playbooks/os/rhel/upgrade-release.yml
+++ b/ci/ansible/playbooks/os/rhel/upgrade-release.yml
@@ -5,7 +5,7 @@
 # This play requires a Leapp metadata archive from the Red Hat portal which cannot be shared publicly.
 # Local path to this archive must be provided via 'leapp_archive' variable, for example:
 
-# ansible-playbook -e leapp_archive=/absolute/path/leapp-data15.tar.gz
+# ansible-playbook -e leapp_archive=/absolute/path/leapp-data16.tar.gz
 
 # Requirements:
 # - System attached to RHUI repositories or Red Hat subscription ('non_cloud' provider)
@@ -227,12 +227,12 @@
     - name: Copy leapp metadata archive
       copy:
         src: "{{ leapp_archive }}"
-        dest: /etc/leapp/files/leapp-data15.tar.gz
+        dest: /etc/leapp/files/{{ leapp_archive | basename }}
         mode: preserve
 
     - name: Unarchive leapp metadata
       unarchive:
-        src: /etc/leapp/files/leapp-data15.tar.gz
+        src: /etc/leapp/files/{{ leapp_archive | basename }}
         dest: /etc/leapp/files/
         remote_src: true
 

--- a/ci/ansible/playbooks/os/rhel/upgrade-release.yml
+++ b/ci/ansible/playbooks/os/rhel/upgrade-release.yml
@@ -304,7 +304,7 @@
       command: leapp answer --add --section remove_pam_pkcs11_module_check.confirm=True
 
     - name: Start leapp upgrade
-      command: leapp upgrade {{ '--no-rhsm' if provider != 'non_cloud' }}
+      command: leapp upgrade --target {{ versions.target.full }} {{ '--no-rhsm' if provider != 'non_cloud' }}
 
     - name: Reboot system to complete leapp upgrade procedure
       reboot:
@@ -352,7 +352,7 @@
         - name: Check that upgraded version remains correctly subscribed
           assert:
             that:
-              - subscription_version.stdout == "8.4"
+              - subscription_version.stdout == versions.target.full
               - subscription_status.stdout == "Subscribed"
             quiet: true
 

--- a/ci/ansible/playbooks/os/rhel/upgrade-release.yml
+++ b/ci/ansible/playbooks/os/rhel/upgrade-release.yml
@@ -2,13 +2,16 @@
 # Based on https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/upgrading_from_rhel_7_to_rhel_8/index
 # and partially on https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/redhat/redhat-in-place-upgrade
 
-# This play requires a Leapp metadata archive from the Red Hat portal which cannot be shared publicly.
-# Local path to this archive must be provided via 'leapp_archive' variable, for example:
-
-# ansible-playbook -e leapp_archive=/absolute/path/leapp-data16.tar.gz
-
 # Requirements:
-# - System attached to RHUI repositories or Red Hat subscription ('non_cloud' provider)
+# - Leapp metadata archive from the Red Hat portal which cannot be shared publicly.
+# - Epiphany manifest with credentials (for 'aws' provider only).
+# - System attached to RHUI repositories or Red Hat subscription (for 'non_cloud' provider only).
+
+# Usage:
+# ansible-playbook -e leapp_archive=/absolute/path/leapp-data16.tar.gz -e epiphany_manifest=/shared/build/aws/manifest.yml
+
+# Note:
+# For AWS, playbook creates/overwrites with backup '/root/.aws/credentials' file locally.
 
 # Limitations:
 # - Ansible connection as root is not supported (PermitRootLogin)
@@ -128,7 +131,7 @@
       register: pre_upgrade_enabled_repositories
       changed_when: false
 
-    # Disable legacy containerd plugin to avoid instance auto-recovery on AWS (modprobe: FATAL: Module aufs not found)
+    # Disable legacy containerd plugin to avoid error (modprobe: FATAL: Module aufs not found)
 
     - name: Check if /etc/containerd/config.toml file exists
       stat:
@@ -176,6 +179,93 @@
             state: restarted
           when: update_containerd_config_option.changed
              or add_containerd_config_option.changed
+
+    # Suspend HealthCheck process on AWS (required for reboots)
+
+    - name: Suspend HealthCheck process for auto scaling groups
+      when: provider == 'aws'
+      run_once: true
+      delegate_to: localhost
+      block:
+        - name: Load Epiphany manifest
+          slurp:
+            src: "{{ epiphany_manifest }}"
+          register: slurp_epiphany_manifest
+
+        - name: Set cloud properties
+          vars:
+            _cluster_doc: >-
+              {{ slurp_epiphany_manifest['content'] | b64decode | from_yaml_all
+                                                    | selectattr('kind', '==', 'epiphany-cluster')
+                                                    | first }}
+          block:
+            - name: Set cloud facts
+              set_fact:
+                aws_region: "{{ _cluster_doc.specification.cloud.region }}"
+                cluster_name: "{{ _cluster_doc.specification.prefix }}-{{ _cluster_doc.specification.name }}"
+
+            - name: Create AWS configuration directory
+              file:
+                path: "{{ '~root' | expanduser }}/.aws"
+                state: directory
+                mode: u=rwx,go=
+
+            - name: Create credentials file
+              copy:
+                dest: "{{ '~root' | expanduser }}/.aws/credentials"
+                content: |
+                  [default]
+                  aws_access_key_id = {{ _cluster_doc.specification.cloud.credentials.key }}
+                  aws_secret_access_key = {{ _cluster_doc.specification.cloud.credentials.secret }}
+                mode: u=rw,go=
+                backup: true
+
+        - name: Find auto scaling groups
+          community.aws.ec2_asg_info:
+            name: "{{ cluster_name }}"
+            region: "{{ aws_region }}"
+          register: cluster_asgs
+
+        - name: Reconfigure ASGs to suspend EC2 health check
+          when: cluster_asgs.results | count > 0
+          block:
+            - name: Set facts on ASGs
+              set_fact:
+                asg_facts: "{{ cluster_asgs.results | json_query(_query) }}"
+              vars:
+                _query: '[].{name: auto_scaling_group_name, suspended_processes: suspended_processes}'
+
+            - name: Set path to file with original configuration of ASGs
+              set_fact:
+                asg_config_file_path: "{{ playbook_dir }}/{{ cluster_name }}-asg-config.yml"
+
+            - name: Check if file with original configuration of ASGs exists
+              stat:
+                path: "{{ asg_config_file_path }}"
+                get_attributes: false
+                get_checksum: false
+                get_mime: false
+              register: stat_asg_config_yml
+
+            - name: Save original configuration of auto scaling groups
+              when: not stat_asg_config_yml.stat.exists
+              become: false
+              copy:
+                dest: "{{ asg_config_file_path }}"
+                mode: u=rw,g=r,o=
+                content: |
+                  # This file is managed by Ansible and is needed to restore original configuration. DO NOT EDIT.
+                  {{ asg_facts | to_nice_yaml }}
+
+            - name: Suspend HealthCheck process
+              when: not 'HealthCheck' in (item.suspended_processes | map(attribute='process_name'))
+              community.aws.ec2_asg:
+                name: "{{ item.name }}"
+                suspend_processes: "{{ item.suspended_processes | union(['HealthCheck']) }}"
+                region: "{{ aws_region }}"
+              loop_control:
+                label: "{{ item.name }}"
+              loop: "{{ asg_facts }}"
 
     - &UPDATE_ALL_PACKAGES
       name: Update all packages in current major version
@@ -616,3 +706,44 @@
       file:
         path: /etc/dnf/vars/releasever  # file created by upgrade
         state: absent
+
+    # Resume HealthCheck process on AWS
+
+    - name: Resume HealthCheck process for auto scaling groups
+      when: provider == 'aws'
+      run_once: true
+      delegate_to: localhost
+      block:
+        - name: Check if file with original configuration of ASGs exists
+          stat:
+            path: "{{ asg_config_file_path }}"
+            get_attributes: false
+            get_checksum: false
+            get_mime: false
+          register: stat_asg_config_yml
+
+        - name: Restore original configuration
+          when: stat_asg_config_yml.stat.exists
+          block:
+            - name: Load original configuration from file
+              slurp:
+                src: "{{ asg_config_file_path }}"
+              register: slurp_asg_config_yml
+
+            - name: Set ASG settings to restore
+              set_fact:
+                asgs_to_restore: "{{ slurp_asg_config_yml['content'] | b64decode | from_yaml }}"
+
+            - name: Resume HealthCheck process
+              community.aws.ec2_asg:
+                name: "{{ item.name }}"
+                suspend_processes: "{{ item.suspended_processes }}"
+                region: "{{ aws_region }}"
+              loop_control:
+                label: "{{ item.name }}"
+              loop: "{{ asgs_to_restore }}"
+
+            - name: Remove file with original configuration of ASGs
+              file:
+                path: "{{ asg_config_file_path }}"
+                state: absent

--- a/ci/ansible/playbooks/os/rhel/upgrade-release.yml
+++ b/ci/ansible/playbooks/os/rhel/upgrade-release.yml
@@ -193,8 +193,14 @@
         name: "*"
         state: latest  # noqa: package-latest
 
-    - &REBOOT_SYSTEM_AFTER_UPDATE
-      name: Reboot system after update  # to load kernel from latest minor version if any
+    - name: Check if reboot is needed
+      command: needs-restarting --reboothint  # exit code 1 means reboot is required
+      changed_when: false
+      register: needs_restarting
+      failed_when: needs_restarting.rc > 1
+
+    - name: Reboot system after update  # to load kernel from latest minor version if any
+      when: needs_restarting.rc == 1
       reboot:
         msg: Reboot initiated by Ansible due to update
         connect_timeout: "{{ reboot.connect_timeout }}"

--- a/ci/ansible/playbooks/os/rhel/upgrade-release.yml
+++ b/ci/ansible/playbooks/os/rhel/upgrade-release.yml
@@ -411,6 +411,9 @@
         enabled: false
         gpgcheck: true
         module_hotfixes: true
+        exclude:  # prevent auto-upgrade from 4.0.6-1.el7
+          - repmgr10
+          - repmgr_10
 
     ### UPGRADE ###
 

--- a/ci/ansible/playbooks/os/rhel/upgrade-release.yml
+++ b/ci/ansible/playbooks/os/rhel/upgrade-release.yml
@@ -13,8 +13,6 @@
 # Limitations:
 # - Ansible connection as root is not supported (PermitRootLogin)
 
-# TODO:
-# Fix issue when running on AWS on repository host deployed with epicli 1.0.2 (instance auto-recovery)
 
 - name: In-place RHEL release upgrade
   hosts: "{{ target | default('all') }}"
@@ -138,6 +136,55 @@
         state: latest
         update_only: true
         name: "*"
+
+    # Disable legacy containerd plugin to avoid instance auto-recovery on AWS (modprobe: FATAL: Module aufs not found)
+
+    - name: Check if /etc/containerd/config.toml file exists
+      stat:
+        path: /etc/containerd/config.toml
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
+      register: stat_containerd_config
+
+    - name: Disable aufs plugin
+      when: stat_containerd_config.stat.exists
+      block:
+        - name: Get disabled_plugins
+          command: grep -oPz '(?s)^disabled_plugins\s*=\s*\[.*?\]' /etc/containerd/config.toml  # TOML allows line breaks inside arrays
+          changed_when: false
+          register: grep_disabled_plugins
+          failed_when: grep_disabled_plugins.rc > 1
+
+        - name: Set plugins to be disabled
+          set_fact:
+            plugins_to_disable: "{{ _disabled_plugins | union(['aufs']) }}"
+          vars:
+            _disabled_plugins: >-
+              {{ (grep_disabled_plugins.stdout | regex_replace('\s*=', ':') | from_yaml).disabled_plugins | default('[]') }}
+
+        - name: Disable aufs plugin (update array)
+          replace:  # handles multi-line array
+            path: /etc/containerd/config.toml
+            regexp: ^disabled_plugins\s*=\s*\[[^\]]*?\]
+            replace: disabled_plugins = {{ plugins_to_disable | string }}
+            backup: true
+          register: update_containerd_config_option
+
+        - name: Disable aufs plugin (add array)
+          lineinfile:
+            path: /etc/containerd/config.toml
+            line: disabled_plugins = {{ plugins_to_disable | string }}
+            backup: true
+          register: add_containerd_config_option
+          when: grep_disabled_plugins.rc == 1
+
+        - name: Restart containerd service
+          systemd:
+            name: containerd.service
+            state: restarted
+          when: update_containerd_config_option.changed
+             or add_containerd_config_option.changed
 
     - &UPDATE_ALL_PACKAGES
       name: Update all packages in current major version

--- a/ci/ansible/playbooks/os/rhel/upgrade-release.yml
+++ b/ci/ansible/playbooks/os/rhel/upgrade-release.yml
@@ -110,24 +110,6 @@
           debug:
             var: provider
 
-    - name: Register SELinux state
-      set_fact:
-        pre_upgrade_selinux_facts: "{{ ansible_facts.selinux }}"
-
-    - name: Register enabled repositories
-      command: yum repolist --quiet
-      register: pre_upgrade_enabled_repositories
-      changed_when: false
-
-    - name: Ensure repositories that provide leapp utility are enabled
-      ini_file:
-        path: "{{ item.repo_file }}"
-        section: "{{ item.name }}"
-        option: enabled
-        value: 1
-        mode: u=rw,go=r
-      loop: "{{ leapp_dependencies.repos[provider] }}"
-
     - name: Update repository certificates
       when: provider == "azure"
       yum:
@@ -136,6 +118,15 @@
         state: latest
         update_only: true
         name: "*"
+
+    - name: Register SELinux state
+      set_fact:
+        pre_upgrade_selinux_facts: "{{ ansible_facts.selinux }}"
+
+    - name: Register enabled repositories
+      command: yum repolist --quiet
+      register: pre_upgrade_enabled_repositories
+      changed_when: false
 
     # Disable legacy containerd plugin to avoid instance auto-recovery on AWS (modprobe: FATAL: Module aufs not found)
 
@@ -218,6 +209,15 @@
       assert:
         that: ansible_distribution_version is version(versions.required.full, '>=')
         quiet: true
+
+    - name: Ensure repositories that provide leapp utility are enabled
+      community.general.ini_file:
+        path: "{{ item.repo_file }}"
+        section: "{{ item.name }}"
+        option: enabled
+        value: 1
+        mode: u=rw,go=r
+      loop: "{{ leapp_dependencies.repos[provider] }}"
 
     - name: Install packages that provide the leapp utility
       package:

--- a/ci/ansible/playbooks/os/rhel/upgrade-release.yml
+++ b/ci/ansible/playbooks/os/rhel/upgrade-release.yml
@@ -210,6 +210,10 @@
         that: ansible_distribution_version is version(versions.required.full, '>=')
         quiet: true
 
+    - name: Get information on installed packages
+      package_facts:
+        manager: rpm
+
     - name: Ensure repositories that provide leapp utility are enabled
       community.general.ini_file:
         path: "{{ item.repo_file }}"
@@ -217,10 +221,11 @@
         option: enabled
         value: 1
         mode: u=rw,go=r
+        no_extra_spaces: true
       loop: "{{ leapp_dependencies.repos[provider] }}"
 
     - name: Install packages that provide the leapp utility
-      package:
+      yum:
         name: "{{ leapp_dependencies.packages[provider] }}"
         state: present
 
@@ -298,13 +303,34 @@
             name: "{{ installed_kernel_devel_packages[:-1] }}"  # keep the last item
             state: absent
 
+    - name: Set PostgreSQL version
+      set_fact:
+        postgresql_version: >-
+          {{ '10' if ansible_facts.packages['postgresql10-server'] is defined else
+             '13' if ansible_facts.packages['postgresql13-server'] is defined else
+             'null' }}
+
+    - name: Add PostgreSQL repository
+      when: postgresql_version != 'null'
+      yum_repository:
+        name: pgdg{{ postgresql_version }}
+        file: pgdg{{ postgresql_version }}-rhel-{{ versions.target.full }}
+        description: PostgreSQL {{ postgresql_version }} for RHEL/CentOS {{ versions.target.full }} - $basearch
+        baseurl: https://download.postgresql.org/pub/repos/yum/{{ postgresql_version }}/redhat/rhel-{{ versions.target.full }}-$basearch
+        gpgkey: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+        enabled: false
+        gpgcheck: true
+        module_hotfixes: true
+
     ### UPGRADE ###
 
     - name: Provide leapp answer about pam_pkcs11_module removal
       command: leapp answer --add --section remove_pam_pkcs11_module_check.confirm=True
 
     - name: Start leapp upgrade
-      command: leapp upgrade --target {{ versions.target.full }} {{ '--no-rhsm' if provider != 'non_cloud' }}
+      command: >-
+        leapp upgrade --target {{ versions.target.full }} {{ '--no-rhsm' if provider != 'non_cloud' }}
+        {{ '--enablerepo pgdg' ~ postgresql_version if postgresql_version != 'null' }}
 
     - name: Reboot system to complete leapp upgrade procedure
       reboot:
@@ -359,12 +385,13 @@
     ### POST-UPGRADE -- CLEANUP ###
 
     - name: Remove packages from the dnf exclude list  # populated by leapp during upgrade
-      ini_file:
+      community.general.ini_file:
         path: /etc/dnf/dnf.conf
         section: main
         option: exclude
         value: ''
         mode: u=rw,go=r
+        no_extra_spaces: true
 
     ## Remove Leapp
 
@@ -376,6 +403,13 @@
     - name: Remove leapp configuration
       file:
         path: /etc/leapp
+        state: absent
+
+    - name: Remove PostgreSQL repository
+      when: postgresql_version != 'null'
+      yum_repository:
+        name: pgdg{{ postgresql_version }}
+        file: pgdg{{ postgresql_version }}-rhel-{{ versions.target.full }}
         state: absent
 
     ## Remove RHEL 7 packages

--- a/ci/ansible/playbooks/os/rhel/upgrade-release.yml
+++ b/ci/ansible/playbooks/os/rhel/upgrade-release.yml
@@ -22,7 +22,7 @@
   vars:
     versions:
       required: {major: '7', full: '7.9'}  # minimal version from which upgrade is supported
-      target: {major: '8', full: '8.5'}
+      target: {major: '8', full: '8.4'}
 
     leapp_dependencies:
       packages:
@@ -278,11 +278,11 @@
 
     - *REFRESH_ANSIBLE_FACTS
 
-    - name: Assert major version
+    - name: Assert target version
       assert:
         that:
-          - ansible_distribution_version is version('8.4','=')
-          - ansible_kernel is version('4.18.0-305','>=')
+          - ansible_distribution_version is version(versions.target.full, '=')
+          - ansible_kernel is version('4.18.0-305', '>=')
         quiet: true
 
     - name: Verify subscription status for non_cloud machines
@@ -523,37 +523,3 @@
           command: subscription-manager release --unset
           register: result
           failed_when: result.rc > 1 # May return code 1 even when correctly subscribed if system purpose is not defined
-
-    ### POST-UPGRADE -- UPDATE TO TARGET VERSION ###
-
-    - name: Update release to 8.5
-      block:
-        - name: Determine if 8.5 is the latest version
-          command: dnf --releasever 8.5 list kernel  # will fail when 8.5 is not the latest minor release
-          register: is_8_5_latest_version_available
-          changed_when: false
-          failed_when: is_8_5_latest_version_available.rc > 1
-
-        - name: Unlock release to latest  # mirrors will not point to 8.5 when it is the latest
-          when: is_8_5_latest_version_available.rc == 1
-          file:
-            path: /etc/dnf/vars/releasever
-            state: absent
-
-        - name: Set release to 8.5
-          when: is_8_5_latest_version_available.rc == 0  # 8.5 is not the latest
-          copy:
-            content: '8.5'
-            dest: /etc/dnf/vars/releasever
-            mode: u=rw,go=r
-
-        - *UPDATE_ALL_PACKAGES
-
-        - *REBOOT_SYSTEM_AFTER_UPDATE  # 8.5 brings a new kernel update
-
-        - *REFRESH_ANSIBLE_FACTS
-
-        - name: Assert update to 8.5 succeeded
-          assert:
-            that: ansible_distribution_version is version(versions.target.full, '=')
-            quiet: true

--- a/docs/changelogs/CHANGELOG-2.0.md
+++ b/docs/changelogs/CHANGELOG-2.0.md
@@ -2,6 +2,10 @@
 
 ## [2.0.1] YYYY-MM-DD
 
+### Added
+
+- [#2932](https://github.com/epiphany-platform/epiphany/issues/2932) - Support `epicli upgrade` for RHEL/AlmaLinux 8
+
 ### Updated
 
 - [#3080](https://github.com/epiphany-platform/epiphany/issues/3080) - update Filebeat to the latest compatible version with OpenSearch


### PR DESCRIPTION
Fixes:
- Issues with CI pipeline's playbook on AWS (instance auto-recovery during RHEL 7 to 8 upgrade)
- Update of libmodulemd package (download-requirement.py)

Tested only on clusters created with epicli v1.0.2.