### PR TITLE
ARM: fix canal configuration

### DIFF
--- a/ansible/playbooks/roles/kubernetes_master/templates/calico.yml.j2
+++ b/ansible/playbooks/roles/kubernetes_master/templates/calico.yml.j2
@@ -3861,6 +3861,7 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
+            # Can be set to default (auto) after upgrading to RHEL9
 {% if 'arm64' in calico_arch %}
             - name: FELIX_IPTABLESBACKEND
               value: "Legacy"

--- a/ansible/playbooks/roles/kubernetes_master/templates/canal.yml.j2
+++ b/ansible/playbooks/roles/kubernetes_master/templates/canal.yml.j2
@@ -3845,6 +3845,11 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
+            # Can be set to default (auto) after upgrading to RHEL9
+{% if 'arm64' in canal_arch %}
+            - name: FELIX_IPTABLESBACKEND
+              value: "Legacy"
+{% endif %}
             # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"


### PR DESCRIPTION
* fix problem with Incorrect iptables system detected (nft instead of legacy)
  by adding FELIX_IPTABLESBACKEND variable to canal configuration

Signed-off-by: cicharka <arkadiusz.cichon@outlook.com>