### PR TITLE
[2.0.1] Fix `use_network_security_groups` is set to `false`

### DIFF
--- a/cli/src/providers/azure/InfrastructureBuilder.py
+++ b/cli/src/providers/azure/InfrastructureBuilder.py
@@ -79,6 +79,7 @@ class InfrastructureBuilder(Step):
                                     item.specification.address_prefix == subnet_definition['address_pool'])
 
             if subnet is None:
+                subnet_nsg_association_name = ''
                 subnet = self.get_subnet(subnet_definition, component_key, 0)
                 infrastructure.append(subnet)
 
@@ -93,6 +94,7 @@ class InfrastructureBuilder(Step):
                                                                                         nsg.specification.name,
                                                                                         0)
                     infrastructure.append(subnet_nsg_association)
+                    subnet_nsg_association_name = subnet_nsg_association.specification.name
 
             availability_set = None
             if 'availability_set' in component_value:
@@ -118,7 +120,7 @@ class InfrastructureBuilder(Step):
                                                                vm_config,
                                                                subnet.specification.name,
                                                                public_ip_name,
-                                                               subnet_nsg_association.specification.name,
+                                                               subnet_nsg_association_name,
                                                                index)
                 infrastructure.append(network_interface)
 

--- a/cli/src/spec/SpecCommand.py
+++ b/cli/src/spec/SpecCommand.py
@@ -58,5 +58,4 @@ These need to be installed to run the cluster spec tests from epicli'''
         for entry in listdir:
             if os.path.isdir(f'{SPEC_TEST_PATH}/spec/{entry}'):
                 groups = groups + [entry]
-        sorted_group = sorted(groups, key=str.lower)
-        return sorted_group
+        return sorted(groups, key=str.lower)

--- a/cli/src/spec/SpecCommand.py
+++ b/cli/src/spec/SpecCommand.py
@@ -58,5 +58,5 @@ These need to be installed to run the cluster spec tests from epicli'''
         for entry in listdir:
             if os.path.isdir(f'{SPEC_TEST_PATH}/spec/{entry}'):
                 groups = groups + [entry]
-        sorted(groups, key=str.lower)
-        return groups
+        sorted_group = sorted(groups, key=str.lower)
+        return sorted_group

--- a/docs/changelogs/CHANGELOG-2.0.md
+++ b/docs/changelogs/CHANGELOG-2.0.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - [#3164](https://github.com/epiphany-platform/epiphany/issues/3164) - Specify version and allow containerd.io package downgrade in haproxy_runc role
+- [#3179](https://github.com/epiphany-platform/epiphany/issues/3179) - terraform fails when `use_network_security_groups` is set to `false`
 
 ### Updated
 


### PR DESCRIPTION
- Fix use_network_security_groups is set to false
- Also minor fix for SonarQube reported bug: https://sonarcloud.io/project/issues?resolved=false&types=BUG&id=epiphany-platform_epiphany&open=AYEfJldDUaTriuEfx6nc