### PR TITLE
[2.0.2] Update cloud OS images

### DIFF
--- a/cli/src/helpers/naming_helpers.py
+++ b/cli/src/helpers/naming_helpers.py
@@ -70,7 +70,7 @@ def get_os_name_normalized(vm_doc):
                 return expected_indicators[indicator]
     if vm_doc.provider == "aws":
         # Example public/official AMI names:
-        # - ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220419
+        # - ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221010
         # - RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2
         # - AlmaLinux OS 8.4.20211015 x86_64
         for indicator in expected_indicators:

--- a/docs/changelogs/CHANGELOG-2.0.md
+++ b/docs/changelogs/CHANGELOG-2.0.md
@@ -24,6 +24,7 @@
 - [#3257](https://github.com/epiphany-platform/epiphany/issues/3257) - Upgrade ansible-core to 2.13 (ansible 6)
 - [#3061](https://github.com/epiphany-platform/epiphany/issues/3061) - Upgrade Keycloak to 19.0.2
 - [#3277](https://github.com/epiphany-platform/epiphany/issues/3277) - Simplify configuration of enabling Rook
+- [#3287](https://github.com/epiphany-platform/epiphany/issues/3287) - Update cloud OS images to the latest
 
 ## [2.0.1] 2022-08-12
 

--- a/docs/home/howto/OS_PATCHING.md
+++ b/docs/home/howto/OS_PATCHING.md
@@ -29,7 +29,7 @@ This document will help you decide how you should patch your OS. This is not a s
 For Epiphany >= v2.0 we recommend the following image (AMI):
 
 - RHEL: `RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2` (kernel 4.18.0-305.12.1.el8_4.x86_64),
-- Ubuntu: `ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220419` (kernel 5.13.0-1022-aws).
+- Ubuntu: `ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221010` (kernel 5.13.0-1022-aws).
 
 Note: For different supported OS versions this guide may be useful as well.
 
@@ -57,7 +57,7 @@ For more information, refer to [AWS Systems Manager User Guide](https://docs.aws
 For Epiphany >= v2.0 we recommend the following image (urn):
 
 - RHEL: `RedHat:rhel-raw:8-raw-gen2:8.4.2022031606` (kernel 4.18.0-305.el8.x86_64),
-- Ubuntu: `Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202204190` (kernel 5.13.0-1022-azure).
+- Ubuntu: `Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202210100` (kernel 5.13.0-1022-azure).
 
 Note: For different supported OS versions this guide may be useful as well.
 

--- a/docs/home/howto/OS_PATCHING.md
+++ b/docs/home/howto/OS_PATCHING.md
@@ -29,7 +29,7 @@ This document will help you decide how you should patch your OS. This is not a s
 For Epiphany >= v2.0 we recommend the following image (AMI):
 
 - RHEL: `RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2` (kernel 4.18.0-305.12.1.el8_4.x86_64),
-- Ubuntu: `ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221010` (kernel 5.13.0-1022-aws).
+- Ubuntu: `ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221010` (kernel 5.15.0-1021-aws).
 
 Note: For different supported OS versions this guide may be useful as well.
 
@@ -57,7 +57,7 @@ For more information, refer to [AWS Systems Manager User Guide](https://docs.aws
 For Epiphany >= v2.0 we recommend the following image (urn):
 
 - RHEL: `RedHat:rhel-raw:8-raw-gen2:8.4.2022031606` (kernel 4.18.0-305.el8.x86_64),
-- Ubuntu: `Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202210100` (kernel 5.13.0-1022-azure).
+- Ubuntu: `Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202210100` (kernel 5.15.0-1021-azure).
 
 Note: For different supported OS versions this guide may be useful as well.
 

--- a/schema/aws/defaults/infrastructure/cloud-os-image-defaults.yml
+++ b/schema/aws/defaults/infrastructure/cloud-os-image-defaults.yml
@@ -6,4 +6,4 @@ specification:
   almalinux-8-arm64: AlmaLinux OS 8.4.20211015 aarch64
   almalinux-8-x86_64: AlmaLinux OS 8.4.20211015 x86_64
   rhel-8-x86_64: RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2
-  ubuntu-20.04-x86_64: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220419
+  ubuntu-20.04-x86_64: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221010

--- a/schema/aws/defaults/infrastructure/virtual-machine.yml
+++ b/schema/aws/defaults/infrastructure/virtual-machine.yml
@@ -17,7 +17,7 @@ specification:
   authorized_to_efs: false
   mount_efs: false
   size: t2.micro
-  os_full_name: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220419
+  os_full_name: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221010
   os_type: linux
   ebs_optimized: false
   disks:

--- a/schema/azure/defaults/infrastructure/cloud-os-image-defaults.yml
+++ b/schema/azure/defaults/infrastructure/cloud-os-image-defaults.yml
@@ -21,4 +21,4 @@ specification:
     publisher: Canonical
     offer: 0001-com-ubuntu-server-focal
     sku: 20_04-lts-gen2
-    version: "20.04.202204190"
+    version: "20.04.202210100"

--- a/schema/azure/defaults/infrastructure/virtual-machine.yml
+++ b/schema/azure/defaults/infrastructure/virtual-machine.yml
@@ -21,7 +21,7 @@ specification:
     publisher: Canonical
     offer: 0001-com-ubuntu-server-focal
     sku: 20_04-lts-gen2
-    version: "20.04.202204190" # Never put latest on anything! Need to always pin the version number but testing we can get away with it
+    version: "20.04.202210100" # Never put latest on anything! Need to always pin the version number but testing we can get away with it
   storage_os_disk:
     managed: true
     caching: ReadWrite


### PR DESCRIPTION
Updating only Ubuntu images as for RHEL 8.4 and AlmaLinux 8.4/8.5 there are no newer patches.
