### PR TITLE
[v1.0.7] Ensure `ca-certificates` package is in the latest version

### DIFF
--- a/CHANGELOG-1.0.md
+++ b/CHANGELOG-1.0.md
@@ -1,5 +1,11 @@
 # Changelog 1.0
 
+## [1.0.7] YYYY-MM-DD
+
+### Fixed
+
+- [#3296](https://github.com/epiphany-platform/epiphany/issues/3296) - Update `ca-certificates` package to the latest version
+
 ## [1.0.6] 2022-08-04
 
 ### Fixed

--- a/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/download-requirements.sh
+++ b/core/src/epicli/data/common/ansible/playbooks/roles/repository/files/download-requirements/ubuntu-18.04/download-requirements.sh
@@ -58,6 +58,9 @@ fi
 
 check_connection apt $apt_sources_list
 
+# Ensure ca-certificates package is in the latest version
+run_cmd_with_retries 3 apt-get install -y ca-certificates
+
 # install prerequisites which might be missing
 apt install -y wget gpg curl tar
 


### PR DESCRIPTION
Fix for #3296 