### PR TITLE
Make YAML format of default configuration compatible with sops

### DIFF
--- a/docs/changelogs/CHANGELOG-2.1-PGML.md
+++ b/docs/changelogs/CHANGELOG-2.1-PGML.md
@@ -11,3 +11,4 @@
 
 - Terraform Azure Provider 2.91.0 to 3.45.0
 - Upgrade Keycloak to 20.0.5-0
+- Make YAML format of default configuration compatible with sops (it converts YAML block scalars to flow scalars)

--- a/schema/common/defaults/configuration/filebeat.yml
+++ b/schema/common/defaults/configuration/filebeat.yml
@@ -10,7 +10,6 @@ specification:
   disable_helm_chart: false
   postgresql_input:
     multiline:
-      pattern: >-
-        '^\d{4}-\d{2}-\d{2} '
+      pattern: '''^\d{4}-\d{2}-\d{2} '''
       negate: true
       match: after


### PR DESCRIPTION
sops converts YAML block scalars to flow scalars (https://yaml-multiline.info/) and after decryption Epiphany raises the following error: `Types of key "pattern" are different: <class 'ruamel.yaml.scalarstring.FoldedScalarString'>, <class 'str'>. Unable to merge.`