### PR TITLE
OpenSearch: add dedicated user for Filebeat (#3079)

### DIFF
--- a/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
+++ b/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
@@ -315,8 +315,8 @@ output.elasticsearch:
 
   # Authentication credentials - either API key or username/password.
   {% if not is_upgrade_run %}
-  username: {{ logging_vars.specification.filebeat_user }}
-  password: {{ "'%s'" % logging_vars.specification.filebeat_password | replace("'","''") }}
+  username: filebeatservice
+  password: {{ "'%s'" % logging_vars.specification.filebeatservice_password | replace("'","''") }}
   {% else %}
   username: logstash
   password: {{ "'%s'" % existing_output_es_password | replace("'","''") }}

--- a/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
+++ b/ansible/playbooks/roles/filebeat/templates/filebeat.yml.j2
@@ -314,10 +314,11 @@ output.elasticsearch:
   {% endfor %}
 
   # Authentication credentials - either API key or username/password.
-  username: logstash
   {% if not is_upgrade_run %}
-  password: {{ "'%s'" % logging_vars.specification.logstash_password | replace("'","''") }}
+  username: {{ logging_vars.specification.filebeat_user }}
+  password: {{ "'%s'" % logging_vars.specification.filebeat_password | replace("'","''") }}
   {% else %}
+  username: logstash
   password: {{ "'%s'" % existing_output_es_password | replace("'","''") }}
   {% endif %}
 

--- a/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
+++ b/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
@@ -196,8 +196,8 @@
         status_code: [200, 404]
       register: kibanaserver_check_response
       when:
-      - groups.opensearch_dashboards[0] is defined
-      - inventory_hostname in groups.opensearch_dashboards
+        - groups.opensearch_dashboards[0] is defined
+        - inventory_hostname in groups.opensearch_dashboards
 
     - name: Create default kibanaserver user
       uri:
@@ -248,8 +248,8 @@
         status_code: [200, 404]
       register: filebeatservice_check_response
       when:
-      - groups.logging[0] is defined
-      - inventory_hostname in groups.logging
+        - groups.logging[0] is defined
+        - inventory_hostname in groups.logging
 
     - name: Create dedicated filebeatservice user
       uri:

--- a/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
+++ b/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
@@ -245,6 +245,7 @@
         method: GET
         status_code: [200, 404]
       register: filebeatservice_check_response
+      when: specification.filebeatservice_user_active
 
     - name: Create dedicated filebeatservice user
       uri:

--- a/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
+++ b/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
@@ -195,7 +195,9 @@
         method: GET
         status_code: [200, 404]
       register: kibanaserver_check_response
-      when: specification.kibanaserver_user_active
+      when:
+      - groups.opensearch_dashboards[0] is defined
+      - inventory_hostname in groups.opensearch_dashboards
 
     - name: Create default kibanaserver user
       uri:
@@ -245,7 +247,9 @@
         method: GET
         status_code: [200, 404]
       register: filebeatservice_check_response
-      when: specification.filebeatservice_user_active
+      when:
+      - groups.logging[0] is defined
+      - inventory_hostname in groups.logging
 
     - name: Create dedicated filebeatservice user
       uri:

--- a/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
+++ b/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
@@ -205,7 +205,7 @@
         url: "{{ opensearch_endpoint }}/_opendistro/_security/api/internalusers/kibanaserver"
         method: PUT
         status_code: [200]
-        body:
+        body: &kibanaserver_data
           password: "{{ specification.kibanaserver_password }}"
           reserved: "true"
           description: "Demo OpenSearch Dashboards user"
@@ -228,9 +228,7 @@
           - op: "replace"
             path: "/kibanaserver"
             value:
-              password: "{{ specification.kibanaserver_password }}"
-              reserved: "true"
-              description: "Demo OpenSearch Dashboards user"
+              <<: *kibanaserver_data
       register: uri_response
       until: uri_response is success
       retries: 15
@@ -257,7 +255,7 @@
         url: "{{ opensearch_endpoint }}/_opendistro/_security/api/internalusers/filebeatservice"
         method: PUT
         status_code: [200]
-        body:
+        body: &filebeatservice_data
           password: "{{ specification.filebeatservice_password }}"
           reserved: "true"
           backend_roles:
@@ -282,11 +280,7 @@
           - op: "replace"
             path: "/filebeatservice"
             value:
-              password: "{{ specification.filebeatservice_password }}"
-              reserved: "true"
-              backend_roles:
-                - "logstash"
-              description: "Epiphany user for Filebeat service"
+              <<: *filebeatservice_data
       register: uri_response
       until: uri_response is success
       retries: 15

--- a/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
+++ b/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
@@ -262,7 +262,7 @@
           reserved: "true"
           backend_roles:
             - "logstash"
-          description: "OpenSearch filebeatservice user"
+          description: "Epiphany user for Filebeat service"
       register: uri_response
       until: uri_response is success
       retries: 5
@@ -286,7 +286,7 @@
               reserved: "true"
               backend_roles:
                 - "logstash"
-              description: "OpenSearch filebeatservice user"
+              description: "Epiphany user for Filebeat service"
       register: uri_response
       until: uri_response is success
       retries: 15

--- a/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
+++ b/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
@@ -238,21 +238,58 @@
         - kibanaserver_check_response is defined
         - kibanaserver_check_response.status == 200
 
-    - name: Create dedicated {{ specification.filebeat_user }} user
+    - name: Check if filebeatservice user exists  # for re-apply scenario
       uri:
         <<: *uri
-        url: "{{ opensearch_endpoint }}/_opendistro/_security/api/internalusers/{{ specification.filebeat_user }}"
+        url: "{{ opensearch_endpoint }}/_opendistro/_security/api/internalusers/filebeatservice"
+        method: GET
+        status_code: [200, 404]
+      register: filebeatservice_check_response
+
+    - name: Create dedicated filebeatservice user
+      uri:
+        <<: *uri
+        url: "{{ opensearch_endpoint }}/_opendistro/_security/api/internalusers/filebeatservice"
         method: PUT
         status_code: [200]
         body:
-          password: "{{ specification.filebeat_password }}"
+          password: "{{ specification.filebeatservice_password }}"
           reserved: "true"
-          description: "OpenSearch {{ specification.filebeat_user }} user"
+          backend_roles:
+            - "logstash"
+          description: "OpenSearch filebeatservice user"
       register: uri_response
       until: uri_response is success
       retries: 5
       delay: 1
       run_once: true
+      when:
+        - filebeatservice_check_response is defined
+        - filebeatservice_check_response.status == 404
+
+    - name: Set filebeatservice user password
+      uri:
+        <<: *uri
+        url: "{{ opensearch_endpoint }}/_opendistro/_security/api/internalusers/"
+        method: PATCH
+        status_code: [200]
+        body:
+          - op: "replace"
+            path: "/filebeatservice"
+            value:
+              password: "{{ specification.filebeatservice_password }}"
+              reserved: "true"
+              backend_roles:
+                - "logstash"
+              description: "OpenSearch filebeatservice user"
+      register: uri_response
+      until: uri_response is success
+      retries: 15
+      delay: 1
+      run_once: true
+      when:
+        - filebeatservice_check_response is defined
+        - filebeatservice_check_response.status == 200
 
     - name: Remove OpenSearch demo users
       uri:

--- a/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
+++ b/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
@@ -215,7 +215,7 @@
       delay: 1
       run_once: true
       when:
-        - kibanaserver_check_response is defined
+        - kibanaserver_check_response.status is defined
         - kibanaserver_check_response.status == 404
 
     - name: Set kibanaserver user password
@@ -237,7 +237,7 @@
       delay: 1
       run_once: true
       when:
-        - kibanaserver_check_response is defined
+        - kibanaserver_check_response.status is defined
         - kibanaserver_check_response.status == 200
 
     - name: Check if filebeatservice user exists  # for re-apply scenario
@@ -269,7 +269,7 @@
       delay: 1
       run_once: true
       when:
-        - filebeatservice_check_response is defined
+        - filebeatservice_check_response.status is defined
         - filebeatservice_check_response.status == 404
 
     - name: Set filebeatservice user password
@@ -293,7 +293,7 @@
       delay: 1
       run_once: true
       when:
-        - filebeatservice_check_response is defined
+        - filebeatservice_check_response.status is defined
         - filebeatservice_check_response.status == 200
 
     - name: Remove OpenSearch demo users

--- a/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
+++ b/ansible/playbooks/roles/opensearch/tasks/configure-opensearch.yml
@@ -238,57 +238,21 @@
         - kibanaserver_check_response is defined
         - kibanaserver_check_response.status == 200
 
-    - name: Check if default logstash user exists
+    - name: Create dedicated {{ specification.filebeat_user }} user
       uri:
         <<: *uri
-        url: "{{ opensearch_endpoint }}/_opendistro/_security/api/internalusers/logstash"
-        method: GET
-        status_code: [200, 404]
-      register: logstash_check_response
-      when: specification.logstash_user_active
-
-    - name: Create default logstash user
-      uri:
-        <<: *uri
-        url: "{{ opensearch_endpoint }}/_opendistro/_security/api/internalusers/logstash"
+        url: "{{ opensearch_endpoint }}/_opendistro/_security/api/internalusers/{{ specification.filebeat_user }}"
         method: PUT
         status_code: [200]
         body:
-          password: "{{ specification.logstash_password }}"
+          password: "{{ specification.filebeat_password }}"
           reserved: "true"
-          description: "OpenSearch logstash user"
+          description: "OpenSearch {{ specification.filebeat_user }} user"
       register: uri_response
       until: uri_response is success
       retries: 5
       delay: 1
       run_once: true
-      when:
-        - logstash_check_response is defined
-        - logstash_check_response.status == 404
-
-    - name: Set OpenSearch logstash user password
-      uri:
-        <<: *uri
-        url: "{{ opensearch_endpoint }}/_opendistro/_security/api/internalusers/"
-        method: PATCH
-        status_code: [200]
-        body:
-          - op: "replace"
-            path: "/logstash"
-            value:
-              password: "{{ specification.logstash_password }}"
-              reserved: "true"
-              backend_roles:
-                - "logstash"
-              description: "OpenSearch logstash user"
-      register: uri_response
-      until: uri_response is success
-      retries: 3
-      delay: 5
-      run_once: true
-      when:
-        - logstash_check_response is defined
-        - kibanaserver_check_response.status == 200
 
     - name: Remove OpenSearch demo users
       uri:

--- a/ansible/playbooks/roles/opensearch_dashboards/tasks/dashboards.yml
+++ b/ansible/playbooks/roles/opensearch_dashboards/tasks/dashboards.yml
@@ -28,7 +28,7 @@
     extra_opts:
       - --strip-components=1
 
-# if opensearch-dashboards is enabled for groups 'logging' and 'opensearch', form dashoards cluster
+# if opensearch-dashboards is enabled for groups 'logging' and 'opensearch', form dashboards cluster
 # on the basis of belonging to a given group
 - name: Set opensearch dashboards hosts as fact
   set_fact:

--- a/ansible/playbooks/roles/opensearch_dashboards/tasks/dashboards.yml
+++ b/ansible/playbooks/roles/opensearch_dashboards/tasks/dashboards.yml
@@ -28,12 +28,16 @@
     extra_opts:
       - --strip-components=1
 
+# if opensearch-dashboards is enabled for groups 'logging' and 'opensearch', form dashoards cluster
+# on the basis of belonging to a given group
 - name: Set opensearch dashboards hosts as fact
   set_fact:
     opensearch_nodes_dashboards: |-
-        {% for item in groups['opensearch_dashboards'] -%}
-          https://{{ item }}:{{ opensearch_api_port }}{% if not loop.last %}","{% endif %}
-        {%- endfor %}
+      {%- set current_host_group = groups[(group_names | intersect(['logging', 'opensearch'])) | first] -%}
+      {%- set hosts = groups['opensearch_dashboards'] | intersect(current_host_group) -%}
+      {%- for item in hosts -%}
+        https://{{ item }}:{{ opensearch_api_port }}{%- if not loop.last -%}","{%- endif -%}
+      {%- endfor -%}
 
 - name: Copy configuration file
   template:

--- a/docs/changelogs/CHANGELOG-2.0.md
+++ b/docs/changelogs/CHANGELOG-2.0.md
@@ -14,6 +14,7 @@
 - [#3106](https://github.com/epiphany-platform/epiphany/issues/3106) - Add image-registry configuration reading
 - [#3140](https://github.com/epiphany-platform/epiphany/issues/3140) - Allow to disable OpenSearch audit logs
 - [#3218](https://github.com/epiphany-platform/epiphany/issues/3218) - Add support for original output coloring
+- [#3079](https://github.com/epiphany-platform/epiphany/issues/3079) - OpenSearch improvement - add dedicated user for Filebeat
 
 ### Fixed
 

--- a/docs/home/howto/DATABASES.md
+++ b/docs/home/howto/DATABASES.md
@@ -486,8 +486,10 @@ specification:
   cluster_name: EpiphanyOpenSearch
 ```
 
-By default, OpenSearch Dashboards ( previously Kibana component )  is deployed only for `logging` component. If you want to deploy it
-for `opensearch` component you have to modify feature mapping. Use below configuration in your manifest:
+By default, OpenSearch Dashboards (previously Kibana component) is deployed only for `logging` component. If you want to deploy it
+for `opensearch` component you have to:
+- modify feature mapping by adding `opensearch-dashboards` under `opensearch` component (see configuration below)
+- setup `kibanaserver` user and its password in `configuration/opensearch`, see [Opensearch user and password configuration](./MONITORING.md#opensearch-component)
 
 ```yaml
 kind: configuration/feature-mappings

--- a/docs/home/howto/DATABASES.md
+++ b/docs/home/howto/DATABASES.md
@@ -486,10 +486,10 @@ specification:
   cluster_name: EpiphanyOpenSearch
 ```
 
-By default, OpenSearch Dashboards (previously Kibana component) is deployed only for `logging` component. If you want to deploy it
+By default, OpenSearch Dashboards (previously Kibana) is deployed only for `logging` component. If you want to deploy it
 for `opensearch` component you have to:
 - modify feature mapping by adding `opensearch-dashboards` under `opensearch` component (see configuration below)
-- setup `kibanaserver` user and its password in `configuration/opensearch`, see [Opensearch user and password configuration](./MONITORING.md#opensearch-component)
+- set up `kibanaserver` user and its password in `configuration/opensearch`, see [Opensearch user and password configuration](./MONITORING.md#opensearch-component)
 
 ```yaml
 kind: configuration/feature-mappings

--- a/docs/home/howto/MONITORING.md
+++ b/docs/home/howto/MONITORING.md
@@ -263,10 +263,9 @@ By default Epiphany removes users that are listed in `demo_users_to_remove` sect
 Additionally, `kibanaserver`<sup>[1]</sup> user (needed by default Epiphany installation of Dashboards) is not removed. If you want to perform configuration by Epiphany, set `kibanaserver_user_active` to `true` for `kibanaserver` user. For `logging` role, this setting is already set to `true` by default.
 We strongly advice to set different password for each user.
 
-Note that `logstash` user (needed in earlier versions of Epiphany for installation of Filebeat) has been replaced by dedicated filebeat user.
-By default in Epiphany name of that user is set to `filebeatadmin`, but can be changed by modifying the value for `filebeat_user` key.
+Note that `logstash` user (needed in earlier versions of Epiphany for installation of Filebeat) has been replaced by dedicated `filebeatservice` user.
 
-To change `admin` user's password, you need to change the value for `admin_password` key ( see the example below ). For `kibanaserver` and `filebeatadmin`, you need to change values for `kibanaserver_password` and `filebeat_password` keys respectively. Changes from logging role will be propagated to OpenSearch Dashboards and Filebeat configuration accordingly.
+To change `admin` user's password, you need to change the value for `admin_password` key ( see the example below ). For `kibanaserver` and `filebeatservice`, you need to change values for `kibanaserver_password` and `filebeatservice_password` keys respectively. Changes from logging role will be propagated to OpenSearch Dashboards and Filebeat configuration accordingly.
 
 ```yaml
 kind: configuration/logging
@@ -277,8 +276,7 @@ specification:
   admin_password: YOUR_PASSWORD
   kibanaserver_password: YOUR_PASSWORD
   kibanaserver_user_active: true
-  filebeat_user: filebeatadmin
-  filebeat_password: PASSWORD_TO_CHANGE
+  filebeatservice_password: PASSWORD_TO_CHANGE
   demo_users_to_remove:
   - kibanaro
   - readall
@@ -292,14 +290,14 @@ To set password for `kibanaserver` user, which is used by Dashboards for communi
 
 #### Filebeat role
 
-To set password of `filebeatadmin` user, which is used by Filebeat for communication with OpenSearch Dashboards backend follow the procedure described in  [Logging role](#-logging-role).
+To set password of `filebeatservice` user, which is used by Filebeat for communication with OpenSearch Dashboards backend follow the procedure described in  [Logging role](#-logging-role).
 
 ### OpenSearch component
 
 By default Epiphany removes all demo users except `admin` user. Those users are listed in `demo_users_to_remove` section of `configuration/opensearch` manifest doc ( see example below ). If you want to keep `kibanaserver` user (needed by default Epiphany installation of OpenSearch Dashboards), you need to exclude it from `demo_users_to_remove` list and set `kibanaserver_user_active` to `true` in order to change the default password.
 We strongly advice to set different password for each user.
 
-To change `admin` user's password, change value for the `admin_password` key. For `kibanaserver` and `filebeatadmin`, change values for `kibanaserver_password` and `filebeat_password` keys respectively.
+To change `admin` user's password, change value for the `admin_password` key. For `kibanaserver` and `filebeatservice`, change values for `kibanaserver_password` and `filebeatservice_password` keys respectively.
 
 ```yaml
 kind: configuration/opensearch
@@ -310,8 +308,7 @@ specification:
   admin_password: YOUR_PASSWORD
   kibanaserver_password: YOUR_PASSWORD
   kibanaserver_user_active: false
-  filebeat_user: filebeatadmin
-  filebeat_password: PASSWORD_TO_CHANGE
+  filebeatservice_password: PASSWORD_TO_CHANGE
   demo_users_to_remove:
   - kibanaro
   - readall

--- a/docs/home/howto/MONITORING.md
+++ b/docs/home/howto/MONITORING.md
@@ -250,20 +250,27 @@ This filter pattern can now be used to query the OpenSsearch indices.
 
 By default OpenSearch Dashoboards adjusts the UTC time in `@timestamp` to the browser's local timezone. This can be changed in `Stack Management` > `Advanced Settings` > `Timezone for date formatting`.
 
-## How to configure default passwords for service users in OpenSearch Dashboards, OpenSearch and Filebeat 
+## How to configure default passwords for service users in OpenSearch Dashboards, OpenSearch and Filebeat
+
+Epiphany provides two roles that inclue OpenSearch installation: `logging` (includes OpenSearch-Dashboards) and `opensearch`.
+In order to learn more about both roles, please look through documentation:
+- [logging role](./LOGGING.md#centralized-logging-setup)
+- [opensearch role](./DATABASES.md#how-to-start-working-with-opensearch)
 
 To configure admin password for OpenSearch Dashoboards ( previously Kibana ) and OpenSearch you need to follow the procedure below.
-There are separate procedures for `logging` and `opensearch` roles since for most of the time `opensearch` and `kibanaserver` users are not required to be present.
 
 ### Logging component
 
 #### Logging role
 
-By default Epiphany removes users that are listed in `demo_users_to_remove` section of `configuration/logging` manifest document.
-Additionally, `kibanaserver`<sup>[1]</sup> user (needed by default Epiphany installation of Dashboards )and `filebeatservice` user (needed by default Epiphany installation of Filebeat) are not removed. If you want to perform configuration by Epiphany, set `kibanaserver_user_active` to `true` for `kibanaserver` user and/or `filebeatservice_user_active` to `true` for `filebeatservice` user. For `logging` role, this setting is already set to `true` by default.
-We strongly advice to set different password for each user.
-
+Default users configured by Epiphany for `logging` role are:
+- `kibanaserver`<sup>[1]</sup> user (needed by default Epiphany installation of Dashboards )
+- `filebeatservice` user (needed by default Epiphany installation of Filebeat)
 Note that `logstash` user from earlier versions of Epiphany, has been replaced by dedicated `filebeatservice` user.
+
+**We strongly advice to set different password for each user.**
+
+Additionally, Epiphany removes users that are listed in `demo_users_to_remove` section of `configuration/logging` manifest document.
 
 To change `admin` user's password, you need to change the value for `admin_password` key ( see the example below ). For `kibanaserver` and `filebeatservice`, you need to change values for `kibanaserver_password` and `filebeatservice_password` keys respectively. Changes from logging role will be propagated to OpenSearch Dashboards and Filebeat configuration accordingly.
 
@@ -275,9 +282,7 @@ specification:
   [...]
   admin_password: YOUR_PASSWORD
   kibanaserver_password: YOUR_PASSWORD
-  kibanaserver_user_active: true
   filebeatservice_password: PASSWORD_TO_CHANGE
-  filebeatservice_user_active: true
   demo_users_to_remove:
   - kibanaro
   - readall
@@ -285,20 +290,14 @@ specification:
   - snapshotrestore
 ```
 
-#### OpenSearch Dashboards ( Kibana ) role
-
-To set password for `kibanaserver` user, which is used by Dashboards for communication with OpenSearch Dashboards backend follow the procedure described in [Logging role](#logging-role).
-
-#### Filebeat role
-
-To set password of `filebeatservice` user, which is used by Filebeat for communication with OpenSearch Dashboards backend follow the procedure described in  [Logging role](#-logging-role).
-
 ### OpenSearch component
 
-By default Epiphany removes all demo users except `admin` user. Those users are listed in `demo_users_to_remove` section of `configuration/opensearch` manifest doc ( see example below ). If you want to keep `kibanaserver` user (needed by default Epiphany installation of OpenSearch Dashboards), you need to exclude it from `demo_users_to_remove` list and set `kibanaserver_user_active` to `true` in order to change the default password.
-We strongly advice to set different password for each user.
+Default user provided by Epiphany for OpenSearch role is `admin`. Additionally, Epiphany removes all demo users except `admin` user.
+Those users are listed in `demo_users_to_remove` section of `configuration/opensearch` manifest doc ( see example below ).
 
-To change `admin` user's password, change value for the `admin_password` key. For `kibanaserver` and `filebeatservice`, change values for `kibanaserver_password` and `filebeatservice_password` keys respectively.
+**We strongly advice to set different password for admin user.**
+
+To change `admin` user's password, change value for the `admin_password` key.
 
 ```yaml
 kind: configuration/opensearch
@@ -307,10 +306,6 @@ name: default
 specification:
   [...]
   admin_password: YOUR_PASSWORD
-  kibanaserver_password: YOUR_PASSWORD
-  kibanaserver_user_active: false
-  filebeatservice_password: PASSWORD_TO_CHANGE
-  filebeatservice_user_active: true
   demo_users_to_remove:
   - kibanaro
   - readall

--- a/docs/home/howto/MONITORING.md
+++ b/docs/home/howto/MONITORING.md
@@ -260,10 +260,10 @@ There are separate procedures for `logging` and `opensearch` roles since for mos
 #### Logging role
 
 By default Epiphany removes users that are listed in `demo_users_to_remove` section of `configuration/logging` manifest document.
-Additionally, `kibanaserver`<sup>[1]</sup> user (needed by default Epiphany installation of Dashboards) is not removed. If you want to perform configuration by Epiphany, set `kibanaserver_user_active` to `true` for `kibanaserver` user. For `logging` role, this setting is already set to `true` by default.
+Additionally, `kibanaserver`<sup>[1]</sup> user (needed by default Epiphany installation of Dashboards )and `filebeatservice` user (needed by default Epiphany installation of Filebeat) are not removed. If you want to perform configuration by Epiphany, set `kibanaserver_user_active` to `true` for `kibanaserver` user and/or `filebeatservice_user_active` to `true` for `filebeatservice` user. For `logging` role, this setting is already set to `true` by default.
 We strongly advice to set different password for each user.
 
-Note that `logstash` user (needed in earlier versions of Epiphany for installation of Filebeat) has been replaced by dedicated `filebeatservice` user.
+Note that `logstash` user from earlier versions of Epiphany, has been replaced by dedicated `filebeatservice` user.
 
 To change `admin` user's password, you need to change the value for `admin_password` key ( see the example below ). For `kibanaserver` and `filebeatservice`, you need to change values for `kibanaserver_password` and `filebeatservice_password` keys respectively. Changes from logging role will be propagated to OpenSearch Dashboards and Filebeat configuration accordingly.
 
@@ -277,6 +277,7 @@ specification:
   kibanaserver_password: YOUR_PASSWORD
   kibanaserver_user_active: true
   filebeatservice_password: PASSWORD_TO_CHANGE
+  filebeatservice_user_active: true
   demo_users_to_remove:
   - kibanaro
   - readall
@@ -309,6 +310,7 @@ specification:
   kibanaserver_password: YOUR_PASSWORD
   kibanaserver_user_active: false
   filebeatservice_password: PASSWORD_TO_CHANGE
+  filebeatservice_user_active: true
   demo_users_to_remove:
   - kibanaro
   - readall

--- a/docs/home/howto/MONITORING.md
+++ b/docs/home/howto/MONITORING.md
@@ -252,10 +252,10 @@ By default OpenSearch Dashoboards adjusts the UTC time in `@timestamp` to the br
 
 ## How to configure default passwords for service users in OpenSearch Dashboards, OpenSearch and Filebeat
 
-Epiphany provides two roles that inclue OpenSearch installation: `logging` (includes OpenSearch-Dashboards) and `opensearch`.
-In order to learn more about both roles, please look through documentation:
-- [logging role](./LOGGING.md#centralized-logging-setup)
-- [opensearch role](./DATABASES.md#how-to-start-working-with-opensearch)
+Epiphany provides two componenets that include OpenSearch installation: `logging` (by default includes OpenSearch-Dashboards as well) and `opensearch`.
+In order to learn more about both components, please look through documentation:
+- [logging](./LOGGING.md#centralized-logging-setup)
+- [opensearch](./DATABASES.md#how-to-start-working-with-opensearch)
 
 To configure admin password for OpenSearch Dashoboards ( previously Kibana ) and OpenSearch you need to follow the procedure below.
 
@@ -294,10 +294,11 @@ specification:
 
 Default user provided by Epiphany for OpenSearch role is `admin`. Additionally, Epiphany removes all demo users except `admin` user.
 Those users are listed in `demo_users_to_remove` section of `configuration/opensearch` manifest doc ( see example below ).
+To change `admin` user's password, change value for the `admin_password` key.
 
 **We strongly advice to set different password for admin user.**
 
-To change `admin` user's password, change value for the `admin_password` key.
+Note that adding `opensearch-dashboards` mapping in `configuration/feature-mappings` under `opensearch` component requires commenting out `kibanaserver` user form `demo_users_to_remove` section (as presented in configuration below). This step should be followed by changing default password for `kibanaserver` user by modifying value for `kibanaserver_password` key.
 
 ```yaml
 kind: configuration/opensearch
@@ -306,12 +307,13 @@ name: default
 specification:
   [...]
   admin_password: YOUR_PASSWORD
+  kibanaserver_password: YOUR_PASSWPRD
   demo_users_to_remove:
   - kibanaro
   - readall
   - snapshotrestore
   - logstash
-  - kibanaserver
+  # - kibanaserver
 ```
 
 ### Upgrade of OpenSearch, OpenSearch Dashboards and Filebeat

--- a/docs/home/howto/MONITORING.md
+++ b/docs/home/howto/MONITORING.md
@@ -264,8 +264,8 @@ To configure admin password for OpenSearch Dashoboards ( previously Kibana ) and
 #### Logging role
 
 Default users configured by Epiphany for `logging` role are:
-- `kibanaserver`<sup>[1]</sup> user (needed by default Epiphany installation of Dashboards )
-- `filebeatservice` user (needed by default Epiphany installation of Filebeat)
+- `kibanaserver`<sup>[1]</sup> - needed by default Epiphany installation of Dashboards
+- `filebeatservice` - needed by default Epiphany installation of Filebeat
 Note that `logstash` user from earlier versions of Epiphany, has been replaced by dedicated `filebeatservice` user.
 
 **We strongly advice to set different password for each user.**
@@ -298,7 +298,7 @@ To change `admin` user's password, change value for the `admin_password` key.
 
 **We strongly advice to set different password for admin user.**
 
-Note that adding `opensearch-dashboards` mapping in `configuration/feature-mappings` under `opensearch` component requires commenting out `kibanaserver` user form `demo_users_to_remove` section (as presented in configuration below). This step should be followed by changing default password for `kibanaserver` user by modifying value for `kibanaserver_password` key.
+Note that adding `opensearch-dashboards` mapping in `configuration/feature-mappings` under `opensearch` component requires commenting out `kibanaserver` user in `demo_users_to_remove` section (as presented in configuration below). This step should be followed by changing default password for `kibanaserver` user by modifying value for `kibanaserver_password` key.
 
 ```yaml
 kind: configuration/opensearch

--- a/docs/home/howto/MONITORING.md
+++ b/docs/home/howto/MONITORING.md
@@ -253,18 +253,20 @@ By default OpenSearch Dashoboards adjusts the UTC time in `@timestamp` to the br
 ## How to configure default passwords for service users in OpenSearch Dashboards, OpenSearch and Filebeat 
 
 To configure admin password for OpenSearch Dashoboards ( previously Kibana ) and OpenSearch you need to follow the procedure below.
-There are separate procedures for `logging` and `opensearch` roles since for most of the time `opensearch`, `kibanaserver` and `logstash` users are not required to be present.
+There are separate procedures for `logging` and `opensearch` roles since for most of the time `opensearch` and `kibanaserver` users are not required to be present.
 
 ### Logging component
 
 #### Logging role
 
 By default Epiphany removes users that are listed in `demo_users_to_remove` section of `configuration/logging` manifest document.
-Additionally, `kibanaserver`<sup>[1]</sup> user (needed by default Epiphany installation of Dashboards) and `logstash` user (needed by default Epiphany installation of Filebeat) are not removed. If you want to perform configuration by Epiphany, set `kibanaserver_user_active` to `true`
-for `kibanaserver` user and/or `logstash_user_active` to `true` for `logstash` user. For `logging` role, those settings are already set to `true` by default.
+Additionally, `kibanaserver`<sup>[1]</sup> user (needed by default Epiphany installation of Dashboards) is not removed. If you want to perform configuration by Epiphany, set `kibanaserver_user_active` to `true` for `kibanaserver` user. For `logging` role, this setting is already set to `true` by default.
 We strongly advice to set different password for each user.
 
-To change `admin` user's password, you need to change the value for `admin_password` key ( see the example below ). For `kibanaserver` and `logstash`, you need to change values for `kibanaserver_password` and `logstash_password` keys respectively. Changes from logging role will be propagated to OpenSearch Dashboards and Filebeat configuration accordingly.
+Note that `logstash` user (needed in earlier versions of Epiphany for installation of Filebeat) has been replaced by dedicated filebeat user.
+By default in Epiphany name of that user is set to `filebeatadmin`, but can be changed by modifying the value for `filebeat_user` key.
+
+To change `admin` user's password, you need to change the value for `admin_password` key ( see the example below ). For `kibanaserver` and `filebeatadmin`, you need to change values for `kibanaserver_password` and `filebeat_password` keys respectively. Changes from logging role will be propagated to OpenSearch Dashboards and Filebeat configuration accordingly.
 
 ```yaml
 kind: configuration/logging
@@ -275,11 +277,12 @@ specification:
   admin_password: YOUR_PASSWORD
   kibanaserver_password: YOUR_PASSWORD
   kibanaserver_user_active: true
-  logstash_password: YOUR_PASSWORD
-  logstash_user_active: true
+  filebeat_user: filebeatadmin
+  filebeat_password: PASSWORD_TO_CHANGE
   demo_users_to_remove:
   - kibanaro
   - readall
+  - logstash
   - snapshotrestore
 ```
 
@@ -289,14 +292,14 @@ To set password for `kibanaserver` user, which is used by Dashboards for communi
 
 #### Filebeat role
 
-To set password of `logstash` user, which is used by Filebeat for communication with OpenSearch Dashboards backend follow the procedure described in  [Logging role](#-logging-role).
+To set password of `filebeatadmin` user, which is used by Filebeat for communication with OpenSearch Dashboards backend follow the procedure described in  [Logging role](#-logging-role).
 
 ### OpenSearch component
 
 By default Epiphany removes all demo users except `admin` user. Those users are listed in `demo_users_to_remove` section of `configuration/opensearch` manifest doc ( see example below ). If you want to keep `kibanaserver` user (needed by default Epiphany installation of OpenSearch Dashboards), you need to exclude it from `demo_users_to_remove` list and set `kibanaserver_user_active` to `true` in order to change the default password.
 We strongly advice to set different password for each user.
 
-To change `admin` user's password, change value for the `admin_password` key. For `kibanaserver` and `logstash`, change values for `kibanaserver_password` and `logstash_password` keys respectively.
+To change `admin` user's password, change value for the `admin_password` key. For `kibanaserver` and `filebeatadmin`, change values for `kibanaserver_password` and `filebeat_password` keys respectively.
 
 ```yaml
 kind: configuration/opensearch
@@ -307,8 +310,8 @@ specification:
   admin_password: YOUR_PASSWORD
   kibanaserver_password: YOUR_PASSWORD
   kibanaserver_user_active: false
-  logstash_password: YOUR_PASSWORD
-  logstash_user_active: false
+  filebeat_user: filebeatadmin
+  filebeat_password: PASSWORD_TO_CHANGE
   demo_users_to_remove:
   - kibanaro
   - readall

--- a/schema/common/defaults/configuration/logging.yml
+++ b/schema/common/defaults/configuration/logging.yml
@@ -9,8 +9,7 @@ specification:
   admin_password: PASSWORD_TO_CHANGE
   kibanaserver_password: PASSWORD_TO_CHANGE
   kibanaserver_user_active: true
-  filebeat_user: filebeatadmin
-  filebeat_password: PASSWORD_TO_CHANGE
+  filebeatservice_password: PASSWORD_TO_CHANGE
   demo_users_to_remove:
     - kibanaro
     - readall

--- a/schema/common/defaults/configuration/logging.yml
+++ b/schema/common/defaults/configuration/logging.yml
@@ -8,15 +8,12 @@ specification:
   opensearch_os_group: opensearch
   admin_password: PASSWORD_TO_CHANGE
   kibanaserver_password: PASSWORD_TO_CHANGE
-  kibanaserver_user_active: true
   filebeatservice_password: PASSWORD_TO_CHANGE
-  filebeatservice_user_active: true
   demo_users_to_remove:
     - kibanaro
     - readall
     - snapshotrestore
     - logstash
-    # - kibanaserver
   paths:
     opensearch_home: /usr/share/opensearch
     opensearch_conf_dir: /usr/share/opensearch/config

--- a/schema/common/defaults/configuration/logging.yml
+++ b/schema/common/defaults/configuration/logging.yml
@@ -10,6 +10,7 @@ specification:
   kibanaserver_password: PASSWORD_TO_CHANGE
   kibanaserver_user_active: true
   filebeatservice_password: PASSWORD_TO_CHANGE
+  filebeatservice_user_active: true
   demo_users_to_remove:
     - kibanaro
     - readall

--- a/schema/common/defaults/configuration/logging.yml
+++ b/schema/common/defaults/configuration/logging.yml
@@ -9,13 +9,13 @@ specification:
   admin_password: PASSWORD_TO_CHANGE
   kibanaserver_password: PASSWORD_TO_CHANGE
   kibanaserver_user_active: true
-  logstash_password: PASSWORD_TO_CHANGE
-  logstash_user_active: true
+  filebeat_user: filebeatadmin
+  filebeat_password: PASSWORD_TO_CHANGE
   demo_users_to_remove:
     - kibanaro
     - readall
     - snapshotrestore
-    # - logstash
+    - logstash
     # - kibanaserver
   paths:
     opensearch_home: /usr/share/opensearch

--- a/schema/common/defaults/configuration/opensearch.yml
+++ b/schema/common/defaults/configuration/opensearch.yml
@@ -10,6 +10,7 @@ specification:
   kibanaserver_password: PASSWORD_TO_CHANGE
   kibanaserver_user_active: true
   filebeatservice_password: PASSWORD_TO_CHANGE
+  filebeatservice_user_active: true
   demo_users_to_remove:
     - kibanaro
     - readall

--- a/schema/common/defaults/configuration/opensearch.yml
+++ b/schema/common/defaults/configuration/opensearch.yml
@@ -7,16 +7,12 @@ specification:
   opensearch_os_user: opensearch
   opensearch_os_group: opensearch
   admin_password: PASSWORD_TO_CHANGE
-  kibanaserver_password: PASSWORD_TO_CHANGE
-  kibanaserver_user_active: true
-  filebeatservice_password: PASSWORD_TO_CHANGE
-  filebeatservice_user_active: true
   demo_users_to_remove:
     - kibanaro
     - readall
     - snapshotrestore
     - logstash
-    # - kibanaserver
+    - kibanaserver
   paths:
     opensearch_home: /usr/share/opensearch
     opensearch_conf_dir: /usr/share/opensearch/config

--- a/schema/common/defaults/configuration/opensearch.yml
+++ b/schema/common/defaults/configuration/opensearch.yml
@@ -7,6 +7,7 @@ specification:
   opensearch_os_user: opensearch
   opensearch_os_group: opensearch
   admin_password: PASSWORD_TO_CHANGE
+  kibanaserver_password: PASSWORD_TO_CHANGE
   demo_users_to_remove:
     - kibanaro
     - readall

--- a/schema/common/defaults/configuration/opensearch.yml
+++ b/schema/common/defaults/configuration/opensearch.yml
@@ -9,13 +9,12 @@ specification:
   admin_password: PASSWORD_TO_CHANGE
   kibanaserver_password: PASSWORD_TO_CHANGE
   kibanaserver_user_active: true
-  logstash_password: PASSWORD_TO_CHANGE
-  logstash_user_active: true
+  filebeatservice_password: PASSWORD_TO_CHANGE
   demo_users_to_remove:
     - kibanaro
     - readall
     - snapshotrestore
-    # - logstash
+    - logstash
     # - kibanaserver
   paths:
     opensearch_home: /usr/share/opensearch

--- a/schema/common/validation/configuration/logging.yml
+++ b/schema/common/validation/configuration/logging.yml
@@ -14,12 +14,8 @@ properties:
     type: string
   kibanaserver_password:
     type: string
-  kibanaserver_user_active:
-    type: boolean
   filebeatservice_password:
     type: string
-  filebeatservice_user_active:
-    type: boolean
   demo_users_to_remove:
     type: array
     items:

--- a/schema/common/validation/configuration/logging.yml
+++ b/schema/common/validation/configuration/logging.yml
@@ -18,6 +18,8 @@ properties:
     type: boolean
   filebeatservice_password:
     type: string
+  filebeatservice_user_active:
+    type: boolean
   demo_users_to_remove:
     type: array
     items:

--- a/schema/common/validation/configuration/logging.yml
+++ b/schema/common/validation/configuration/logging.yml
@@ -16,9 +16,7 @@ properties:
     type: string
   kibanaserver_user_active:
     type: boolean
-  filebeat_user:
-    type: string
-  filebeat_password:
+  filebeatservice_password:
     type: string
   demo_users_to_remove:
     type: array

--- a/schema/common/validation/configuration/logging.yml
+++ b/schema/common/validation/configuration/logging.yml
@@ -16,10 +16,10 @@ properties:
     type: string
   kibanaserver_user_active:
     type: boolean
-  logstash_password:
+  filebeat_user:
     type: string
-  logstash_user_active:
-    type: boolean
+  filebeat_password:
+    type: string
   demo_users_to_remove:
     type: array
     items:

--- a/schema/common/validation/configuration/opensearch.yml
+++ b/schema/common/validation/configuration/opensearch.yml
@@ -12,14 +12,6 @@ properties:
     type: string
   admin_password:
     type: string
-  kibanaserver_password:
-    type: string
-  kibanaserver_user_active:
-    type: boolean
-  filebeatservice_password:
-    type: string
-  filebeatservice_user_active:
-    type: boolean
   demo_users_to_remove:
     type: array
     items:

--- a/schema/common/validation/configuration/opensearch.yml
+++ b/schema/common/validation/configuration/opensearch.yml
@@ -16,10 +16,8 @@ properties:
     type: string
   kibanaserver_user_active:
     type: boolean
-  logstash_password:
+  filebeatservice_password:
     type: string
-  logstash_user_active:
-    type: boolean
   demo_users_to_remove:
     type: array
     items:

--- a/schema/common/validation/configuration/opensearch.yml
+++ b/schema/common/validation/configuration/opensearch.yml
@@ -12,6 +12,8 @@ properties:
     type: string
   admin_password:
     type: string
+  kibanaserver_password:
+    type: string
   demo_users_to_remove:
     type: array
     items:

--- a/schema/common/validation/configuration/opensearch.yml
+++ b/schema/common/validation/configuration/opensearch.yml
@@ -18,6 +18,8 @@ properties:
     type: boolean
   filebeatservice_password:
     type: string
+  filebeatservice_user_active:
+    type: boolean
   demo_users_to_remove:
     type: array
     items:

--- a/tests/spec/spec/filebeat/filebeat_spec.rb
+++ b/tests/spec/spec/filebeat/filebeat_spec.rb
@@ -9,12 +9,10 @@ end
 # Configurable passwords for ES users were introduced in v0.10.0.
 # For testing upgrades, we use default passwords for now but they should be read from filebeat.yml (remote host).
 es_filebeatservice_user_password  = readDataYaml('configuration/logging')['specification']['filebeatservice_password'] || 'filebeatservice'
-es_filebeatservice_user_is_active = readDataYaml('configuration/logging')['specification']['filebeatservice_user_active']
-es_filebeatservice_user_is_active = true if es_filebeatservice_user_is_active.nil?
+es_filebeatservice_user_is_active = !listInventoryHosts('logging').empty?
 
 es_kibanaserver_user_password  = readDataYaml('configuration/logging')['specification']['kibanaserver_password'] || 'kibanaserver'
-es_kibanaserver_user_is_active = readDataYaml('configuration/logging')['specification']['kibanaserver_user_active']
-es_kibanaserver_user_is_active = true if es_kibanaserver_user_is_active.nil?
+es_kibanaserver_user_is_active = !listInventoryHosts('logging').empty?
 
 es_api_port     = 9200
 kibana_api_port = 5601

--- a/tests/spec/spec/filebeat/filebeat_spec.rb
+++ b/tests/spec/spec/filebeat/filebeat_spec.rb
@@ -8,7 +8,7 @@ end
 
 # Configurable passwords for ES users were introduced in v0.10.0.
 # For testing upgrades, we use default passwords for now but they should be read from filebeat.yml (remote host).
-es_filebeatservice_user_password  = readDataYaml('configuration/logging')['specification']['filebeatservice_password'] || 'filebeatservice'
+es_filebeatservice_user_password  = readDataYaml('configuration/logging')['specification']['filebeatservice_password'] || 'PASSWORD_TO_CHANGE'
 es_filebeatservice_user_is_active = !listInventoryHosts('logging').empty?
 
 es_kibanaserver_user_password  = readDataYaml('configuration/logging')['specification']['kibanaserver_password'] || 'kibanaserver'

--- a/tests/spec/spec/filebeat/filebeat_spec.rb
+++ b/tests/spec/spec/filebeat/filebeat_spec.rb
@@ -11,11 +11,7 @@ end
 es_filebeat_user_password  = readDataYaml('configuration/logging')['specification']['filebeatservice_password'] || 'PASSWORD_TO_CHANGE'
 es_filebeat_user_is_active = !listInventoryHosts('logging').empty?
 
-filebeat_user = if upgradeRun?
-                  'logstash'
-                else
-                  'filebeatservice'
-                end
+filebeat_user = upgradeRun? ? 'logstash' : 'filebeatservice'
 
 es_kibanaserver_user_password  = readDataYaml('configuration/logging')['specification']['kibanaserver_password'] || 'kibanaserver'
 es_kibanaserver_user_is_active = !listInventoryHosts('logging').empty?

--- a/tests/spec/spec/filebeat/filebeat_spec.rb
+++ b/tests/spec/spec/filebeat/filebeat_spec.rb
@@ -8,9 +8,9 @@ end
 
 # Configurable passwords for ES users were introduced in v0.10.0.
 # For testing upgrades, we use default passwords for now but they should be read from filebeat.yml (remote host).
-es_logstash_user_password  = readDataYaml('configuration/logging')['specification']['logstash_password'] || 'logstash'
-es_logstash_user_is_active = readDataYaml('configuration/logging')['specification']['logstash_user_active']
-es_logstash_user_is_active = true if es_logstash_user_is_active.nil?
+es_filebeatservice_user_password  = readDataYaml('configuration/logging')['specification']['filebeatservice_password'] || 'filebeatservice'
+es_filebeatservice_user_is_active = readDataYaml('configuration/logging')['specification']['filebeatservice_user_active']
+es_filebeatservice_user_is_active = true if es_filebeatservice_user_is_active.nil?
 
 es_kibanaserver_user_password  = readDataYaml('configuration/logging')['specification']['kibanaserver_password'] || 'kibanaserver'
 es_kibanaserver_user_is_active = readDataYaml('configuration/logging')['specification']['kibanaserver_user_active']
@@ -44,11 +44,11 @@ describe 'Check Filebeat directories and config files' do
   end
 end
 
-if es_logstash_user_is_active
+if es_filebeatservice_user_is_active
   listInventoryHosts('logging').each do |val|
     describe 'Check the connection to the Elasticsearch hosts' do
       let(:disable_sudo) { false }
-      describe command("curl -k -u logstash:#{es_logstash_user_password} -o /dev/null -s -w '%{http_code}' https://#{val}:#{es_api_port}") do
+      describe command("curl -k -u filebeatservice:#{es_filebeatservice_user_password} -o /dev/null -s -w '%{http_code}' https://#{val}:#{es_api_port}") do
         it 'is expected to be equal' do
           expect(subject.stdout.to_i).to eq 200
         end

--- a/tests/spec/spec/logging/logging_spec.rb
+++ b/tests/spec/spec/logging/logging_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 # Configurable passwords for ES users were introduced in v0.10.0.
 # For testing upgrades, we use the default password for now but we're going to switch to TLS auth.
-es_kibanaserver_user_password  = readDataYaml('configuration/logging')['specification']['kibanaserver_password'] || 'kibanaserver'
-es_kibanaserver_user_is_active = readDataYaml('configuration/logging')['specification']['kibanaserver_user_active']
-es_kibanaserver_user_is_active = true if es_kibanaserver_user_is_active.nil?
+es_kibanaserver_user_password = readDataYaml('configuration/logging')['specification']['kibanaserver_password'] || 'kibanaserver'
 es_admin_password = readDataYaml('configuration/logging')['specification']['admin_password'] || 'admin'
 es_rest_api_port  = 9200
 es_transport_port = 9300

--- a/tests/spec/spec/opensearch/opensearch_spec.rb
+++ b/tests/spec/spec/opensearch/opensearch_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
 # Configurable passwords for ES users were introduced in v0.10.0.
 # For testing upgrades, we use the default password for now but we're going to switch to TLS auth.
-es_kibanaserver_user_password  = readDataYaml('configuration/opensearch')['specification']['kibanaserver_password'] || 'kibanaserver'
-es_kibanaserver_user_is_active = readDataYaml('configuration/opensearch')['specification']['kibanaserver_user_active']
-es_kibanaserver_user_is_active = true if es_kibanaserver_user_is_active.nil?
 es_admin_password = readDataYaml('configuration/opensearch')['specification']['admin_password'] || 'admin'
 es_rest_api_port  = 9200
 es_transport_port = 9300


### PR DESCRIPTION
* removes previously used logstash user from filebeat configuration
* removes logstash users from demo users configured by opensearch
* enables creation of dedicated filebeat user - `filebeatservice`
* remove `[kibanaserver|filebeatservice]_user_active` flag
* docs updated

Signed-off-by: cicharka <arkadiusz.cichon@outlook.com>