### PR TITLE
Add the format command to epicli

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,25 +13,28 @@
             "env": { "PYTHONPATH": "${workspaceFolder}" },
             "console": "integratedTerminal",
             // init
-            "args": ["init", "--provider", "azure", "--name", "nostai-dev1", "--full"]
+            "args": ["init", "--provider", "azure", "--name", "nostai-dev01", "--full"]
 
             // apply
-            // "args": ["--debug", "0", "apply", "-f", "${workspaceFolder}/clusters/nostai-dev1.yml", "--vault-password", "1IAtsoN"]
-            // "args": ["--debug", "0", "apply", "-f", "${workspaceFolder}/clusters/nostai-dev1.yml", "--no-infra", "--vault-password", "1IAtsoN"]
-            // "args": ["--debug", "0", "apply", "-f", "${workspaceFolder}/clusters/nostai-dev1.yml", "--skip-config"]
+            // "args": ["--debug", "0", "apply", "-f", "${workspaceFolder}/clusters/nostai-dev01.yml", "--vault-password", "1IAtsoN"]
+            // "args": ["--debug", "0", "apply", "-f", "${workspaceFolder}/clusters/nostai-dev01.yml", "--no-infra", "--vault-password", "1IAtsoN"]
+            // "args": ["--debug", "0", "apply", "-f", "${workspaceFolder}/clusters/nostai-dev01.yml", "--skip-config"]
 
             // test
-            // "args": ["--auto-approve", "test", "-b", "${workspaceFolder}/clusters/build/nostai-dev1"]
-            // "args": ["--auto-approve", "test", "-b", "${workspaceFolder}/clusters/build/nostai-dev1", "-i", "common,filebeat,grafana"]
-            // "args": ["--auto-approve", "test", "-b", "${workspaceFolder}/clusters/build/nostai-dev1", "-i", "jmx_exporter,kafka,kafka_exporter"]
-            // "args": ["--auto-approve", "test", "-b", "${workspaceFolder}/clusters/build/nostai-dev1", "-i", "node_exporter,opensearch,prometheus,zookeeper"]
+            // "args": ["--auto-approve", "test", "-b", "${workspaceFolder}/clusters/build/nostai-dev01"]
+            // "args": ["--auto-approve", "test", "-b", "${workspaceFolder}/clusters/build/nostai-dev01", "-i", "common,filebeat,grafana"]
+            // "args": ["--auto-approve", "test", "-b", "${workspaceFolder}/clusters/build/nostai-dev01", "-i", "jmx_exporter,kafka,kafka_exporter"]
+            // "args": ["--auto-approve", "test", "-b", "${workspaceFolder}/clusters/build/nostai-dev01", "-i", "node_exporter,opensearch,prometheus,zookeeper"]
 
             // delete
-            // "args": ["delete", "-b", "${workspaceFolder}/clusters/build/nostai-dev1"]
+            // "args": ["delete", "-b", "${workspaceFolder}/clusters/build/nostai-dev01"]
 
             // help
             // "args": ["--help"]
             // "args": ["apply", "--help"]
+
+            // format
+            // "args": ["format", "-f", "${workspaceFolder}/clusters/nostai-dev01.yml"]
         }
     ]
 }

--- a/cli/epicli.py
+++ b/cli/epicli.py
@@ -13,6 +13,7 @@ from cli.licenses import LICENSES
 from cli.src.commands.Apply import Apply
 from cli.src.commands.Backup import Backup
 from cli.src.commands.Delete import Delete
+from cli.src.commands.FormatManifest import FormatManifest
 from cli.src.commands.Init import Init
 from cli.src.commands.Prepare import Prepare
 from cli.src.commands.Recovery import Recovery
@@ -96,6 +97,7 @@ Terraform : 1..4 map to the following Terraform verbosity levels:
     test_parser(subparsers)
     backup_parser(subparsers)
     recovery_parser(subparsers)
+    format_parser(subparsers)
 
     # check if there were any variables and display full help
     if len(sys.argv) < 2:
@@ -387,6 +389,31 @@ def recovery_parser(subparsers):
             return cmd.recovery()
 
     sub_parser.set_defaults(func=run_recovery)
+
+
+def format_parser(subparsers):
+    """Format YAML file."""
+
+    sub_parser = subparsers.add_parser('format',
+                                       description='Format manifest file.')
+    optional = sub_parser._action_groups.pop()
+    required = sub_parser.add_argument_group('required arguments')
+
+    #required
+    required.add_argument('-f', '--input-manifest', dest='input_manifest', type=str, required=True,
+                            help='Manifest file to format.')
+
+    #optional
+    optional.add_argument('--with-backup', dest='with_backup', required=False, action='store_true', default=False,
+                            help='When used a backup is made before overwriting the file.')
+    sub_parser._action_groups.append(optional)
+
+    def run_format(args):
+        adjust_paths_from_file(args)
+        with FormatManifest(args) as cmd:
+            return cmd.format()
+
+    sub_parser.set_defaults(func=run_format)
 
 
 def experimental_query():

--- a/cli/src/commands/FormatManifest.py
+++ b/cli/src/commands/FormatManifest.py
@@ -1,0 +1,35 @@
+import shutil
+
+from cli.src.Log import Log
+from cli.src.Step import Step
+
+from cli.src.helpers.data_loader import load_yamls_file
+from cli.src.helpers.yaml_helpers import dump_all
+
+
+class FormatManifest(Step):
+    def __init__(self, input_data):
+        super().__init__(__name__)
+        self.logger = Log(__name__)
+        self.input_manifest = input_data.input_manifest
+        self.with_backup = input_data.with_backup
+
+
+    def format(self):
+        """
+        Load input manifest and save it.
+        """
+
+        docs = load_yamls_file(self.input_manifest)
+
+        # Make backup
+        if self.with_backup:
+            backup_path = self.input_manifest + '.bak'
+            self.logger.info(f'Creating backup: {backup_path}')
+            shutil.copy2(self.input_manifest, backup_path)
+
+        # Overwrite manifest
+        with open(file=self.input_manifest, mode='w', encoding='utf-8') as stream:
+            dump_all(docs, stream)
+
+        return 0

--- a/docs/changelogs/CHANGELOG-2.1-PGML.md
+++ b/docs/changelogs/CHANGELOG-2.1-PGML.md
@@ -15,6 +15,7 @@
 - Integration with Opsgenie
 - Support for externally managed VNets
 - yq and ytt in Dockerfile
+- epicli format
 
 ### Updated
 


### PR DESCRIPTION
The new command is meant to format YAML manifest files that have been processed by an external tool that uses a different format. The original (Epiphany) format allows for comparing changes.