### PR TITLE
Change Erlang repository

### DIFF
--- a/CHANGELOG-1.0.md
+++ b/CHANGELOG-1.0.md
@@ -1,5 +1,11 @@
 # Changelog 1.0
 
+## [1.0.5] 2022-0X-XX
+
+### Fixed
+
+- [#3198](https://github.com/epiphany-platform/epiphany/issues/3198) - [Ubuntu] download-requirements.sh fails on downloading Erlang packages
+
 ## [1.0.4] 2022-05-30
 
 ### Fixed

--- a/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/rabbitmq/defaults/main.yml
@@ -5,7 +5,7 @@ versions:
   general: 3.8.9 # required for upgrade
   # packages
   debian:
-    erlang: 1:23.1.*
+    erlang: 1:23.*
     rabbitmq: 3.8.9*
   redhat:
     erlang_filename: erlang-23.1.5-1.el7.x86_64.rpm

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/add-repositories.sh
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/add-repositories.sh
@@ -9,8 +9,8 @@ echo "deb https://packages.grafana.com/oss/deb stable main" | tee /etc/apt/sourc
 wget -qO - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
 
-wget -qO - https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | apt-key add -
-echo "deb https://packages.erlang-solutions.com/ubuntu bionic contrib" | tee /etc/apt/sources.list.d/erlang-23.x.list
+wget -qO - https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key | sudo gpg --dearmor | sudo tee /usr/share/keyrings/io.cloudsmith.rabbitmq.E495BB49CC4BBE5B.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/io.cloudsmith.rabbitmq.E495BB49CC4BBE5B.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu bionic main" | tee /etc/apt/sources.list.d/rabbitmq-erlang-23.x.list
 
 wget -qO - https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey | apt-key add -
 echo "deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu bionic main" | tee /etc/apt/sources.list.d/rabbitmq.list

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/requirements.txt
@@ -21,23 +21,23 @@ elasticsearch-oss 7.10.2 # for opendistroforelasticsearch & logging roles
 # Metapackages such as erlang and erlang-nox must only be used
 # with apt version pinning. They do not pin their dependency versions.
 # List based on: https://www.rabbitmq.com/install-debian.html#installing-erlang-package
-erlang-asn1 1:23.1.5
-erlang-base 1:23.1.5
-erlang-crypto 1:23.1.5
-erlang-eldap 1:23.1.5
-erlang-ftp 1:23.1.5
-erlang-inets 1:23.1.5
-erlang-mnesia 1:23.1.5
-erlang-os-mon 1:23.1.5
-erlang-parsetools 1:23.1.5
-erlang-public-key 1:23.1.5
-erlang-runtime-tools 1:23.1.5
-erlang-snmp 1:23.1.5
-erlang-ssl 1:23.1.5
-erlang-syntax-tools 1:23.1.5
-erlang-tftp 1:23.1.5
-erlang-tools 1:23.1.5
-erlang-xmerl 1:23.1.5
+erlang-asn1 1:23
+erlang-base 1:23
+erlang-crypto 1:23
+erlang-eldap 1:23
+erlang-ftp 1:23
+erlang-inets 1:23
+erlang-mnesia 1:23
+erlang-os-mon 1:23
+erlang-parsetools 1:23
+erlang-public-key 1:23
+erlang-runtime-tools 1:23
+erlang-snmp 1:23
+erlang-ssl 1:23
+erlang-syntax-tools 1:23
+erlang-tftp 1:23
+erlang-tools 1:23
+erlang-xmerl 1:23
 
 ethtool
 filebeat 7.9.2


### PR DESCRIPTION
For RabbitMQ 3.8.9 Erlang 23.x is recommended but it has been removed from the [Erlang Solutions](https://packages.erlang-solutions.com/erlang/#tabs-debian) repo for `bionic`. This PR switches to Cloudsmith.io repo and installs the latest version of Erlang 23.