### PR TITLE
ceph: fix tag for ceph image

### DIFF
--- a/ansible/playbooks/roles/repository/files/download-requirements/requirements/x86_64/images.yml
+++ b/ansible/playbooks/roles/repository/files/download-requirements/requirements/x86_64/images.yml
@@ -176,9 +176,8 @@ images:
     'k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1':
       sha1: be1cf43617eea007629c0eb99149a99b6498f889
 
-    'quay.io/ceph/ceph:v16.2.7':
-      sha1: fe9b7802c67e19111f83ffe4754ab62df66fd417
-      allow_mismatch: true
+    'quay.io/ceph/ceph:v16.2.7-20220510':
+      sha1: 3cdc34eb3f2c5af8de5ad121c7b1bb176cca811a
 
     'quay.io/cephcsi/cephcsi:v3.5.1':
       sha1: 51dee9ea8ad76fb95ebd16f951e8ffaaaba95eb6

--- a/docs/changelogs/CHANGELOG-2.0.md
+++ b/docs/changelogs/CHANGELOG-2.0.md
@@ -18,6 +18,7 @@
 - [#3179](https://github.com/epiphany-platform/epiphany/issues/3179) - terraform fails when `use_network_security_groups` is set to `false`
 - [#3165](https://github.com/epiphany-platform/epiphany/issues/3165) - download-requirements.py may fail due to expired certificate
 - [#3189](https://github.com/epiphany-platform/epiphany/issues/3189) - Fix configuration/feature-mapping enabling
+- [#3152](https://github.com/epiphany-platform/epiphany/issues/3152) - Use a stable tag for the quay.io/ceph/ceph:v16.2.7 image
 
 ### Updated
 

--- a/schema/common/defaults/configuration/image-registry.yml
+++ b/schema/common/defaults/configuration/image-registry.yml
@@ -63,8 +63,8 @@ specification:
             file_name: flannel-v0.14.0-amd64.tar
           - name: "quay.io/coreos/flannel:v0.14.0"
             file_name: flannel-v0.14.0.tar
-          - name: "quay.io/ceph/ceph:v16.2.7"
-            file_name: ceph-v16.2.7.tar
+          - name: "quay.io/ceph/ceph:v16.2.7-20220510"
+            file_name: ceph-v16.2.7-20220510.tar
           - name: "quay.io/cephcsi/cephcsi:v3.5.1"
             file_name: cephcsi-v3.5.1.tar
           - name: "quay.io/csiaddons/k8s-sidecar:v0.2.1"

--- a/schema/common/defaults/configuration/rook.yml
+++ b/schema/common/defaults/configuration/rook.yml
@@ -35,4 +35,4 @@ specification:
       image: rook/ceph:v1.8.8
     cephClusterSpec:
       cephVersion:
-        image: quay.io/ceph/ceph:v16.2.7
+        image: quay.io/ceph/ceph:v16.2.7-20220510


### PR DESCRIPTION
* Use a stable tag for the quay.io/ceph/ceph:v16.2.7 image

Signed-off-by: cicharka <arkadiusz.cichon@outlook.com>